### PR TITLE
Pluginization stage 2 hygiene: centralize WidgetConfig metadata keys

### DIFF
--- a/src/DeskBox/Controls/WidgetContents/QuickCaptureSurfaceContent.xaml.cs
+++ b/src/DeskBox/Controls/WidgetContents/QuickCaptureSurfaceContent.xaml.cs
@@ -38,7 +38,6 @@ public sealed partial class QuickCaptureSurfaceContent :
     IWidgetGroupContentCacheable,
     IDisposable
 {
-    private const string MasterPaneWidthMetadataKey = "QuickCaptureMasterPaneWidth";
     private const int DetailAutoSaveDelayMs = 600;
     private const int DetailImageDecodePixelWidth = 1200;
     private readonly LocalizationService _localizationService;
@@ -128,7 +127,7 @@ public sealed partial class QuickCaptureSurfaceContent :
         }
         ResponsiveContentGrid.DataContext = ViewModel;
         ViewModel.PropertyChanged += ViewModel_PropertyChanged;
-        if (config.Metadata.TryGetValue(MasterPaneWidthMetadataKey, out string? persisted) &&
+        if (config.Metadata.TryGetValue(WidgetMetadataKeys.QuickCaptureMasterPaneWidth, out string? persisted) &&
             double.TryParse(persisted, NumberStyles.Float, CultureInfo.InvariantCulture, out double width))
         {
             _persistedMasterPaneWidth = _masterDetailLayoutPolicy.NormalizePersistedMasterWidth(width);
@@ -626,7 +625,7 @@ public sealed partial class QuickCaptureSurfaceContent :
 
         _persistedMasterPaneWidth =
             _masterDetailLayoutPolicy.NormalizePersistedMasterWidth(masterWidth);
-        Config.Metadata[MasterPaneWidthMetadataKey] =
+        Config.Metadata[WidgetMetadataKeys.QuickCaptureMasterPaneWidth] =
             _persistedMasterPaneWidth.Value.ToString(
                 "0.###",
                 CultureInfo.InvariantCulture);

--- a/src/DeskBox/Services/WidgetMetadataKeys.cs
+++ b/src/DeskBox/Services/WidgetMetadataKeys.cs
@@ -1,0 +1,48 @@
+namespace DeskBox.Services;
+
+/// <summary>
+/// Central registry of every WidgetConfig.Metadata key used across the
+/// application (pluginization roadmap section 7, stage 2 data hygiene).
+/// Before this class the key literals lived in eight different files with
+/// two naming styles (bare PascalCase vs dotted feature prefixes) and one
+/// literal declared twice (QuickCaptureMasterPaneWidth).
+///
+/// The owning families keep their constants; this registry aliases them so
+/// there is exactly one place to grep, review and register metadata keys.
+/// New keys must be added here at the same time they are introduced - the
+/// WidgetMetadataKeysContractTests freeze pins the complete inventory.
+///
+/// Note: dotted keys (Todo.*, Weather.*) are feature-owned state stored in
+/// the shared WidgetConfig.Metadata dictionary; see the roadmap section on
+/// per-kind settings stores for the long-term direction of moving feature
+/// state out of the shared dictionary.
+/// </summary>
+public static class WidgetMetadataKeys
+{
+    // Chrome & behavior (host-owned)
+    public const string ChromeMode = WidgetChromeModeNames.MetadataKey;
+    public const string CollapseBehavior = WidgetCollapseBehaviorNames.MetadataKey;
+    public const string FolderOpenBehavior = FileWidgetFolderOpenBehaviorNames.MetadataKey;
+
+    // Foreground text overrides (host-owned)
+    public const string WidgetForegroundMode = WidgetForegroundSettings.ModeOverrideMetadataKey;
+    public const string WidgetForegroundColor = WidgetForegroundSettings.ColorOverrideMetadataKey;
+    public const string WidgetTextEdgeMode = WidgetForegroundSettings.EdgeOverrideMetadataKey;
+
+    // File stack overrides (File-widget owned)
+    public const string FileStacksEnabled = WidgetFileStackSettings.EnabledOverrideMetadataKey;
+    public const string FileStackGroupBy = WidgetFileStackSettings.GroupByOverrideMetadataKey;
+    public const string FileStackThreshold = WidgetFileStackSettings.ThresholdOverrideMetadataKey;
+    public const string FileStackOrderBy = WidgetFileStackSettings.OrderByOverrideMetadataKey;
+    public const string FileStackOpenMode = WidgetFileStackSettings.OpenModeOverrideMetadataKey;
+    public const string FileStackDisabledGroups = WidgetFileStackSettings.DisabledStacksMetadataKey;
+    public const string FileStackNameOverrides = WidgetFileStackSettings.StackNameOverridesMetadataKey;
+    public const string FileStackGroupOrder = WidgetFileStackSettings.StackOrderMetadataKey;
+    public const string FileStackMemberOverrides = WidgetFileStackSettings.StackMemberOverridesMetadataKey;
+
+    // Feature-owned instance state (dotted namespace style)
+    public const string WeatherViewMode = WeatherWidgetViewModeSettings.MetadataKey;
+    public const string TodoMasterPaneWidth = "Todo.MasterPaneWidth";
+    public const string TodoTitleEditorHeight = "Todo.TitleEditorHeight";
+    public const string QuickCaptureMasterPaneWidth = "QuickCaptureMasterPaneWidth";
+}

--- a/src/DeskBox/Views/QuickCaptureWidgetWindow.ResponsiveDetail.cs
+++ b/src/DeskBox/Views/QuickCaptureWidgetWindow.ResponsiveDetail.cs
@@ -14,7 +14,7 @@ public sealed partial class QuickCaptureWidgetWindow
 {
     private void InitializeResponsiveDetail()
     {
-        if (ViewModel.Config.Metadata.TryGetValue(MasterPaneWidthMetadataKey, out string? persisted) &&
+        if (ViewModel.Config.Metadata.TryGetValue(WidgetMetadataKeys.QuickCaptureMasterPaneWidth, out string? persisted) &&
             double.TryParse(persisted, NumberStyles.Float, CultureInfo.InvariantCulture, out double width))
         {
             _persistedMasterPaneWidth = _masterDetailLayoutPolicy.NormalizePersistedMasterWidth(width);
@@ -184,7 +184,7 @@ public sealed partial class QuickCaptureWidgetWindow
         double normalized = _masterDetailLayoutPolicy.NormalizePersistedMasterWidth(
             MasterColumn.ActualWidth);
         _persistedMasterPaneWidth = normalized;
-        ViewModel.Config.Metadata[MasterPaneWidthMetadataKey] = normalized.ToString(
+        ViewModel.Config.Metadata[WidgetMetadataKeys.QuickCaptureMasterPaneWidth] = normalized.ToString(
             "0.###",
             CultureInfo.InvariantCulture);
         _settingsService.SaveDebounced();

--- a/src/DeskBox/Views/QuickCaptureWidgetWindow.xaml.cs
+++ b/src/DeskBox/Views/QuickCaptureWidgetWindow.xaml.cs
@@ -53,7 +53,6 @@ public sealed partial class QuickCaptureWidgetWindow :
     private const int ItemsViewTransitionOffsetPx = 6;
     private const int DetailAutoSaveDelayMs = 600;
     private const int RevealCompletedBackgroundDelayMs = 240;
-    private const string MasterPaneWidthMetadataKey = "QuickCaptureMasterPaneWidth";
     private static readonly string QuickCaptureTextPreviewDirectory = Path.Combine(
         DeskBoxDataPathService.Current.RootPath,
         "QuickCapture",

--- a/tests/DeskBox.Tests/MarkdownAndSplitterContractTests.cs
+++ b/tests/DeskBox.Tests/MarkdownAndSplitterContractTests.cs
@@ -418,7 +418,7 @@ public sealed class MarkdownAndSplitterContractTests
         Assert.Contains("x:Name=\"DetailAddFileButton\"\n                            Grid.Row=\"2\"", xaml.ReplaceLineEndings("\n"), StringComparison.Ordinal);
         Assert.Contains("x:Name=\"DetailMarkdownEditor\"", xaml, StringComparison.Ordinal);
         Assert.Contains("RightTapped=\"QuickCaptureItem_RightTapped\"", xaml, StringComparison.Ordinal);
-        Assert.Contains("MasterPaneWidthMetadataKey", surface, StringComparison.Ordinal);
+        Assert.Contains("WidgetMetadataKeys.QuickCaptureMasterPaneWidth", surface, StringComparison.Ordinal);
         Assert.Contains("IWidgetAddActionContent", surface, StringComparison.Ordinal);
         Assert.Contains("DetailMarkdownView_TaskToggleRequested", surface, StringComparison.Ordinal);
         Assert.Contains("TimeSpan.FromMilliseconds(DetailAutoSaveDelayMs)", surface, StringComparison.Ordinal);
@@ -450,7 +450,7 @@ public sealed class MarkdownAndSplitterContractTests
         Assert.Contains("QuickCaptureWideLayoutDualPane", code, StringComparison.Ordinal);
         Assert.Contains("WidgetSegmentedStyleHelper.Apply", code, StringComparison.Ordinal);
         Assert.Contains("ViewModel.TabStyle", code, StringComparison.Ordinal);
-        Assert.Contains("Config.Metadata[MasterPaneWidthMetadataKey]", code, StringComparison.Ordinal);
+        Assert.Contains("Config.Metadata[WidgetMetadataKeys.QuickCaptureMasterPaneWidth]", code, StringComparison.Ordinal);
         Assert.Contains("IWidgetResponsiveLayoutContent", code, StringComparison.Ordinal);
         Assert.Contains("IWidgetHostViewportContent", code, StringComparison.Ordinal);
         Assert.Contains("OnHostViewportSizeChanged", code, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/WidgetMetadataKeysContractTests.cs
+++ b/tests/DeskBox.Tests/WidgetMetadataKeysContractTests.cs
@@ -1,0 +1,75 @@
+namespace DeskBox.Tests;
+
+/// <summary>
+/// Freezes the complete WidgetConfig.Metadata key inventory through the
+/// central WidgetMetadataKeys registry (pluginization roadmap section 7,
+/// stage 2 data hygiene). Every key a family owns must be aliased here;
+/// new keys are added together with their family constant, and the
+/// QuickCaptureMasterPaneWidth literal exists exactly once (it used to be
+/// declared privately in two files).
+/// </summary>
+public sealed class WidgetMetadataKeysContractTests
+{
+    [Fact]
+    public void Registry_AliasesEveryKnownMetadataKey()
+    {
+        string registry = File.ReadAllText(TestPaths.SourceFile(
+            "src/DeskBox/Services/WidgetMetadataKeys.cs"));
+
+        string[] requiredAliases =
+        [
+            "ChromeMode = WidgetChromeModeNames.MetadataKey",
+            "CollapseBehavior = WidgetCollapseBehaviorNames.MetadataKey",
+            "FolderOpenBehavior = FileWidgetFolderOpenBehaviorNames.MetadataKey",
+            "WidgetForegroundMode = WidgetForegroundSettings.ModeOverrideMetadataKey",
+            "WidgetForegroundColor = WidgetForegroundSettings.ColorOverrideMetadataKey",
+            "WidgetTextEdgeMode = WidgetForegroundSettings.EdgeOverrideMetadataKey",
+            "FileStacksEnabled = WidgetFileStackSettings.EnabledOverrideMetadataKey",
+            "FileStackGroupBy = WidgetFileStackSettings.GroupByOverrideMetadataKey",
+            "FileStackThreshold = WidgetFileStackSettings.ThresholdOverrideMetadataKey",
+            "FileStackOrderBy = WidgetFileStackSettings.OrderByOverrideMetadataKey",
+            "FileStackOpenMode = WidgetFileStackSettings.OpenModeOverrideMetadataKey",
+            "FileStackDisabledGroups = WidgetFileStackSettings.DisabledStacksMetadataKey",
+            "FileStackNameOverrides = WidgetFileStackSettings.StackNameOverridesMetadataKey",
+            "FileStackGroupOrder = WidgetFileStackSettings.StackOrderMetadataKey",
+            "FileStackMemberOverrides = WidgetFileStackSettings.StackMemberOverridesMetadataKey",
+            "WeatherViewMode = WeatherWidgetViewModeSettings.MetadataKey",
+            "TodoMasterPaneWidth = \"Todo.MasterPaneWidth\"",
+            "TodoTitleEditorHeight = \"Todo.TitleEditorHeight\"",
+            "QuickCaptureMasterPaneWidth = \"QuickCaptureMasterPaneWidth\"",
+        ];
+
+        foreach (string alias in requiredAliases)
+        {
+            Assert.Contains(alias, registry, StringComparison.Ordinal);
+        }
+
+        Assert.Equal(19, requiredAliases.Length);
+    }
+
+    [Fact]
+    public void QuickCaptureMasterPaneWidth_DeclaredExactlyOnce()
+    {
+        // The literal used to be declared privately in both
+        // QuickCaptureSurfaceContent and the dead QuickCaptureWidgetWindow;
+        // both now consume the registry constant.
+        string[] consumers =
+        [
+            "src/DeskBox/Controls/WidgetContents/QuickCaptureSurfaceContent.xaml.cs",
+            "src/DeskBox/Views/QuickCaptureWidgetWindow.ResponsiveDetail.cs",
+        ];
+
+        foreach (string consumer in consumers)
+        {
+            string source = File.ReadAllText(TestPaths.SourceFile(consumer));
+            Assert.DoesNotContain(
+                "const string MasterPaneWidthMetadataKey",
+                source,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "WidgetMetadataKeys.QuickCaptureMasterPaneWidth",
+                source,
+                StringComparison.Ordinal);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Third slice of stage 2 data hygiene:

- New `WidgetMetadataKeys` registry aliases all 19 metadata keys owned by their families (chrome, collapse, folder-open, foreground overrides, nine FileStack overrides, Weather.ViewMode, two Todo keys, QuickCapture pane width) - one place to grep, review and register keys.
- Families keep their constants: zero behavior change, zero audit-profile churn (the earlier plan expected a profile bump here; the alias design avoids it entirely).
- `QuickCaptureMasterPaneWidth` was declared privately in two files; both consumers now reference the registry constant.
- `WidgetMetadataKeysContractTests` freezes the complete inventory and the single-declaration rule; two MarkdownAndSplitter pins follow the rename.

## Validation

- Full suite 3383/3383 green on x64.
- Canonical Debug rebuilt and restarted from the branch.