### PR TITLE
Extract MusicSettingsSection UserControl (stage 2, first of four)

### DIFF
--- a/scripts/update-settings-search-catalog.ps1
+++ b/scripts/update-settings-search-catalog.ps1
@@ -26,9 +26,13 @@ function Get-SearchEntries([System.Xml.Linq.XElement]$Element, [string]$SectionT
         }
     }
 
-    if ($Element.Name.NamespaceName -eq $sectionNamespace) {
-        $sectionDocument = [System.Xml.Linq.XDocument]::Load(
-            (Join-Path $viewsRoot "SettingsSections/$typeName.xaml"))
+    # Section references expand by type name: the section file lives in
+    # SettingsSections regardless of the namespace its code-behind declares
+    # (MusicSettingsSection uses DeskBox.Controls.WidgetContents per the
+    # pluginization roadmap 16.4 decision).
+    $sectionFilePath = Join-Path $viewsRoot "SettingsSections/$typeName.xaml"
+    if (Test-Path -LiteralPath $sectionFilePath) {
+        $sectionDocument = [System.Xml.Linq.XDocument]::Load($sectionFilePath)
         Get-SearchEntries $sectionDocument.Root $SectionTag
     }
     foreach ($child in $Element.Elements()) {

--- a/src/DeskBox/Views/SettingsSections/MusicSettingsSection.xaml
+++ b/src/DeskBox/Views/SettingsSections/MusicSettingsSection.xaml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="DeskBox.Controls.WidgetContents.MusicSettingsSection"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:DeskBox.Controls"
+    xmlns:svc="using:DeskBox.Services"
+    xmlns:toolkit="using:CommunityToolkit.WinUI.Controls">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="ms-appx:///Styles/SettingsOverviewResources.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <StackPanel
+        Style="{StaticResource SectionPanelStyle}">
+        <StackPanel Margin="0,8,0,0" Spacing="4">
+            <toolkit:SettingsCard
+                HorizontalContentAlignment="Right"
+                svc:Localized.DescriptionKey="Settings.Music.DisplayMode.Description"
+                svc:Localized.HeaderKey="Settings.Music.DisplayMode.Title">
+                <toolkit:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE8B9;" />
+                </toolkit:SettingsCard.HeaderIcon>
+                <ComboBox
+                    MinWidth="{StaticResource SettingsControlMinWidth}"
+                    ItemsSource="{Binding AvailableMusicDisplayModeOptions}"
+                    controls:SettingsComboBox.Value="{Binding SelectedMusicDisplayMode, Mode=TwoWay}" />
+            </toolkit:SettingsCard>
+
+            <toolkit:SettingsCard
+                HorizontalContentAlignment="Right"
+                svc:Localized.DescriptionKey="Settings.Music.ArtworkBackdrop.Description"
+                svc:Localized.HeaderKey="Settings.Music.ArtworkBackdrop.Title">
+                <toolkit:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xEB9F;" />
+                </toolkit:SettingsCard.HeaderIcon>
+                <ToggleSwitch
+                    OnContent=""
+                    OffContent=""
+                    MinWidth="0"
+                    IsOn="{Binding MusicUseArtworkBackdrop, Mode=TwoWay}" />
+            </toolkit:SettingsCard>
+
+            <toolkit:SettingsCard
+                HorizontalContentAlignment="Right"
+                svc:Localized.DescriptionKey="Settings.Music.CoverHoverMotion.Description"
+                svc:Localized.HeaderKey="Settings.Music.CoverHoverMotion.Title">
+                <toolkit:SettingsCard.HeaderIcon>
+                    <FontIcon Glyph="&#xE7F8;" />
+                </toolkit:SettingsCard.HeaderIcon>
+                <ToggleSwitch
+                    OnContent=""
+                    OffContent=""
+                    MinWidth="0"
+                    IsOn="{Binding MusicEnableCoverHoverMotion, Mode=TwoWay}" />
+            </toolkit:SettingsCard>
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/src/DeskBox/Views/SettingsSections/MusicSettingsSection.xaml.cs
+++ b/src/DeskBox/Views/SettingsSections/MusicSettingsSection.xaml.cs
@@ -1,0 +1,19 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace DeskBox.Controls.WidgetContents;
+
+// Extracted verbatim from the SettingsWindow.xaml inline MusicSettingsSection
+// template (pluginization roadmap stage 2, first of the four inline-template
+// extractions; Music is the per-kind store pilot). Bindings deliberately stay
+// {Binding} against the inherited SettingsViewModel DataContext - switching to
+// x:Bind would change the frozen bindable-property inventory. The namespace is
+// DeskBox.Controls.WidgetContents per the roadmap 16.4 decision (feature
+// namespace, not a host Views namespace); the file stays in
+// Views/SettingsSections so the search-catalog generator keeps finding it.
+public sealed partial class MusicSettingsSection : UserControl
+{
+    public MusicSettingsSection()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DeskBox/Views/SettingsWindow.xaml
+++ b/src/DeskBox/Views/SettingsWindow.xaml
@@ -6,6 +6,7 @@
     xmlns:media="using:Microsoft.UI.Xaml.Media.Imaging"
     xmlns:controls="using:DeskBox.Controls"
     xmlns:sections="using:DeskBox.Views.SettingsSections"
+    xmlns:contents="using:DeskBox.Controls.WidgetContents"
     xmlns:viewModels="using:DeskBox.ViewModels"
     xmlns:svc="using:DeskBox.Services"
     xmlns:toolkit="using:CommunityToolkit.WinUI.Controls"
@@ -2110,53 +2111,7 @@ svc:Localized.DescriptionKey="Settings.DefaultWidth.Description"
                 </StackPanel>
                     </DataTemplate>
                     <DataTemplate x:Key="MusicSettingsSectionTemplate" x:DataType="viewModels:SettingsViewModel">
-                        <StackPanel
-                    x:Name="MusicSettingsSection"
-                    Visibility="Collapsed"
-                    Style="{StaticResource SectionPanelStyle}">
-                    <StackPanel Margin="0,8,0,0" Spacing="4">
-                        <toolkit:SettingsCard
-                            HorizontalContentAlignment="Right"
-                            svc:Localized.DescriptionKey="Settings.Music.DisplayMode.Description"
-                            svc:Localized.HeaderKey="Settings.Music.DisplayMode.Title">
-                            <toolkit:SettingsCard.HeaderIcon>
-                                <FontIcon Glyph="&#xE8B9;" />
-                            </toolkit:SettingsCard.HeaderIcon>
-                            <ComboBox
-                                MinWidth="{StaticResource SettingsControlMinWidth}"
-                                ItemsSource="{Binding AvailableMusicDisplayModeOptions}"
-                                controls:SettingsComboBox.Value="{Binding SelectedMusicDisplayMode, Mode=TwoWay}" />
-                        </toolkit:SettingsCard>
-
-                        <toolkit:SettingsCard
-                            HorizontalContentAlignment="Right"
-                            svc:Localized.DescriptionKey="Settings.Music.ArtworkBackdrop.Description"
-                            svc:Localized.HeaderKey="Settings.Music.ArtworkBackdrop.Title">
-                            <toolkit:SettingsCard.HeaderIcon>
-                                <FontIcon Glyph="&#xEB9F;" />
-                            </toolkit:SettingsCard.HeaderIcon>
-                            <ToggleSwitch
-                                OnContent=""
-                                OffContent=""
-                                MinWidth="0"
-                                IsOn="{Binding MusicUseArtworkBackdrop, Mode=TwoWay}" />
-                        </toolkit:SettingsCard>
-
-                        <toolkit:SettingsCard
-                            HorizontalContentAlignment="Right"
-                            svc:Localized.DescriptionKey="Settings.Music.CoverHoverMotion.Description"
-                            svc:Localized.HeaderKey="Settings.Music.CoverHoverMotion.Title">
-                            <toolkit:SettingsCard.HeaderIcon>
-                                <FontIcon Glyph="&#xE7F8;" />
-                            </toolkit:SettingsCard.HeaderIcon>
-                            <ToggleSwitch
-                                OnContent=""
-                                OffContent=""
-                                MinWidth="0"
-                                IsOn="{Binding MusicEnableCoverHoverMotion, Mode=TwoWay}" />
-                        </toolkit:SettingsCard>
-                    </StackPanel>
-                </StackPanel>
+                        <contents:MusicSettingsSection x:Name="MusicSettingsSection" Visibility="Collapsed" />
                     </DataTemplate>
                     <DataTemplate x:Key="WeatherSettingsSectionTemplate" x:DataType="viewModels:SettingsViewModel">
                         <StackPanel

--- a/tests/DeskBox.Tests/ArchitectureContractTests.cs
+++ b/tests/DeskBox.Tests/ArchitectureContractTests.cs
@@ -69,7 +69,7 @@ public sealed class ArchitectureContractTests
         {
             ["Weather"] = 16,
             ["Todo"] = 36,
-            ["Music"] = 13,
+            ["Music"] = 14,
             ["Glance"] = 19,
             ["Search"] = 20,
             ["QuickCapture"] = 22,

--- a/tests/DeskBox.Tests/SettingsDeferredSectionsTests.cs
+++ b/tests/DeskBox.Tests/SettingsDeferredSectionsTests.cs
@@ -63,9 +63,14 @@ public sealed class SettingsDeferredSectionsTests
             yield return new(tag, header,
                 (string?)element.Attribute(Services + "Localized.DescriptionKey"));
         }
-        if (element.Name.NamespaceName == "using:DeskBox.Views.SettingsSections")
+        // Section references expand by type name: the section file lives in
+        // SettingsSections regardless of the namespace its code-behind
+        // declares (MusicSettingsSection uses DeskBox.Controls.WidgetContents
+        // per the pluginization roadmap 16.4 decision).
+        string sectionFilePath = Path.Combine(viewsRoot, "SettingsSections", name + ".xaml");
+        if (File.Exists(sectionFilePath))
         {
-            XElement nested = XDocument.Load(Path.Combine(viewsRoot, "SettingsSections", name + ".xaml")).Root!;
+            XElement nested = XDocument.Load(sectionFilePath).Root!;
             foreach (var entry in ReadEntries(nested, tag, viewsRoot))
             {
                 yield return entry;


### PR DESCRIPTION
## Summary

First of the four inline settings-template extractions; Music is the per-kind store pilot.

- Three Music cards moved verbatim from the SettingsWindow inline template into `Views/SettingsSections/MusicSettingsSection.xaml`, hosted exactly like Glance/Search (DataTemplate wrapper keeps DataType and the x:Name slice marker; {Binding} preserved so the frozen 327 inventory is untouched).
- Code-behind declares `DeskBox.Controls.WidgetContents` (roadmap 16.4 namespace decision) - feature namespace, no new grandfather entry.
- Search-catalog generator + parity test now expand section references by type name (file existence in SettingsSections) instead of matching the host Views XML namespace - the old match would have silently dropped the Music entries.
- ArchitectureContractTests Music inventory 13 -> 14 (deliberate).

## Validation

- Full suite 3383/3383 green on x64. Canonical Debug rebuilt and restarted.