### PR TITLE
Pluginization stage 2 data hygiene: todo orphan cleanup + backup cache exclusion

### DIFF
--- a/docs/architecture/pluginization-roadmap.md
+++ b/docs/architecture/pluginization-roadmap.md
@@ -379,6 +379,19 @@ P0：§6 重写为 Runtime 矩阵（删除 A→B→C 旧结论，与 §14 唯一
 
 **批次 D 前置决策（已定）**：MusicSettingsSection 命名空间落 `DeskBox.Controls.WidgetContents`（文件仍在 Views/SettingsSections/，命名空间≠目录是 C# 合法形态，且该命名空间已在功能 using 白名单内零扰动）；实现纪律=保持 `{Binding}` 不改 x:Bind（保 327 计数）、保 `x:Name="MusicSettingsSection"`（Slice 断言端点）、Music 文件计数 13→15 有意更新。
 
+### 16.5 中期外部评审吸收（v1.6，2026-09-07，PR #231 合并后）
+
+外部评审对 PR #231 的裁定（8.5/10、方向正确、无需回滚）与我方指纹级自审一致。吸收六条入册：
+
+1. **两层概念显式化**：`DeskBox.Abstractions` = **Host Abstractions**（1P 内建功能与宿主的共享契约，含 WidgetConfig 持久化模型与 FrameworkElement 依赖），**不是未来 Extension SDK**。未来 3P/AI 层是独立的 **Extension Model**（PackageId/Contribution/Capability DTO，"完全不知道 File Widget 是什么"，§14 图的语义契约层）。已在 Abstractions 加 README 声明。
+2. **WidgetConfig 禁扩令**：它是 legacy 宿主持久化模型（宿主公共态+File 专属态混装），不得扩成万能插件配置；未来按"核心实例状态 + 插件 payload"拆分（与 §5 三层 ID、per-plugin 存储同向）。
+3. **ArchitectureContractTests 定位=迁移期棘轮**：不得膨胀为半成品 Roslyn 分析器（正则/文件名启发式的边界是弱的）；**退役条件**=Feature 边界由类型系统/API shape 物理化之时，届时删除 FrozenFeatureFileCounts——但 Music/设置节搬迁完成前它仍是必要的绊线，不提前删。
+4. **ExtensionModel 硬约束**（未来创建时）：禁 WinAppSDK/WinUI/WidgetManager/AppSettings/Windows API，目标 TFM 尽量纯 net10.0（不带 -windows）——它是语言无关协议的 .NET 投影，不是内部 DTO 包。
+5. **Music dogfood 验收条件**（升级阶段 2/D 判据）：Music 只能见 host contracts + feature context + 自有服务，**不得**见 WidgetManager 内部/App.Current/SettingsService 整体/其他功能类型；且 Register→Contribute→Enable→Activate→Disable→Dispose 全生命周期链路真实跑通——这才证明阶段 1 的接缝成立。
+6. **搬迁原则**："遇到真实依赖才最小接口进入"，禁止"以后插件可能用所以先扔进去"。
+
+评审的偏差记录（不影响吸收）：其字段分类有误（ViewMode 实为共享，File 专属是 MappedFolderPath/Items 等）；其两条"建议"（broker 不进 Abstractions、三 Runtime 并存）本路线图已先行决策；其评审未覆盖本批工程量大头（audit 六轮重对齐、retail SelfContained 修复）。
+
 ## 附录 A：关键证据文件索引
 
 | 主题 | 文件 |

--- a/src/DeskBox.Abstractions/README.md
+++ b/src/DeskBox.Abstractions/README.md
@@ -1,0 +1,27 @@
+# DeskBox.Abstractions
+
+Internal host contract assembly for the widget content seam
+(`IWidgetContent` family, `WidgetConfig`, `WidgetContentDescriptor`,
+chrome enums, calendar presentation models).
+
+**This is NOT the public extension/plugin SDK.**
+
+- It exists so first-party built-in features and the host share one
+  physical assembly while the pluginization program runs
+  (docs/architecture/pluginization-roadmap.md, stage 1).
+- It deliberately contains host-persistence models (`WidgetConfig`
+  mixes host-common state with File-widget-specific fields) and WinUI
+  types (`FrameworkElement`), which is exactly what a third-party
+  extension model must never see.
+- The future third-party/AI-facing layer is a separate, language-neutral
+  Extension Model (roadmap section 14): plain DTOs, no WinAppSDK, no
+  WinUI, no host types - projected to JSON Schema / WIT / RPC adapters.
+
+Rules of engagement:
+
+- Move types in only when a real dependency demands it, as a minimal
+  interface - never "because a plugin might use it someday".
+- Do not grow `WidgetConfig`; new per-feature state belongs in feature
+  stores or the future plugin payload split.
+- Host namespaces are kept (`DeskBox.Models/Contracts/Services`) for
+  zero-churn migration; future platform types get their own namespaces.

