### PR TITLE
feat: 文件拖入支持"快捷方式放桌面外"默认项

### DIFF
--- a/src/DeskBox/Controls/WidgetContents/FileSurfaceContent.ShortcutDrop.cs
+++ b/src/DeskBox/Controls/WidgetContents/FileSurfaceContent.ShortcutDrop.cs
@@ -32,6 +32,21 @@ public sealed partial class FileSurfaceContent
             action,
             SettingsService.ManagedDropActionFollowWindows,
             StringComparison.Ordinal);
+        // DeskBox's own file drags (same-widget reorder and cross-widget
+        // moves) must keep their existing move semantics even though their
+        // sources usually live outside the desktop. The desktop-based shortcut
+        // default applies to external shell payloads only.
+        bool isDeskBoxFileDrag = sourcePaths.Length > 0 &&
+            string.Equals(
+                TryGetString(
+                    dataView.Properties,
+                    DeskBoxDragData.InternalFileDragTokenProperty),
+                DeskBoxDragData.InternalFileDragToken,
+                StringComparison.Ordinal) &&
+            !string.IsNullOrWhiteSpace(
+                TryGetString(
+                    dataView.Properties,
+                    DeskBoxDragData.SourceWidgetIdProperty));
 
         return FileDropIntentPolicy.ResolveMappedTransfer(
             hasMappedFolder: !string.IsNullOrWhiteSpace(ViewModel.MappedFolderPath),
@@ -50,7 +65,32 @@ public sealed partial class FileSurfaceContent
             sameVolume,
             // The source may not advertise Link even though an extracted
             // filesystem path is sufficient for DeskBox to create a shortcut.
-            canLink: true);
+            canLink: true,
+            shortcutOutsideDesktop:
+                !isDeskBoxFileDrag &&
+                string.Equals(
+                    action,
+                    SettingsService.ManagedDropActionShortcutOutsideDesktop,
+                    StringComparison.Ordinal),
+            sourcesOnDesktop: ResolveSourcesOnDesktop(sourcePaths));
+    }
+
+    private static bool ResolveSourcesOnDesktop(
+        IEnumerable<string> sourcePaths)
+    {
+        string[] paths = sourcePaths
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .ToArray();
+        if (paths.Length == 0)
+        {
+            return true;
+        }
+
+        (string userDesktop, string publicDesktop) =
+            FileService.GetDesktopPaths();
+        return FileDropIntentPolicy.AreAllUnderDirectories(
+            paths,
+            [userDesktop, publicDesktop]);
     }
 
     private static DataPackageOperation ToDataPackageOperation(

--- a/src/DeskBox/Controls/WidgetContents/FileSurfaceContent.xaml.cs
+++ b/src/DeskBox/Controls/WidgetContents/FileSurfaceContent.xaml.cs
@@ -3067,7 +3067,13 @@ public sealed partial class FileSurfaceContent :
                             StringComparison.Ordinal),
                         altDown: Win32Helper.IsKeyPressed(VirtualKey.Menu),
                         followWindows: false,
-                        sameVolume: sameVolume)
+                        sameVolume: sameVolume,
+                        shortcutOutsideDesktop: string.Equals(
+                            _settingsService.Settings.ManagedDropAction,
+                            SettingsService.ManagedDropActionShortcutOutsideDesktop,
+                            StringComparison.Ordinal),
+                        sourcesOnDesktop: ResolveSourcesOnDesktop(
+                            droppedFiles.Select(file => file.Path)))
                 });
         bool? moveWhenMapped = mapped
             ? intent == FileDropIntent.Move

--- a/src/DeskBox/Helpers/FileDropIntentPolicy.cs
+++ b/src/DeskBox/Helpers/FileDropIntentPolicy.cs
@@ -28,7 +28,9 @@ internal static class FileDropIntentPolicy
         bool altDown = false,
         bool followWindows = false,
         bool sameVolume = true,
-        bool canLink = true)
+        bool canLink = true,
+        bool shortcutOutsideDesktop = false,
+        bool sourcesOnDesktop = true)
     {
         if (!hasMappedFolder)
         {
@@ -59,6 +61,25 @@ internal static class FileDropIntentPolicy
         if (shiftDown)
         {
             return canMove ? FileDropIntent.Move : FileDropIntent.None;
+        }
+
+        // The "shortcut outside the desktop" default keeps files that already
+        // live on the desktop moving into managed storage, while every other
+        // source becomes a link so the original never leaves its location.
+        // Explicit modifier gestures above always take precedence. A caller
+        // that cannot extract the source paths treats the payload as
+        // desktop-resident to preserve the previous behaviour.
+        if (shortcutOutsideDesktop)
+        {
+            if (sourcesOnDesktop && canMove)
+            {
+                return FileDropIntent.Move;
+            }
+
+            if (!sourcesOnDesktop && canLink)
+            {
+                return FileDropIntent.Shortcut;
+            }
         }
 
         // Explorer chooses Move for a same-volume drop and Copy when the
@@ -120,5 +141,79 @@ internal static class FileDropIntentPolicy
         return sourcePaths
             .Where(path => !string.IsNullOrWhiteSpace(path))
             .All(path => AreSameVolume(path, destinationPath));
+    }
+
+    /// <summary>
+    /// Whether <paramref name="path"/> is <paramref name="directory"/> itself
+    /// or one of its descendants. Comparison is case-insensitive and guarded
+    /// against sibling prefixes such as "DesktopBackup".
+    /// </summary>
+    public static bool IsUnderDirectory(string path, string directory)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(path) ||
+                string.IsNullOrWhiteSpace(directory))
+            {
+                return false;
+            }
+
+            string fullPath = Path.GetFullPath(path).TrimEnd(
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar);
+            string fullRoot = Path.GetFullPath(directory).TrimEnd(
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar);
+            if (fullRoot.Length == 0)
+            {
+                return false;
+            }
+
+            return string.Equals(
+                    fullPath,
+                    fullRoot,
+                    StringComparison.OrdinalIgnoreCase) ||
+                fullPath.StartsWith(
+                    fullRoot + Path.DirectorySeparatorChar,
+                    StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            // Invalid or inaccessible paths are never treated as resident.
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Whether every non-empty <paramref name="sourcePaths"/> entry lives under
+    /// at least one of the given <paramref name="directories"/>. An unknown
+    /// payload (no extractable root) resolves as desktop-resident so the
+    /// default move behaviour is preserved rather than surprising the user.
+    /// </summary>
+    public static bool AreAllUnderDirectories(
+        IEnumerable<string> sourcePaths,
+        IEnumerable<string> directories)
+    {
+        try
+        {
+            string[] roots = directories
+                .Where(directory => !string.IsNullOrWhiteSpace(directory))
+                .Select(directory => Path.GetFullPath(directory))
+                .ToArray();
+            if (roots.Length == 0)
+            {
+                return true;
+            }
+
+            return sourcePaths
+                .Where(path => !string.IsNullOrWhiteSpace(path))
+                .All(path => roots.Any(root => IsUnderDirectory(path, root)));
+        }
+        catch
+        {
+            // Invalid or inaccessible roots fall back to desktop-resident so
+            // the existing move behaviour is preserved.
+            return true;
+        }
     }
 }

