### PR TITLE
Plugin manifest schema v0 draft (roadmap stage 2.5)

### DIFF
--- a/docs/architecture/plugin-schema-v0-notes.md
+++ b/docs/architecture/plugin-schema-v0-notes.md
@@ -1,0 +1,29 @@
+# DeskBox Plugin Schema v0 — 语义注记
+
+配套 `plugin-schema-v0.json`。v0 是草案：给三路 spike（roadmap 阶段 3.5）、CLI validator（阶段 6）、商店规范（阶段 7）一个共同靶子，会迭代；契约测试只轻钉存在性与词汇，不逐字段冻结。
+
+## 与已定决策的对应
+
+| Schema 条目 | 决策来源 |
+|---|---|
+| `category` 三枚举 | §13.1（声明式资源包首发品类；WASM/进程外一等 Runtime） |
+| `hostApi{min,max}` + 运行期 protocolVersion | §13.4 版本双闸（安装期挡不可能兼容的包，握手期不匹配回结构化错误附 supported 列表） |
+| 六模板枚举 | §13.5（Metric/List/Status/Gallery/ActionList/SimpleForm；v0 无自由布局原语，不发明小型 XAML） |
+| `payload.version` + per-element fallback | §13.5 分层规则（manifest 严格 / RPC envelope 宽容 / payload 按版本严格、未知元素 fallback→丢弃） |
+| `permissions`/`scopes`/`capabilities` + `defaultSet` | §13.2（Tauri ACL 词汇、JSON 格式不抄 TOML、deny 压 allow、防御性默认 deny 集） |
+| `activationEvents` | §5.8（实例恢复与运行时激活分离：窗口/布局恢复永远发生，事件只决定 Runtime 何时拉起） |
+| 三级 ID 分离 | §7 阶段 7（Package ≠ Widget Type ≠ Instance） |
+| `signature` 双字段 | §13.6 三级签名（完整性 SHA256 / 发布者 Ed25519 / Full-Trust 走 Windows 代码签名+Store/WinGet 渠道） |
+| `data.*SchemaVersion` | §9 插件 schema 迁移条款（宿主负责备份→迁移→验证→提交/回滚） |
+
+## 通道三分法（引用 §13.4，写进包语义）
+
+- **Capability Call**（插件→宿主，request/response，受权限+scope 控制）——被鼓励的正常流量；
+- **Lifecycle/Event**（宿主→插件，typed event，白名单：onActivate/onWidgetVisible/onFileChanged/onTimer/onSettingsChanged…）；
+- **任意宿主函数 invoke**——禁止。MCP 弃用反向请求的教训只适用于第三类。
+
+## v0 明确不包含（防止提前冻结）
+
+- 声明式 UI payload 的字段级 schema（六模板各自的 payload 结构留给 spike 输出后定 v1）；
+- 商店侧字段（价格/entitlement 是服务端元数据，§15：包本体是免费产物）；
+- 进程外/WASM 运行时的传输细节（stdio+LSP framing 是 Process Runtime 的事，不是 manifest 的事）。