--- a/src/DeskBox/Services/DeskBoxDataBackupService.cs
+++ b/src/DeskBox/Services/DeskBoxDataBackupService.cs
@@ -1454,8 +1454,14 @@ public sealed partial class DeskBoxDataBackupService
             return false;
         }
 
+        // cache/ (widget image caches) and weather-cache.json are disposable:
+        // they regenerate on next use, so backups skip them. Restoring a
+        // backup without them only means the first weather render falls back
+        // to the location flow and glance images redownload.
         return !relativePath.StartsWith("quick-capture/thumbnails/", StringComparison.OrdinalIgnoreCase) &&
-               !relativePath.StartsWith("quick-capture/exports/", StringComparison.OrdinalIgnoreCase);
+               !relativePath.StartsWith("quick-capture/exports/", StringComparison.OrdinalIgnoreCase) &&
+               !relativePath.StartsWith("cache/", StringComparison.OrdinalIgnoreCase) &&
+               !string.Equals(relativePath, "weather-cache.json", StringComparison.OrdinalIgnoreCase);
     }
 
     private static async Task<(long Length, string Sha256)> CopyAndHashAsync(

--- a/src/DeskBox/Services/TodoWidgetStore.cs
+++ b/src/DeskBox/Services/TodoWidgetStore.cs
@@ -173,6 +173,78 @@ public sealed class TodoWidgetStore
         return SaveAsync(new TodoWidgetData());
     }
 
+    /// <summary>
+    /// Deletes every persisted artifact of a widget's todo data: the store
+    /// file, its resilient backup, the attachments directory, and the widget
+    /// directory itself when it becomes empty. Callers invoke this when the
+    /// widget is removed (WidgetManager.RemoveWidgetAsync and the duplicate
+    /// cleanup in ResetFeatureWidgetAsync) so deleting a todo widget leaves
+    /// no orphaned data behind, mirroring GlanceWidgetStore.
+    /// </summary>
+    public static Task DeleteForWidgetAsync(string widgetId) =>
+        DeleteForWidgetAsync(
+            Path.Combine(
+                DeskBoxDataPathService.Current.DataDirectory,
+                "widgets"),
+            widgetId);
+
+    internal static Task DeleteForWidgetAsync(string widgetsDataRoot, string widgetId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(widgetId);
+        string dataDir = Path.Combine(widgetsDataRoot, SanitizeWidgetId(widgetId));
+        string storePath = Path.Combine(dataDir, "todo.json");
+        TryDeleteFile(storePath);
+        TryDeleteFile(ResilientJsonStore.GetBackupPath(storePath));
+        TryDeleteDirectory(Path.Combine(dataDir, "attachments"));
+        TryDeleteDirectoryIfEmpty(dataDir);
+        return Task.CompletedTask;
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (Exception ex)
+        {
+            App.Log($"[TodoWidgetStore] Failed to delete '{path}': {ex.Message}");
+        }
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch (Exception ex)
+        {
+            App.Log($"[TodoWidgetStore] Failed to delete directory '{path}': {ex.Message}");
+        }
+    }
+
+    private static void TryDeleteDirectoryIfEmpty(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path) && !Directory.EnumerateFileSystemEntries(path).Any())
+            {
+                Directory.Delete(path);
+            }
+        }
+        catch (Exception ex)
+        {
+            App.Log($"[TodoWidgetStore] Failed to remove empty directory '{path}': {ex.Message}");
+        }
+    }
+
     private static void NormalizeSteps(List<TodoStep> steps)
     {
         int sortOrder = 0;

--- a/src/DeskBox/Services/WidgetManager.FeatureWidgets.cs
+++ b/src/DeskBox/Services/WidgetManager.FeatureWidgets.cs
@@ -1050,6 +1050,13 @@ public sealed partial class WidgetManager
                 {
                     await GlanceWidgetStore.DeleteForWidgetAsync(duplicate.Id);
                 }
+                else if (kind == WidgetKind.Todo)
+                {
+                    // Duplicate todo instances keep their own stores and
+                    // attachments; dropping the config alone used to orphan
+                    // them under data/widgets/{id}/.
+                    await TodoWidgetStore.DeleteForWidgetAsync(duplicate.Id);
+                }
                 if (!_settingsService.Settings.DeletedWidgetIds.Contains(duplicate.Id))
                 {
                     _settingsService.Settings.DeletedWidgetIds.Add(duplicate.Id);

--- a/src/DeskBox/Services/WidgetManager.cs
+++ b/src/DeskBox/Services/WidgetManager.cs
@@ -1632,6 +1632,20 @@ public sealed partial class WidgetManager
                     SetFeatureWidgetEnabledState(WidgetKind.Glance, false);
                 }
             }