--- a/src/DeskBox/Helpers/NativeDropEffectPolicy.cs
+++ b/src/DeskBox/Helpers/NativeDropEffectPolicy.cs
@@ -32,7 +32,9 @@ internal static class NativeDropEffectPolicy
         bool hasShellApplicationData = false,
         bool defaultMove = true,
         bool followWindows = false,
-        bool sameVolume = true)
+        bool sameVolume = true,
+        bool shortcutOutsideDesktop = false,
+        bool sourcesOnDesktop = true)
     {
         if (hasShellApplicationData)
         {
@@ -66,7 +68,9 @@ internal static class NativeDropEffectPolicy
             // The native source may omit DROPEFFECT_LINK even though DeskBox
             // can safely create a local .lnk from the extracted path. The
             // visual still falls back to Copy when Link is not advertised.
-            canLink: true);
+            canLink: true,
+            shortcutOutsideDesktop: shortcutOutsideDesktop,
+            sourcesOnDesktop: sourcesOnDesktop);
         return intent switch
         {
             FileDropIntent.Copy => Copy,
@@ -83,7 +87,9 @@ internal static class NativeDropEffectPolicy
         uint keyState,
         bool defaultMove,
         bool followWindows = false,
-        bool sameVolume = true)
+        bool sameVolume = true,
+        bool shortcutOutsideDesktop = false,
+        bool sourcesOnDesktop = true)
     {
         FileDropIntent intent = FileDropIntentPolicy.ResolveMappedTransfer(
             hasMappedFolder: true,
@@ -93,18 +99,40 @@ internal static class NativeDropEffectPolicy
             defaultMove: defaultMove,
             altDown: (keyState & AltKeyState) != 0,
             followWindows: followWindows,
-            sameVolume: sameVolume);
+            sameVolume: sameVolume,
+            shortcutOutsideDesktop: shortcutOutsideDesktop,
+            sourcesOnDesktop: sourcesOnDesktop);
         return intent != FileDropIntent.Move;
     }
 
     public static bool ShouldCreateMappedShortcut(
         bool containsTemporaryFiles,
-        uint keyState)
+        uint keyState,
+        bool shortcutOutsideDesktop = false,
+        bool sourcesOnDesktop = true)
     {
-        return !containsTemporaryFiles &&
-               ((keyState & AltKeyState) != 0 ||
-                (keyState & (ControlKeyState | ShiftKeyState)) ==
-                    (ControlKeyState | ShiftKeyState));
+        if (containsTemporaryFiles)
+        {
+            return false;
+        }
+
+        bool altDown = (keyState & AltKeyState) != 0;
+        bool controlDown = (keyState & ControlKeyState) != 0;
+        bool shiftDown = (keyState & ShiftKeyState) != 0;
+        if (altDown || (controlDown && shiftDown))
+        {
+            return true;
+        }
+
+        // Explicit Ctrl=copy and Shift=move gestures must win over the
+        // desktop-based shortcut default so the completion matches the
+        // feedback cursor shown to the user.
+        if (controlDown || shiftDown)
+        {
+            return false;
+        }
+
+        return shortcutOutsideDesktop && !sourcesOnDesktop;
     }
 
     public static bool IsRightButtonDrag(uint keyState)

--- a/src/DeskBox/Helpers/NativeDropTarget.cs
+++ b/src/DeskBox/Helpers/NativeDropTarget.cs
@@ -134,6 +134,7 @@ public sealed class NativeDropTarget : IDisposable
     private readonly NativeDropTargetComObject _comObject;
     private readonly Func<bool> _defaultMoveProvider;
     private readonly Func<bool>? _followWindowsProvider;
+    private readonly Func<bool>? _shortcutOutsideDesktopProvider;
     private readonly Func<uint, NativeDropDescriptionText?>? _dropDescriptionProvider;
     private readonly Func<bool>? _useShellVisualProvider;
     private readonly NativeDropImageManager? _dropImageManager;
@@ -145,6 +146,11 @@ public sealed class NativeDropTarget : IDisposable
     private bool _registered;
     private bool _rightButtonDragActive;
     private IReadOnlyList<string> _dragPathHints = [];
+
+    // Physical CF_HDROP paths peeked during the drag so the feedback effect
+    // can reflect the "shortcut outside the desktop" default without staging
+    // virtual payloads or forcing delayed rendering.
+    private IReadOnlyList<string> _peekedDropPaths = [];
 
     private sealed record ShellApplicationDropItem(
         string AppUserModelId,
@@ -225,11 +231,13 @@ public sealed class NativeDropTarget : IDisposable
         Func<bool>? defaultMoveProvider,
         Func<uint, NativeDropDescriptionText?>? dropDescriptionProvider,
         Func<bool>? useShellVisualProvider = null,
-        Func<bool>? followWindowsProvider = null)
+        Func<bool>? followWindowsProvider = null,
+        Func<bool>? shortcutOutsideDesktopProvider = null)
     {
         _hwnd = hwnd;
         _defaultMoveProvider = defaultMoveProvider ?? (() => true);
         _followWindowsProvider = followWindowsProvider;
+        _shortcutOutsideDesktopProvider = shortcutOutsideDesktopProvider;
         _dropDescriptionProvider = dropDescriptionProvider;
         _useShellVisualProvider = useShellVisualProvider;
         _comObject = new NativeDropTargetComObject(this);
@@ -306,6 +314,7 @@ public sealed class NativeDropTarget : IDisposable
             NativeDropEffectPolicy.IsRightButtonDrag(keyState);
         uint allowedEffects = effect;
         InspectDragData(dataObject);
+        PeekDropPaths(dataObject);
         _dragPathHints = HasFileData && !HasVirtualFileData
             ? TryExtractHDropPathHints(dataObject)
             : [];
@@ -318,7 +327,9 @@ public sealed class NativeDropTarget : IDisposable
             allowedEffects,
             HasShellApplicationData,
             _defaultMoveProvider(),
-            followWindows: GetFollowWindowsSetting());
+            followWindows: GetFollowWindowsSetting(),
+            shortcutOutsideDesktop: GetShortcutOutsideDesktopSetting(),
+            sourcesOnDesktop: ResolveSourcesOnDesktop(_peekedDropPaths));
         if (HasFileData)
         {
             RetainActiveDataObject(dataObject);
@@ -344,7 +355,9 @@ public sealed class NativeDropTarget : IDisposable
             allowedEffects,
             HasShellApplicationData,
             _defaultMoveProvider(),
-            followWindows: GetFollowWindowsSetting());
+            followWindows: GetFollowWindowsSetting(),
+            shortcutOutsideDesktop: GetShortcutOutsideDesktopSetting(),
+            sourcesOnDesktop: ResolveSourcesOnDesktop(_peekedDropPaths));
         UpdateShellVisual(point, effect);
         return S_OK;
     }