--- a/docs/architecture/plugin-schema-v0.json
+++ b/docs/architecture/plugin-schema-v0.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://deskbox.fun/schemas/plugin-manifest-v0.json",
+  "title": "DeskBox Plugin Manifest (schema v0 draft)",
+  "description": "Draft manifest vocabulary for the DeskBox extension system. v0 exists to give the three-way runtime spike, the plugin CLI validator and the store specification one shared target; it will iterate and is intentionally lightly pinned by tests (existence + vocabulary, not field-by-field freezing). Design decisions: roadmap sections 13.2 (permissions), 13.4 (protocol skeleton), 13.5 (declarative UI), 14 (Extension Model) and 15 (store/commerce).",
+  "type": "object",
+  "required": ["schemaVersion", "id", "version", "publisher", "category", "hostApi", "widgets", "signature"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "const": 0,
+      "description": "Manifest schema version. Unknown future versions must be rejected at install time (install-gate), not silently tolerated."
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*(\\.[a-z0-9][a-z0-9-]*)+$",
+      "description": "Package id, reverse-DNS style (e.g. com.github.stats). Package id != widget type id != widget instance id (three-level separation)."
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Package semver. Must increase on every store upload or the installer refuses (Rainmeter discipline)."
+    },
+    "publisher": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Publisher identity. In the pre-account phase this is the Ed25519 publisher key fingerprint; later it binds to a registered account."
+    },
+    "category": {
+      "enum": ["resource-pack", "wasm", "out-of-proc"],
+      "description": "resource-pack: declarative-only, no code executes, store launch category. wasm: sandboxed component. out-of-proc: full-trust process (Windows code signing channel required, L1 review)."
+    },
+    "hostApi": {
+      "type": "object",
+      "required": ["min", "max"],
+      "additionalProperties": false,
+      "properties": {
+        "min": { "type": "string", "description": "Minimum host API version (install gate)." },
+        "max": { "type": "string", "description": "Maximum tested host API version; hosts above this may refuse or warn." }
+      },
+      "description": "Install-time half of the version double-gate; the runtime handshake protocolVersion is the other half (roadmap 13.4)."
+    },
+    "widgets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["typeId", "displayName", "template"],
+        "additionalProperties": false,
+        "properties": {
+          "typeId": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]*$",
+            "description": "Widget type id, unique within the package; conventionally prefixed by the package id."
+          },
+          "displayName": { "type": "string", "minLength": 1 },
+          "template": {
+            "enum": ["metric", "list", "status", "gallery", "action-list", "simple-form"],
+            "description": "Host-rendered declarative template (roadmap 13.5). v0 deliberately has no free-form layout primitives."
+          },
+          "payload": {
+            "type": "object",
+            "required": ["version"],
+            "properties": {
+              "version": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Payload schema version; the host picks the parser by version, strict within a known version, unknown elements fall back per-element then drop."
+              }
+            },
+            "additionalProperties": true,
+            "description": "Template payload data + bindings. HostConfig owns theming; the payload never carries style."
+          },
+          "defaultSize": {
+            "type": "object",
+            "properties": { "width": { "type": "number" }, "height": { "type": "number" } },
+            "additionalProperties": false
+          },
+          "activationEvents": {
+            "type": "array",
+            "items": {
+              "enum": ["onStartupFinished", "onWidgetOpen", "onCommand", "onSchedule", "onFileAssociation", "onEvent"]
+            },
+            "description": "Declarative activation events (roadmap 5.8): widgets restore their window/layout always; these decide when the plugin runtime starts."
+          }
+        }
+      }
+    },
+    "permissions": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9-]+:[a-z0-9-]+$",
+        "description": "Tauri-style identifier plugin-name:permission-name referencing a capability declaration. Granting happens through capabilities, not by listing here."
+      },
+      "default": []
+    },
+    "scopes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["permission"],
+        "properties": {
+          "permission": { "type": "string" },
+          "allow": { "type": "array", "items": { "type": "string" }, "description": "e.g. directory globs (Downloads/**), URL filters (api.github.com), quotas (100/day)." },
+          "deny": { "type": "array", "items": { "type": "string" }, "description": "Deny always wins over allow (Tauri rule); the host additionally maintains defensive default-denies (own config/credential dirs)." }
+        },
+        "additionalProperties": false
+      },
+      "default": []
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["permission"],
+        "properties": {
+          "permission": { "type": "string" },
+          "context": { "type": "string", "description": "Which plugin context (package / widget type) receives the grant." },
+          "defaultSet": { "type": "boolean", "default": false, "description": "Granted automatically at install with explicit UI notice (Tauri default.toml semantics)." }
+        },
+        "additionalProperties": false
+      },
+      "default": []
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "settingsSchemaVersion": { "type": "integer", "minimum": 1 },
+        "dataSchemaVersion": { "type": "integer", "minimum": 1 }
+      },
+      "additionalProperties": false,
+      "description": "Plugin-declared schema versions; the host runs backup -> migrate -> verify -> commit/rollback on updates (roadmap section 9 plugin schema migration clause)."
+    },
+    "signature": {
+      "type": "object",
+      "required": ["contentHash", "publisherKey"],
+      "properties": {
+        "contentHash": { "type": "string", "description": "SHA-256 of the package contents (integrity, tier 1 of the three-tier signing model)." },
+        "publisherKey": { "type": "string", "description": "Ed25519 signature over the content hash (publisher identity, tier 2). Full-trust executables additionally require Windows code signing (tier 3) and ship through Store/WinGet channels." }
+      },
+      "additionalProperties": false
+    },
+    "fallback": {
+      "type": "object",
+      "properties": {
+        "unknownElement": { "enum": ["fallback", "drop", "reject"], "default": "drop" },
+        "missingTemplate": { "enum": ["placeholder", "reject"], "default": "placeholder" }
+      },
+      "additionalProperties": false,
+      "description": "UI payload degradation policy per roadmap 13.5 layer split: manifest strict / RPC envelope lenient / payload versioned-strict with per-element fallback."
+    }
+  }
+}