+            else if (config.WidgetKind == WidgetKind.Todo)
+            {
+                // Todo widgets can coexist; deleting one removes its store and
+                // attachments, and only disables the feature when the last
+                // instance goes away (mirroring the Glance branch above).
+                await TodoWidgetStore.DeleteForWidgetAsync(config.Id);
+                bool hasRemainingTodoWidget = _settingsService.Settings.Widgets.Any(widget =>
+                    widget.WidgetKind == WidgetKind.Todo &&
+                    !IsDeleted(widget.Id));
+                if (!hasRemainingTodoWidget)
+                {
+                    SetFeatureWidgetEnabledState(WidgetKind.Todo, false);
+                }
+            }
             else
             {
                 SetFeatureWidgetEnabledState(config.WidgetKind, false);

--- a/tests/DeskBox.Tests/DeskBoxDataBackupServiceTests.cs
+++ b/tests/DeskBox.Tests/DeskBoxDataBackupServiceTests.cs
@@ -34,6 +34,12 @@ public sealed class DeskBoxDataBackupServiceTests : IDisposable
             Path.Combine(dataDirectory, "quick-capture", "exports")).FullName;
         await File.WriteAllBytesAsync(Path.Combine(thumbnailDirectory, "cached.png"), [4, 5, 6]);
         await File.WriteAllTextAsync(Path.Combine(exportDirectory, "temporary.txt"), "temporary");
+        string glanceCacheDirectory = Directory.CreateDirectory(
+            Path.Combine(dataDirectory, "cache", "glance", "images")).FullName;
+        await File.WriteAllBytesAsync(Path.Combine(glanceCacheDirectory, "wallpaper.jpg"), [7, 8, 9]);
+        await File.WriteAllTextAsync(
+            Path.Combine(dataDirectory, "weather-cache.json"),
+            "{\"schemaVersion\":2}");
         var service = new DeskBoxDataBackupService(_appDataRoot);
 
         string backupPath = await service.ExportBackupAsync(_exportRoot);
@@ -45,6 +51,8 @@ public sealed class DeskBoxDataBackupServiceTests : IDisposable
         Assert.Null(archive.GetEntry("data/ignored.tmp"));
         Assert.Null(archive.GetEntry("data/quick-capture/thumbnails/cached.png"));
         Assert.Null(archive.GetEntry("data/quick-capture/exports/temporary.txt"));
+        Assert.Null(archive.GetEntry("data/cache/glance/images/wallpaper.jpg"));
+        Assert.Null(archive.GetEntry("data/weather-cache.json"));
         ZipArchiveEntry manifestEntry = Assert.IsType<ZipArchiveEntry>(archive.GetEntry("manifest.json"));
         string manifestJson;
         using (var reader = new StreamReader(manifestEntry.Open()))

--- a/tests/DeskBox.Tests/TodoOrphanCleanupContractTests.cs
+++ b/tests/DeskBox.Tests/TodoOrphanCleanupContractTests.cs
@@ -1,0 +1,64 @@
+namespace DeskBox.Tests;
+
+/// <summary>
+/// Source-scan contract for the todo orphan-data cleanup wiring (pluginization
+/// roadmap section 7, stage 2 data hygiene). The deletion logic itself is
+/// covered by TodoWidgetStoreTests against an isolated root; these assertions
+/// pin the two WidgetManager call sites so the hooks cannot be removed
+/// silently. House precedent: IdleRuntimeLifecycleContractTests-style
+/// Contains checks over production sources.
+/// </summary>
+public sealed class TodoOrphanCleanupContractTests
+{
+    [Fact]
+    public void RemoveWidgetAsync_DeletesTodoStoreBeforeFeatureDisableCheck()
+    {
+        string manager = File.ReadAllText(TestPaths.SourceFile(
+            "src/DeskBox/Services/WidgetManager.cs"));
+
+        int todoBranch = manager.IndexOf(
+            "else if (config.WidgetKind == WidgetKind.Todo)",
+            StringComparison.Ordinal);
+        Assert.True(todoBranch >= 0, "RemoveWidgetAsync must handle WidgetKind.Todo.");
+
+        int deleteCall = manager.IndexOf(
+            "await TodoWidgetStore.DeleteForWidgetAsync(config.Id);",
+            StringComparison.Ordinal);
+        int remainingCheck = manager.IndexOf(
+            "hasRemainingTodoWidget",
+            StringComparison.Ordinal);
+        int glanceBranch = manager.IndexOf(
+            "if (config.WidgetKind == WidgetKind.Glance)",
+            StringComparison.Ordinal);
+
+        Assert.True(deleteCall > todoBranch, "The todo branch must delete the widget store.");
+        Assert.True(
+            remainingCheck > deleteCall,
+            "The feature may only be disabled after checking for remaining todo widgets.");
+        Assert.True(
+            glanceBranch >= 0 && todoBranch > glanceBranch,
+            "The todo branch mirrors the glance branch structure.");
+    }
+
+    [Fact]
+    public void ResetFeatureWidgetAsync_DeletesDataForDuplicateTodoWidgets()
+    {
+        string features = File.ReadAllText(TestPaths.SourceFile(
+            "src/DeskBox/Services/WidgetManager.FeatureWidgets.cs"));
+
+        int duplicateLoop = features.IndexOf(
+            "ResetFeatureWidget removed duplicate",
+            StringComparison.Ordinal);
+        Assert.True(duplicateLoop >= 0, "Duplicate removal loop not found.");
+
+        string duplicateRegion = features[..duplicateLoop];
+        Assert.Contains(
+            "else if (kind == WidgetKind.Todo)",
+            duplicateRegion,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "await TodoWidgetStore.DeleteForWidgetAsync(duplicate.Id);",
+            duplicateRegion,
+            StringComparison.Ordinal);
+    }
+}