@@ -378,7 +391,9 @@ public sealed class NativeDropTarget : IDisposable
             allowedEffects,
             shellApplicationDrop,
             defaultMove,
-            followWindows: followWindows);
+            followWindows: followWindows,
+            shortcutOutsideDesktop: GetShortcutOutsideDesktopSetting(),
+            sourcesOnDesktop: ResolveSourcesOnDesktop(_peekedDropPaths));
         IReadOnlyList<string> paths = shellApplicationDrop
             ? TryExtractShellApplicationShortcuts(dataObject)
             : [];
@@ -388,15 +403,21 @@ public sealed class NativeDropTarget : IDisposable
         {
             (paths, containsTemporaryFiles) = TryExtractFilePaths(dataObject);
         }
+        bool shortcutOutsideDesktop = GetShortcutOutsideDesktopSetting();
+        bool sourcesOnDesktop = ResolveSourcesOnDesktop(paths);
         bool copyRequested = NativeDropEffectPolicy.ShouldCopyMappedTransfer(
             containsTemporaryFiles,
             keyState,
             defaultMove,
-            followWindows: followWindows);
+            followWindows: followWindows,
+            shortcutOutsideDesktop: shortcutOutsideDesktop,
+            sourcesOnDesktop: sourcesOnDesktop);
         bool shortcutRequested = createdShellApplicationLinks ||
             NativeDropEffectPolicy.ShouldCreateMappedShortcut(
                 containsTemporaryFiles,
-                keyState);
+                keyState,
+                shortcutOutsideDesktop: shortcutOutsideDesktop,
+                sourcesOnDesktop: sourcesOnDesktop);
         if (_shellVisualActive)
         {
             _dropImageManager?.Drop(
@@ -461,6 +482,97 @@ public sealed class NativeDropTarget : IDisposable
         }
     }
 
