### PR TITLE
Fix widget context menus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# DeskBox development workflow
+
+- After changing application code, first stop any running `DeskBox.exe` whose executable path is under this repository, then build the affected project, and start a fresh instance from the current Debug build unless the user explicitly asks not to restart it. Stopping before the build avoids locking the output executable.
+- The canonical local development executable is `src/DeskBox/bin/Debug/net10.0-windows10.0.22621.0/DeskBox.exe`.
+- After starting DeskBox, verify that exactly the intended repository build is running and report the executable path.
+- Do not launch DeskBox from `Output`, `artifacts`, `.artifacts`, or `src/DeskBox/AppPackages` unless the user explicitly requests testing a packaged or published build.
+- Preserve unrelated user changes and release artifacts. Ask before deleting material output directories or installer packages unless the user explicitly authorizes their removal.

--- a/src/DeskBox/Views/ContentWidgetWindow.Commands.cs
+++ b/src/DeskBox/Views/ContentWidgetWindow.Commands.cs
@@ -175,11 +175,9 @@ public sealed partial class ContentWidgetWindow
 
     private void ContentWidgetShell_RightTapped(object sender, RightTappedRoutedEventArgs e)
     {
-        if (ContentWidgetShell.ChromeMode is not (WidgetChromeMode.Overlay or WidgetChromeMode.Hidden))
-        {
-            return;
-        }
-
+        // Item-level context menus mark the event handled before it reaches the shell.
+        // Any remaining right click is therefore on the content background and should
+        // expose the same widget actions as the title bar.
         ShowFlyoutWithInteraction(CreateMoreFlyout(), ContentWidgetShell, e.GetPosition(ContentWidgetShell));
         e.Handled = true;
     }

--- a/src/DeskBox/Views/QuickCaptureWidgetWindow.Menus.cs
+++ b/src/DeskBox/Views/QuickCaptureWidgetWindow.Menus.cs
@@ -57,12 +57,9 @@ public sealed partial class QuickCaptureWidgetWindow
 
     private void QuickCaptureShell_RightTapped(object sender, RightTappedRoutedEventArgs e)
     {
-        if (QuickCaptureShell.ChromeMode is not (WidgetChromeMode.Overlay or WidgetChromeMode.Hidden) ||
-            !ShouldOpenTitleBarFlyout(e.OriginalSource))
-        {
-            return;
-        }
-
+        // Item-level context menus mark the event handled before it reaches the shell.
+        // Any remaining right click is on the blank content background, where the
+        // title-bar menu is the appropriate widget-level menu.
         ShowFlyoutWithElevation(CreateMoreFlyout(), QuickCaptureShell, e.GetPosition(QuickCaptureShell));
         e.Handled = true;
     }

--- a/src/DeskBox/Views/WidgetWindow.Menus.cs
+++ b/src/DeskBox/Views/WidgetWindow.Menus.cs
@@ -262,24 +262,26 @@ public sealed partial class WidgetWindow
     {
         var flyout = new MenuFlyout();
 
-        var pasteItem = new MenuFlyoutItem
+        if (CanPasteFromClipboard())
         {
-            Text = _localizationService.T("Common.Paste"),
-            Icon = new FontIcon { Glyph = "\uE77F" },
-            IsEnabled = CanPasteFromClipboard()
-        };
-        pasteItem.Click += async (_, _) =>
-        {
-            try
+            var pasteItem = new MenuFlyoutItem
             {
-                await PasteFromClipboardAsync();
-            }
-            catch (Exception ex)
+                Text = _localizationService.T("Common.Paste"),
+                Icon = new FontIcon { Glyph = "\uE77F" }
+            };
+            pasteItem.Click += async (_, _) =>
             {
-                await ShowErrorDialogAsync(_localizationService.T("Widget.PasteFailed"), ex.Message);
-            }
-        };
-        flyout.Items.Add(pasteItem);
+                try
+                {
+                    await PasteFromClipboardAsync();
+                }
+                catch (Exception ex)
+                {
+                    await ShowErrorDialogAsync(_localizationService.T("Widget.PasteFailed"), ex.Message);
+                }
+            };
+            flyout.Items.Add(pasteItem);
+        }
 
         if (!string.IsNullOrWhiteSpace(ViewModel.MappedFolderPath))
         {
@@ -334,6 +336,16 @@ public sealed partial class WidgetWindow
         flyout.Items.Add(CreateStackSettingsMenu());
 
         flyout.Items.Add(new MenuFlyoutSeparator());
+        flyout.Items.Add(WidgetChromeMenuBuilder.Create(
+            ViewModel.Config,
+            _chromeDescriptor,
+            _localizationService,
+            SetChromeModeOverride));
+        flyout.Items.Add(WidgetCollapseMenuBuilder.Create(
+            ViewModel.Config,
+            _localizationService,
+            SetCollapseBehaviorOverride,
+            ResetCompactWidthOverride));
 
         var sortSubItem = new MenuFlyoutSubItem
         {


### PR DESCRIPTION
## What changed

- Show the title-bar widget menu when right-clicking blank Todo and Quick Capture content areas.
- Add title style and expansion behavior controls to the file-widget content menu.
- Place those controls between automatic stacking and sorting.
- Hide Paste when the clipboard cannot be pasted instead of showing a disabled command.
- Add repository workflow guidance so local code changes stop the old DeskBox process, build, restart the current Debug executable, and verify its path.

## Why

Several widget content areas exposed inconsistent context menus. Todo and Quick Capture blank areas had no widget-level menu, while the file-widget content menu was missing presentation controls and always displayed a disabled Paste entry.

## Impact

Widget-level actions are now available consistently from blank content areas, and the file-widget menu is ordered and filtered according to availability. The development workflow also avoids accidentally testing stale packaged builds.

## Validation

- Restored the full solution after clearing generated outputs.
- Built `src/DeskBox/DeskBox.csproj` successfully with 0 errors.
- Started and verified the freshly built Debug executable from the canonical repository path.