--- a/tests/DeskBox.Tests/PluginSchemaContractTests.cs
+++ b/tests/DeskBox.Tests/PluginSchemaContractTests.cs
@@ -1,0 +1,73 @@
+using System.Text.Json;
+
+namespace DeskBox.Tests;
+
+/// <summary>
+/// Light pin for the plugin manifest schema v0 draft (roadmap stage 2.5).
+/// Deliberately pins existence and vocabulary only - the draft will iterate
+/// with the runtime spike, so field-by-field freezing is explicitly avoided
+/// (see plugin-schema-v0-notes.md).
+/// </summary>
+public sealed class PluginSchemaContractTests
+{
+    [Fact]
+    public void SchemaV0_ExistsAndParses()
+    {
+        string schemaPath = TestPaths.FromRepository(
+            "docs/architecture/plugin-schema-v0.json");
+        Assert.True(File.Exists(schemaPath), "plugin-schema-v0.json is missing.");
+
+        using JsonDocument schema = JsonDocument.Parse(File.ReadAllText(schemaPath));
+        JsonElement root = schema.RootElement;
+
+        Assert.Equal(
+            0,
+            root.GetProperty("properties").GetProperty("schemaVersion")
+                .GetProperty("const").GetInt32());
+    }
+
+    [Fact]
+    public void SchemaV0_CategoryVocabulary_MatchesRuntimeMatrix()
+    {
+        using JsonDocument schema = JsonDocument.Parse(File.ReadAllText(
+            TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json")));
+        JsonElement category = schema.RootElement.GetProperty("properties")
+            .GetProperty("category").GetProperty("enum");
+
+        string[] categories = category.EnumerateArray()
+            .Select(value => value.GetString()!)
+            .Order()
+            .ToArray();
+        Assert.Equal(["out-of-proc", "resource-pack", "wasm"], categories);
+    }
+
+    [Fact]
+    public void SchemaV0_TemplateVocabulary_MatchesSixTemplateDecision()
+    {
+        using JsonDocument schema = JsonDocument.Parse(File.ReadAllText(
+            TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json")));
+        // Walk to widgets[].items.properties.template.enum
+        JsonElement template = schema.RootElement.GetProperty("properties")
+            .GetProperty("widgets").GetProperty("items")
+            .GetProperty("properties").GetProperty("template")
+            .GetProperty("enum");
+
+        string[] templates = template.EnumerateArray()
+            .Select(value => value.GetString()!)
+            .Order()
+            .ToArray();
+        Assert.Equal(
+            ["action-list", "gallery", "list", "metric", "simple-form", "status"],
+            templates);
+    }
+
+    [Fact]
+    public void SchemaV0_Notes_ExistAndReferenceChannelTrichotomy()
+    {
+        string notes = File.ReadAllText(TestPaths.FromRepository(
+            "docs/architecture/plugin-schema-v0-notes.md"));
+        Assert.Contains("Capability Call", notes, StringComparison.Ordinal);
+        Assert.Contains("Lifecycle/Event", notes, StringComparison.Ordinal);
+        Assert.Contains("任意宿主函数 invoke", notes, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary

First deliverable of batch D per the construction checklist: the shared target that the three-way runtime spike, the plugin CLI validator and the store specification all depend on.

- `docs/architecture/plugin-schema-v0.json` - manifest vocabulary for every already-decided boundary (category/runtime matrix, version double-gate, six templates, payload fallback, Tauri-style permissions/scopes/capabilities, activation events, three-level ids, two-tier signature, plugin data schema versions).
- `docs/architecture/plugin-schema-v0-notes.md` - maps each field to its roadmap decision; lists what v0 deliberately does not freeze.
- `PluginSchemaContractTests` - light pins (existence + vocabulary), no field-by-field freezing.

## Validation

- Full suite 3387/3387 green on x64 (4 new tests). Zero product code, zero audit impact.