+    private bool GetShortcutOutsideDesktopSetting()
+    {
+        try
+        {
+            return _shortcutOutsideDesktopProvider?.Invoke() == true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Lightweight HDROP-only peek at the drop payload. Unlike
+    /// <see cref="TryExtractFilePaths"/> this never stages virtual files; it
+    /// only reads physical CF_HDROP paths so the caller can determine whether
+    /// the source lives on the desktop for the "shortcut outside the desktop"
+    /// default. Cached internally until the drag session ends. Skipped entirely
+    /// when the feature is disabled so the default Move/Copy paths pay no OLE
+    /// GetData cost.
+    /// </summary>
+    private void PeekDropPaths(nint dataObject)
+    {
+        _peekedDropPaths = [];
+        if (!GetShortcutOutsideDesktopSetting() ||
+            dataObject == IntPtr.Zero ||
+            HasVirtualFileData ||
+            HasShellApplicationData)
+        {
+            return;
+        }
+
+        try
+        {
+            var oleDataObject = new NativeOleDataObject(dataObject);
+            var format = new NativeFormatEtc
+            {
+                ClipboardFormat = (ushort)CF_HDROP,
+                TargetDevice = IntPtr.Zero,
+                Aspect = DVASPECT_CONTENT,
+                Index = -1,
+                MediumType = TYMED_HGLOBAL,
+            };
+            if (oleDataObject.GetData(
+                    ref format,
+                    out NativeStorageMedium medium) != S_OK ||
+                medium.Content == IntPtr.Zero)
+            {
+                return;
+            }
+
+            try
+            {
+                _peekedDropPaths = GetDroppedFiles(medium.Content);
+            }
+            finally
+            {
+                ReleaseStgMedium(ref medium);
+            }
+        }
+        catch
+        {
+            // Delayed-rendering or an inaccessible data object is treated as
+            // an unknown payload, which falls back to the desktop-resident
+            // default (preserves the existing move behaviour).
+        }
+    }
+
+    /// <summary>
+    /// Whether the given authoritative paths (or the cached peek when the
+    /// authoritative list is empty) all live under the user or public desktop.
+    /// A completely unknown payload resolves as desktop-resident so the
+    /// existing move default is preserved.
+    /// </summary>
+    private bool ResolveSourcesOnDesktop(IReadOnlyList<string> paths)
+    {
+        IReadOnlyList<string> effectivePaths = paths.Count > 0
+            ? paths
+            : _peekedDropPaths;
+        if (effectivePaths.Count == 0)
+        {
+            return true;
+        }
+
+        (string userDesktop, string publicDesktop) =
+            FileService.GetDesktopPaths();
+        return FileDropIntentPolicy.AreAllUnderDirectories(
+            effectivePaths,
+            [userDesktop, publicDesktop]);
+    }
+
     private void InspectDragData(nint dataObject)
     {
         bool hasHDropData = TryHasHDropData(dataObject);
@@ -479,6 +591,7 @@ public sealed class NativeDropTarget : IDisposable
         HasFileData = false;
         HasVirtualFileData = false;
         HasShellApplicationData = false;
+        _peekedDropPaths = [];
         _dragPathHints = [];
     }
 

--- a/src/DeskBox/Models/AppSettings.cs
+++ b/src/DeskBox/Models/AppSettings.cs
@@ -541,7 +541,8 @@ public class AppSettings
 
     /// <summary>
     /// How files should be handled when dropped into a managed storage widget.
-    /// Valid values: <c>"Move"</c>, <c>"Copy"</c>, <c>"FollowWindows"</c>.
+    /// Valid values: <c>"Move"</c>, <c>"Copy"</c>, <c>"FollowWindows"</c>,
+    /// <c>"ShortcutOutsideDesktop"</c>.
     /// </summary>
     public string ManagedDropAction { get; set; } = "Move";
 

--- a/src/DeskBox/Services/DragDropPermissionService.cs
+++ b/src/DeskBox/Services/DragDropPermissionService.cs
@@ -686,7 +686,10 @@ public static class DragDropPermissionService
         }
 
         string workingDirectory = Path.GetDirectoryName(targetPath) ?? AppContext.BaseDirectory;
-        string iconPath = Path.Combine(AppContext.BaseDirectory, "Assets", "deskbox.ico");
+        // An empty icon location lets the shell resolve the source file's own
+        // icon (embedded icon for executables, type association for documents)
+        // instead of stamping every shortcut with the DeskBox branding.
+        string iconPath = string.Empty;
 #if DESKBOX_NATIVE_AOT
         var metadata = new ShortcutInfo(
             targetPath,
@@ -752,7 +755,11 @@ public static class DragDropPermissionService
         shellLink.SetPath(targetPath);
         shellLink.SetArguments(arguments);
         shellLink.SetWorkingDirectory(workingDirectory);
-        shellLink.SetIconLocation(iconPath, 0);
+        if (!string.IsNullOrEmpty(iconPath))
+        {
+            shellLink.SetIconLocation(iconPath, 0);
+        }
+
         var persistFile = (System.Runtime.InteropServices.ComTypes.IPersistFile)shellLink;
         persistFile.Save(shortcutPath, true);
     }

--- a/src/DeskBox/Services/SettingsService.cs
+++ b/src/DeskBox/Services/SettingsService.cs
@@ -221,6 +221,8 @@ public sealed class SettingsService
     public const string ManagedDropActionMove = "Move";
     public const string ManagedDropActionCopy = "Copy";
     public const string ManagedDropActionFollowWindows = "FollowWindows";
+    public const string ManagedDropActionShortcutOutsideDesktop =
+        "ShortcutOutsideDesktop";
 
     public const string AttachmentStorageModeLink = "Link";
     public const string AttachmentStorageModeCopy = "Copy";
@@ -2410,7 +2412,8 @@ settings.FocusClickedWidgetOnRaise = false;
 
         if (!string.Equals(settings.ManagedDropAction, ManagedDropActionMove, StringComparison.Ordinal) &&
             !string.Equals(settings.ManagedDropAction, ManagedDropActionCopy, StringComparison.Ordinal) &&
-            !string.Equals(settings.ManagedDropAction, ManagedDropActionFollowWindows, StringComparison.Ordinal))
+            !string.Equals(settings.ManagedDropAction, ManagedDropActionFollowWindows, StringComparison.Ordinal) &&
+            !string.Equals(settings.ManagedDropAction, ManagedDropActionShortcutOutsideDesktop, StringComparison.Ordinal))
         {
             settings.ManagedDropAction = ManagedDropActionMove;
             changed = true;

--- a/src/DeskBox/Strings/ar-SA.json
+++ b/src/DeskBox/Strings/ar-SA.json
@@ -702,6 +702,7 @@
   "Settings.DropAction.Description": "اختر ما إذا كنت تريد إسقاط الملفات أو نقل النسخة الأصلية إلى عنصر واجهة مستخدم مُدار",
   "Settings.DropAction.Move": "تحرك",
   "Settings.DropAction.Copy": "نسخ",
+  "Settings.DropAction.ShortcutOutsideDesktop": "نقل ملفات سطح المكتب وإنشاء اختصارات للبقية",
   "Settings.AttachmentStorageMode.Title": "طريقة حفظ المرفقات",
   "Settings.AttachmentStorageMode.Description": "يستخدم الربط الملف الأصلي؛ ويحفظ النسخ نسخة منفصلة داخل DeskBox",
   "Settings.AttachmentStorageMode.Link": "ربط الملف الأصلي",

--- a/src/DeskBox/Strings/bn-BD.json
+++ b/src/DeskBox/Strings/bn-BD.json
@@ -702,6 +702,7 @@
   "Settings.DropAction.Description": "ড্রপ ফাইল কপি বা একটি পরিচালিত উইজেটে মূল সরান কিনা চয়ন করুন",
   "Settings.DropAction.Move": "সরান",
   "Settings.DropAction.Copy": "কপি",
+  "Settings.DropAction.ShortcutOutsideDesktop": "ডেস্কটপ ফাইল সরান, বাকিগুলির জন্য শর্টকাট তৈরি করুন",
   "Settings.AttachmentStorageMode.Title": "সংযুক্তি সংরক্ষণের উপায়",
   "Settings.AttachmentStorageMode.Description": "লিঙ্ক মূল ফাইল ব্যবহার করে; কপি DeskBox-এ আলাদা একটি অনুলিপি রাখে",
   "Settings.AttachmentStorageMode.Link": "মূল ফাইল লিঙ্ক করুন",

--- a/src/DeskBox/Strings/de-DE.json
+++ b/src/DeskBox/Strings/de-DE.json
@@ -688,6 +688,7 @@
     "Settings.DropAction.Description": "Wählen, ob Drops Dateien kopieren oder das Original in ein verwaltetes Widget verschieben",
     "Settings.DropAction.Move": "Verschieben",
     "Settings.DropAction.Copy": "Kopieren",
+    "Settings.DropAction.ShortcutOutsideDesktop": "Desktop-Dateien verschieben, für andere Verknüpfungen erstellen",
     "Settings.AttachmentStorageMode.Title": "Speicherort für Anhänge",
     "Settings.AttachmentStorageMode.Description": "Verknüpfen nutzt die Originaldatei; Kopieren speichert eine separate Kopie in DeskBox",
     "Settings.AttachmentStorageMode.Link": "Originaldatei verknüpfen",

--- a/src/DeskBox/Strings/en-US.json
+++ b/src/DeskBox/Strings/en-US.json
@@ -702,6 +702,7 @@
     "Settings.DropAction.Description": "Choose whether drops copy files, move the original, or follow the Windows default",
     "Settings.DropAction.Move": "Move",
     "Settings.DropAction.Copy": "Copy",
+    "Settings.DropAction.ShortcutOutsideDesktop": "Move desktop files, create shortcuts for others",
     "Settings.AttachmentStorageMode.Title": "Attachment storage",
     "Settings.AttachmentStorageMode.Description": "Link uses the original file; Copy saves a separate copy in DeskBox",
     "Settings.AttachmentStorageMode.Link": "Link original file",

--- a/src/DeskBox/Strings/es-ES.json
+++ b/src/DeskBox/Strings/es-ES.json
@@ -702,6 +702,7 @@
   "Settings.DropAction.Description": "Elija si descarta copiar archivos o mover el original a un widget administrado",
   "Settings.DropAction.Move": "Mover",
   "Settings.DropAction.Copy": "Copiar",
+  "Settings.DropAction.ShortcutOutsideDesktop": "Mover archivos del escritorio, crear accesos directos para el resto",
   "Settings.AttachmentStorageMode.Title": "Almacenamiento de archivos adjuntos",
   "Settings.AttachmentStorageMode.Description": "Vincular usa el archivo original; Copiar guarda una copia separada en DeskBox",
   "Settings.AttachmentStorageMode.Link": "Vincular archivo original",

--- a/src/DeskBox/Strings/fr-FR.json
+++ b/src/DeskBox/Strings/fr-FR.json
@@ -702,6 +702,7 @@
   "Settings.DropAction.Description": "Choisissez si vous supprimez les fichiers de copie ou déplacez l'original dans un widget géré",
   "Settings.DropAction.Move": "Déplacer",
   "Settings.DropAction.Copy": "Copier",
+  "Settings.DropAction.ShortcutOutsideDesktop": "Déplacer les fichiers du bureau, créer des raccourcis pour les autres",
   "Settings.AttachmentStorageMode.Title": "Stockage des pièces jointes",
   "Settings.AttachmentStorageMode.Description": "Le lien utilise le fichier d’origine; la copie enregistre un exemplaire distinct dans DeskBox",
   "Settings.AttachmentStorageMode.Link": "Lier le fichier d'origine",

--- a/src/DeskBox/Strings/hi-IN.json
+++ b/src/DeskBox/Strings/hi-IN.json
@@ -702,6 +702,7 @@
   "Settings.DropAction.Description": "चुनें कि क्या प्रतिलिपि फ़ाइलें हटा दी जाएंगी या मूल को प्रबंधित विजेट में ले जाया जाएगा",
   "Settings.DropAction.Move": "हटो",
   "Settings.DropAction.Copy": "प्रतिलिपि",
+  "Settings.DropAction.ShortcutOutsideDesktop": "डेस्कटॉप फ़ाइलें ले जाएँ, बाकी के लिए शॉर्टकट बनाएँ",
   "Settings.AttachmentStorageMode.Title": "अटैचमेंट सहेजने का तरीका",
   "Settings.AttachmentStorageMode.Description": "लिंक मूल फ़ाइल का उपयोग करता है; कॉपी DeskBox में अलग प्रति सहेजती है",
   "Settings.AttachmentStorageMode.Link": "मूल फ़ाइल लिंक करें",

--- a/src/DeskBox/Strings/ja-JP.json
+++ b/src/DeskBox/Strings/ja-JP.json
@@ -688,6 +688,7 @@
     "Settings.DropAction.Description": "ドロップ時にファイルをコピーするか、管理ウィジェットに移動するかを選択します",
     "Settings.DropAction.Move": "移動",
     "Settings.DropAction.Copy": "コピー",
+    "Settings.DropAction.ShortcutOutsideDesktop": "デスクトップのファイルは移動、その他はショートカットを作成",
     "Settings.AttachmentStorageMode.Title": "添付ファイルの保存方法",
     "Settings.AttachmentStorageMode.Description": "リンクは元のファイルを使用し、コピーは DeskBox 内に複製を保存します",
     "Settings.AttachmentStorageMode.Link": "元のファイルをリンク",

--- a/src/DeskBox/Strings/pt-BR.json
+++ b/src/DeskBox/Strings/pt-BR.json
@@ -688,6 +688,7 @@
     "Settings.DropAction.Description": "Escolha se ao soltar copiará arquivos ou moverá o original para um Widget gerenciado",
     "Settings.DropAction.Move": "Mover",
     "Settings.DropAction.Copy": "Copiar",
+    "Settings.DropAction.ShortcutOutsideDesktop": "Mover arquivos da área de trabalho, criar atalhos para os demais",
     "Settings.AttachmentStorageMode.Title": "Armazenamento de anexos",
     "Settings.AttachmentStorageMode.Description": "Vincular usa o arquivo original; Copiar salva uma cópia separada no DeskBox",
     "Settings.AttachmentStorageMode.Link": "Link para o arquivo original",

--- a/src/DeskBox/Strings/ru-RU.json
+++ b/src/DeskBox/Strings/ru-RU.json
@@ -702,6 +702,7 @@
   "Settings.DropAction.Description": "Выберите, следует ли удалять файлы копирования или перемещать оригинал в управляемый виджет.",
   "Settings.DropAction.Move": "Переместить",
   "Settings.DropAction.Copy": "Копировать",
+  "Settings.DropAction.ShortcutOutsideDesktop": "Перемещать файлы с рабочего стола, создавать ярлыки для остальных",
   "Settings.AttachmentStorageMode.Title": "Хранение вложений",
   "Settings.AttachmentStorageMode.Description": "Ссылка использует исходный файл; копирование сохраняет отдельную копию в DeskBox",
   "Settings.AttachmentStorageMode.Link": "Ссылка на исходный файл",

--- a/src/DeskBox/Strings/zh-CN.json
+++ b/src/DeskBox/Strings/zh-CN.json
@@ -400,6 +400,7 @@
     "Weather.Refresh.Minute": "{0} 分钟",
     "Settings.WidgetTitleIcon.Title": "格子标题图标",
     "Settings.DropAction.Copy": "复制",
+    "Settings.DropAction.ShortcutOutsideDesktop": "桌面文件移动，其他建快捷方式",
     "Settings.Capsule.Overrides.Empty.Title": "所有格子均跟随全局设置",
     "Settings.ShowImageFilesAsIcons.Title": "图片和视频只显示图标",
     "Settings.Update.Install": "立即安装",

--- a/src/DeskBox/Strings/zh-TW.json
+++ b/src/DeskBox/Strings/zh-TW.json
@@ -400,6 +400,7 @@
   "Weather.Refresh.Minute": "{0} 分鐘",
   "Settings.WidgetTitleIcon.Title": "格子標題圖示",
   "Settings.DropAction.Copy": "複製",
+  "Settings.DropAction.ShortcutOutsideDesktop": "桌面檔案移動，其他建立捷徑",
   "Settings.Capsule.Overrides.Empty.Title": "所有格子均跟隨全域設定",
   "Settings.ShowImageFilesAsIcons.Title": "圖片和影片僅顯示圖示",
   "Settings.Update.Install": "立即安裝",

--- a/src/DeskBox/ViewModels/SettingsViewModel.FeatureOptions.cs
+++ b/src/DeskBox/ViewModels/SettingsViewModel.FeatureOptions.cs
@@ -111,6 +111,8 @@ public partial class SettingsViewModel
                     SettingsService.ManagedDropActionCopy,
                 SettingsService.ManagedDropActionFollowWindows =>
                     SettingsService.ManagedDropActionFollowWindows,
+                SettingsService.ManagedDropActionShortcutOutsideDesktop =>
+                    SettingsService.ManagedDropActionShortcutOutsideDesktop,
                 _ => SettingsService.ManagedDropActionMove
             };
             if (!SetProperty(ref _selectedManagedDropAction, normalized))