--- a/tests/DeskBox.Tests/TodoWidgetStoreTests.cs
+++ b/tests/DeskBox.Tests/TodoWidgetStoreTests.cs
@@ -28,6 +28,48 @@ public sealed class TodoWidgetStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task DeleteForWidgetAsync_RemovesStoreBackupAttachmentsAndEmptyDirectory()
+    {
+        var store = CreateStore("todo-widget");
+        await store.SaveAsync(CreateData("item-1", "buy milk"));
+        // Force a resilient backup next to the store file.
+        string backupPath = ResilientJsonStore.GetBackupPath(store.StorePath);
+        await File.WriteAllTextAsync(backupPath, "{}");
+        Directory.CreateDirectory(store.AttachmentDirectory);
+        await File.WriteAllBytesAsync(
+            Path.Combine(store.AttachmentDirectory, "spec.pdf"),
+            [1, 2, 3]);
+        string widgetDirectory = Path.GetDirectoryName(store.StorePath)!;
+
+        await TodoWidgetStore.DeleteForWidgetAsync(_widgetsDataRoot, "todo-widget");
+
+        Assert.False(File.Exists(store.StorePath));
+        Assert.False(File.Exists(backupPath));
+        Assert.False(Directory.Exists(store.AttachmentDirectory));
+        Assert.False(Directory.Exists(widgetDirectory));
+    }
+
+    [Fact]
+    public async Task DeleteForWidgetAsync_IsIdempotentAndKeepsSiblingWidgetData()
+    {
+        var removed = CreateStore("todo-a");
+        var sibling = CreateStore("todo-b");
+        await removed.SaveAsync(CreateData("item-1", "removed"));
+        await sibling.SaveAsync(CreateData("item-2", "kept"));
+        Directory.CreateDirectory(sibling.AttachmentDirectory);
+        await File.WriteAllBytesAsync(
+            Path.Combine(sibling.AttachmentDirectory, "keep.pdf"),
+            [4, 5, 6]);
+
+        await TodoWidgetStore.DeleteForWidgetAsync(_widgetsDataRoot, "todo-a");
+        await TodoWidgetStore.DeleteForWidgetAsync(_widgetsDataRoot, "todo-a");
+
+        Assert.False(File.Exists(removed.StorePath));
+        Assert.True(File.Exists(sibling.StorePath));
+        Assert.True(File.Exists(Path.Combine(sibling.AttachmentDirectory, "keep.pdf")));
+    }
+
+    [Fact]
     public async Task SaveAsync_PersistsAndReloadsItems()
     {
         var store = CreateStore("todo-widget");


### PR DESCRIPTION
## Summary

First slice of roadmap stage 2 (pluginization/data-hygiene branch):

- **Todo orphan data fix**: deleting a todo widget now removes its store file, resilient backup, attachments directory and the empty widget directory via a new TodoWidgetStore.DeleteForWidgetAsync (idempotent, mirrors GlanceWidgetStore). Wired into both call sites - RemoveWidgetAsync and the duplicate cleanup in ResetFeatureWidgetAsync. Multi-instance aware: the feature only disables when the last todo widget goes away.
- **Backup hygiene**: ShouldIncludeInBackup now also excludes the disposable cache/ tree (glance image cache) and weather-cache.json. Restoring costs one location-fallback on the first weather render; documented in code.

## Validation

- Full suite 3381/3381 green on x64 (4 new tests: deletion semantics x2, backup exclusions, source-scan hooks contract x2).
- Canonical Debug rebuilt and restarted from the branch.