@@ -1081,7 +1083,8 @@ set => WidgetOpacity = Math.Clamp(1.0 - value / 100d, SettingsService.MinWidgetO
     [
         SettingsService.ManagedDropActionCopy,
         SettingsService.ManagedDropActionMove,
-        SettingsService.ManagedDropActionFollowWindows
+        SettingsService.ManagedDropActionFollowWindows,
+        SettingsService.ManagedDropActionShortcutOutsideDesktop
     ];
 
     public string[] AvailableManagedDropActionDisplayNames =>
@@ -1096,6 +1099,9 @@ set => WidgetOpacity = Math.Clamp(1.0 - value / 100d, SettingsService.MinWidgetO
                 _localizationService.T("Settings.DropAction.Move"),
             SettingsService.ManagedDropActionFollowWindows =>
                 _localizationService.T("Settings.DropAction.System"),
+            SettingsService.ManagedDropActionShortcutOutsideDesktop =>
+                _localizationService.T(
+                    "Settings.DropAction.ShortcutOutsideDesktop"),
             _ => _localizationService.T("Settings.DropAction.Copy")
         };
 

--- a/src/DeskBox/ViewModels/SettingsViewModel.SettingsSync.cs
+++ b/src/DeskBox/ViewModels/SettingsViewModel.SettingsSync.cs
@@ -149,6 +149,8 @@ public partial class SettingsViewModel
                     SettingsService.ManagedDropActionMove,
                 SettingsService.ManagedDropActionFollowWindows =>
                     SettingsService.ManagedDropActionFollowWindows,
+                SettingsService.ManagedDropActionShortcutOutsideDesktop =>
+                    SettingsService.ManagedDropActionShortcutOutsideDesktop,
                 _ => SettingsService.ManagedDropActionCopy
             };
             SelectedQuickCaptureDefaultView = NormalizeQuickCaptureDefaultView(settings.QuickCaptureDefaultView);

--- a/src/DeskBox/ViewModels/SettingsViewModel.cs
+++ b/src/DeskBox/ViewModels/SettingsViewModel.cs
@@ -386,6 +386,8 @@ private string[]? _cachedWeatherRefreshIntervalDisplayNames;
                 SettingsService.ManagedDropActionMove,
             SettingsService.ManagedDropActionFollowWindows =>
                 SettingsService.ManagedDropActionFollowWindows,
+            SettingsService.ManagedDropActionShortcutOutsideDesktop =>
+                SettingsService.ManagedDropActionShortcutOutsideDesktop,
             _ => SettingsService.ManagedDropActionCopy
         };
         _selectedQuickCaptureDefaultView = NormalizeQuickCaptureDefaultView(settings.QuickCaptureDefaultView);

--- a/src/DeskBox/ViewModels/WidgetViewModel.LayoutAndSettings.cs
+++ b/src/DeskBox/ViewModels/WidgetViewModel.LayoutAndSettings.cs
@@ -86,6 +86,8 @@ public partial class WidgetViewModel
                 _localizationService.T("Common.Move"),
             SettingsService.ManagedDropActionFollowWindows =>
                 _localizationService.T("Settings.DropAction.System"),
+            SettingsService.ManagedDropActionShortcutOutsideDesktop =>
+                _localizationService.T("Settings.DropAction.ShortcutOutsideDesktop"),
             _ => _localizationService.T("Common.Copy")
         };
     }
@@ -101,6 +103,22 @@ public partial class WidgetViewModel
                 StringComparison.Ordinal))
         {
             return true;
+        }
+
+        if (string.Equals(
+                action,
+                SettingsService.ManagedDropActionShortcutOutsideDesktop,
+                StringComparison.Ordinal))
+        {
+            if (sourcePaths is null)
+            {
+                return false;
+            }
+
+            var (userDesktop, publicDesktop) = FileService.GetDesktopPaths();
+            return FileDropIntentPolicy.AreAllUnderDirectories(
+                sourcePaths,
+                [userDesktop, publicDesktop]);
         }
 
         if (!string.Equals(

--- a/src/DeskBox/Views/ContentWidgetWindow.NativeDragDrop.cs
+++ b/src/DeskBox/Views/ContentWidgetWindow.NativeDragDrop.cs
@@ -95,7 +95,8 @@ public sealed partial class ContentWidgetWindow
                     ShouldDefaultNativeFileDropToMove,
                     CreateNativeFileDropDescription,
                     ShouldUseNativeFileDropVisual,
-                    ShouldFollowWindowsNativeFileDrop);
+                    ShouldFollowWindowsNativeFileDrop,
+                    ShouldShortcutOutsideDesktopNativeFileDrop);
                 target.DragEnterEvent += NativeFileDropTarget_DragEnterEvent;
                 target.DragOverEvent += NativeFileDropTarget_DragOverEvent;
                 target.DragLeaveEvent += NativeFileDropTarget_DragLeaveEvent;
@@ -239,6 +240,14 @@ public sealed partial class ContentWidgetWindow
         return string.Equals(
             App.Current.SettingsService.Settings.ManagedDropAction,
             SettingsService.ManagedDropActionFollowWindows,
+            StringComparison.Ordinal);
+    }
+
+    private bool ShouldShortcutOutsideDesktopNativeFileDrop()
+    {
+        return string.Equals(
+            App.Current.SettingsService.Settings.ManagedDropAction,
+            SettingsService.ManagedDropActionShortcutOutsideDesktop,
             StringComparison.Ordinal);
     }
 

--- a/tests/DeskBox.Tests/FileInteractionPolicyTests.cs
+++ b/tests/DeskBox.Tests/FileInteractionPolicyTests.cs
@@ -93,6 +93,132 @@ public sealed class FileInteractionPolicyTests
     }
 
     [Fact]
+    public void DropIntent_ShortcutOutsideDesktop_MovesDesktopResidentSources()
+    {
+        Assert.Equal(
+            FileDropIntent.Move,
+            FileDropIntentPolicy.ResolveMappedTransfer(
+                hasMappedFolder: true,
+                forceCopy: false,
+                controlDown: false,
+                shiftDown: false,
+                defaultMove: true,
+                shortcutOutsideDesktop: true,
+                sourcesOnDesktop: true));
+    }
+
+    [Fact]
+    public void DropIntent_ShortcutOutsideDesktop_LinksNonDesktopSources()
+    {
+        Assert.Equal(
+            FileDropIntent.Shortcut,
+            FileDropIntentPolicy.ResolveMappedTransfer(
+                hasMappedFolder: true,
+                forceCopy: false,
+                controlDown: false,
+                shiftDown: false,
+                defaultMove: true,
+                shortcutOutsideDesktop: true,
+                sourcesOnDesktop: false,
+                canLink: true));
+    }
+
+    [Fact]
+    public void DropIntent_ShortcutOutsideDesktop_ModifierGesturesStillWin()
+    {
+        Assert.Equal(
+            FileDropIntent.Copy,
+            FileDropIntentPolicy.ResolveMappedTransfer(
+                hasMappedFolder: true,
+                forceCopy: false,
+                controlDown: true,
+                shiftDown: false,
+                defaultMove: true,
+                shortcutOutsideDesktop: true,
+                sourcesOnDesktop: false));
+        Assert.Equal(
+            FileDropIntent.Shortcut,
+            FileDropIntentPolicy.ResolveMappedTransfer(
+                hasMappedFolder: true,
+                forceCopy: false,
+                controlDown: false,
+                shiftDown: false,
+                defaultMove: true,
+                altDown: true,
+                canLink: true,
+                shortcutOutsideDesktop: true,
+                sourcesOnDesktop: true));
+    }
+
+    [Fact]
+    public void DropIntent_ShortcutOutsideDesktop_PreservesDefaultWhenDisabled()
+    {
+        Assert.Equal(
+            FileDropIntent.Move,
+            FileDropIntentPolicy.ResolveMappedTransfer(
+                hasMappedFolder: true,
+                forceCopy: false,
+                controlDown: false,
+                shiftDown: false,
+                defaultMove: true,
+                shortcutOutsideDesktop: false,
+                sourcesOnDesktop: false));
+    }
+
+    [Fact]
+    public void DropIntent_ShortcutOutsideDesktop_ForceCopyStillWins()
+    {
+        Assert.Equal(
+            FileDropIntent.Copy,
+            FileDropIntentPolicy.ResolveMappedTransfer(
+                hasMappedFolder: true,
+                forceCopy: true,
+                controlDown: false,
+                shiftDown: false,
+                defaultMove: true,
+                shortcutOutsideDesktop: true,
+                sourcesOnDesktop: false));
+    }
+
+    [Theory]
+    [InlineData(@"C:\Users\Me\Desktop\file.txt", @"C:\Users\Me\Desktop", true)]
+    [InlineData(@"C:\Users\Me\Desktop", @"C:\Users\Me\Desktop", true)]
+    [InlineData(@"C:\Users\Me\DesktopBackup\file.txt", @"C:\Users\Me\Desktop", false)]
+    [InlineData(@"C:\Users\Me\Downloads\file.txt", @"C:\Users\Me\Desktop", false)]
+    public void IsUnderDirectory_TreatsBoundariesAndSiblingsCorrectly(
+        string path,
+        string directory,
+        bool expected)
+    {
+        Assert.Equal(expected, FileDropIntentPolicy.IsUnderDirectory(path, directory));
+    }
+
+    [Fact]
+    public void AreAllUnderDirectories_RequiresEverySourceUnderARoot()
+    {
+        var roots = new[]
+        {
+            @"C:\Users\Me\Desktop",
+            @"C:\Users\Public\Desktop"
+        };
+
+        Assert.True(FileDropIntentPolicy.AreAllUnderDirectories(
+            [@"C:\Users\Me\Desktop\a.txt", @"C:\Users\Public\Desktop\b.txt"],
+            roots));
+        Assert.False(FileDropIntentPolicy.AreAllUnderDirectories(
+            [@"C:\Users\Me\Desktop\a.txt", @"C:\Users\Me\Downloads\b.txt"],
+            roots));
+    }
+
+    [Fact]
+    public void AreAllUnderDirectories_UnknownPayloadCountsAsDesktopResident()
+    {
+        Assert.True(FileDropIntentPolicy.AreAllUnderDirectories(
+            [],
+            [@"C:\Users\Me\Desktop"]));
+    }
+
+    [Fact]
     public void WidgetIconSizeOverride_RoundTripsWithoutChangingTheGlobalSetting()
     {
         var config = new WidgetConfig { IconSizeOverride = 48 };

--- a/tests/DeskBox.Tests/NativeDropEffectPolicyTests.cs
+++ b/tests/DeskBox.Tests/NativeDropEffectPolicyTests.cs
@@ -254,4 +254,137 @@ public sealed class NativeDropEffectPolicyTests
                 allowedEffects: NativeDropEffectPolicy.Move,
                 hasShellApplicationData: true));
     }
+
+    [Fact]
+    public void ShortcutOutsideDesktop_RequestsShortcutForNonDesktopSources()
+    {
+        Assert.True(
+            NativeDropEffectPolicy.ShouldCreateMappedShortcut(
+                containsTemporaryFiles: false,
+                keyState: 0,
+                shortcutOutsideDesktop: true,
+                sourcesOnDesktop: false));
+        Assert.True(
+            NativeDropEffectPolicy.ShouldCopyMappedTransfer(
+                containsTemporaryFiles: false,
+                keyState: 0,
+                defaultMove: true,
+                shortcutOutsideDesktop: true,
+                sourcesOnDesktop: false));
+    }
+
+    [Fact]
+    public void ShortcutOutsideDesktop_ModifierGesturesStillWin()
+    {
+        const uint controlKeyState = 0x0008;
+        const uint shiftKeyState = 0x0004;
+
+        // Ctrl=copy and Shift=move must beat the desktop-based shortcut
+        // default so the completed operation matches the feedback cursor.
+        Assert.False(
+            NativeDropEffectPolicy.ShouldCreateMappedShortcut(
+                containsTemporaryFiles: false,
+                keyState: controlKeyState,
+                shortcutOutsideDesktop: true,
+                sourcesOnDesktop: false));
+        Assert.False(
+            NativeDropEffectPolicy.ShouldCreateMappedShortcut(
+                containsTemporaryFiles: false,
+                keyState: shiftKeyState,
+                shortcutOutsideDesktop: true,
+                sourcesOnDesktop: false));
+        // Alt and Ctrl+Shift remain explicit shortcut gestures.
+        Assert.True(
+            NativeDropEffectPolicy.ShouldCreateMappedShortcut(
+                containsTemporaryFiles: false,
+                keyState: NativeDropEffectPolicy.AltKeyState,
+                shortcutOutsideDesktop: true,
+                sourcesOnDesktop: true));
+        Assert.True(
+            NativeDropEffectPolicy.ShouldCreateMappedShortcut(
+                containsTemporaryFiles: false,
+                keyState: controlKeyState | shiftKeyState,
+                shortcutOutsideDesktop: true,
+                sourcesOnDesktop: true));
+    }
+
+    [Fact]
+    public void ShortcutOutsideDesktop_KeepsMoveForDesktopSources()
+    {
+        Assert.False(
+            NativeDropEffectPolicy.ShouldCreateMappedShortcut(
+                containsTemporaryFiles: false,
+                keyState: 0,
+                shortcutOutsideDesktop: true,
+                sourcesOnDesktop: true));
+        Assert.False(
+            NativeDropEffectPolicy.ShouldCopyMappedTransfer(
+                containsTemporaryFiles: false,
+                keyState: 0,
+                defaultMove: true,
+                shortcutOutsideDesktop: true,
+                sourcesOnDesktop: true));
+    }
+
+    [Fact]
+    public void ShortcutOutsideDesktop_NeverAppliesToTemporaryPayloads()
+    {
+        Assert.False(
+            NativeDropEffectPolicy.ShouldCreateMappedShortcut(
+                containsTemporaryFiles: true,
+                keyState: 0,
+                shortcutOutsideDesktop: true,
+                sourcesOnDesktop: false));
+        Assert.True(
+            NativeDropEffectPolicy.ShouldCopyMappedTransfer(
+                containsTemporaryFiles: true,
+                keyState: 0,
+                defaultMove: true,
+                shortcutOutsideDesktop: true,
+                sourcesOnDesktop: false));
+    }
+
+    [Fact]
+    public void ShortcutOutsideDesktop_FeedbackUsesLinkWhenAllowed()
+    {
+        uint allowed = NativeDropEffectPolicy.Copy |
+                       NativeDropEffectPolicy.Move |
+                       NativeDropEffectPolicy.Link;
+
+        Assert.Equal(
+            NativeDropEffectPolicy.Link,
+            NativeDropEffectPolicy.ResolveFeedbackEffect(
+                hasFileData: true,
+                hasVirtualFileData: false,
+                keyState: 0,
+                allowedEffects: allowed,
+                shortcutOutsideDesktop: true,
+                sourcesOnDesktop: false));
+        Assert.Equal(
+            NativeDropEffectPolicy.Move,
+            NativeDropEffectPolicy.ResolveFeedbackEffect(
+                hasFileData: true,
+                hasVirtualFileData: false,
+                keyState: 0,
+                allowedEffects: allowed,
+                shortcutOutsideDesktop: true,
+                sourcesOnDesktop: true));
+    }
+
+    [Fact]
+    public void ShortcutOutsideDesktop_FeedbackFallsBackToCopyWithoutLink()
+    {
+        uint allowed = NativeDropEffectPolicy.Copy |
+                       NativeDropEffectPolicy.Move;
+
+        Assert.Equal(
+            NativeDropEffectPolicy.Copy,
+            NativeDropEffectPolicy.ResolveFeedbackEffect(
+                hasFileData: true,
+                hasVirtualFileData: false,
+                keyState: 0,
+                allowedEffects: allowed,
+                shortcutOutsideDesktop: true,
+                sourcesOnDesktop: false));
+    }
 }

--- a/tests/DeskBox.Tests/SettingsServiceTests.cs
+++ b/tests/DeskBox.Tests/SettingsServiceTests.cs
@@ -657,6 +657,21 @@ public sealed class SettingsServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task LoadAsync_PreservesShortcutOutsideDesktopDropAction()
+    {
+        await File.WriteAllTextAsync(
+            Path.Combine(_settingsRoot, "settings.json"),
+            "{\"managedDropAction\":\"ShortcutOutsideDesktop\"}");
+
+        var service = new SettingsService(_settingsRoot);
+        await service.LoadAsync();
+
+        Assert.Equal(
+            SettingsService.ManagedDropActionShortcutOutsideDesktop,
+            service.Settings.ManagedDropAction);
+    }
+
+    [Fact]
     public async Task LoadAsync_MigratesLegacyDisabledWideDetailToSinglePane()
     {
         await File.WriteAllTextAsync(

--- a/tests/DeskBox.Tests/ShortcutNativeDifferentialTests.cs
+++ b/tests/DeskBox.Tests/ShortcutNativeDifferentialTests.cs
@@ -669,6 +669,7 @@ public sealed class ShortcutNativeDifferentialTests : IDisposable
 
         Assert.Equal(firstTarget, first?.TargetPath);
         Assert.Equal("--first", first?.Arguments);
+        Assert.Equal(string.Empty, first?.IconLocation);
         Assert.Equal(secondTarget, second?.TargetPath);
         Assert.Equal("--other", second?.Arguments);
     }


### PR DESCRIPTION
- 新增 ShortcutOutsideDesktop 设置项，拖入文件到格子时可按默认策略在桌面外创建快捷方式
- 修复设置界面 ShortcutOutsideDesktop 选项不持久化的问题
- 修复拖入生成的快捷方式未显示源文件图标的问题
- NativeDropTarget 在拖拽过程中 peek CF_HDROP 路径，反馈效果无需暂存虚拟负载

Adds a ShortcutOutsideDesktop default for file drops, persists the setting in the settings UI, shows source-file icons for generated shortcuts, and peeks CF_HDROP paths during drag for correct feedback effects. Includes unit tests.