### PR TITLE
Music per-kind settings store + schema v10 (stage 2 pilot, audit profile 61)

### DIFF
--- a/scripts/publish-aot-audit.ps1
+++ b/scripts/publish-aot-audit.ps1
@@ -20,7 +20,7 @@ $auditStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 # scripts/start-aot-preview.ps1 and the lowercase requiredAuditProfileVersion
 # chain in the run-aot-*-smoke.ps1 runners, and update every contract test
 # pinning "= <previous version>" (grep: auditProfileVersion).
-$auditProfileVersion = 60
+$auditProfileVersion = 61
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 $project = Join-Path $repoRoot "src\DeskBox\DeskBox.csproj"
@@ -2042,7 +2042,7 @@ $stage4E5SourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage4E5ExpectedWmc1510Count = 863
+$stage4E5ExpectedWmc1510Count = 867
 $stage4E5ActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -2074,7 +2074,7 @@ $stage5AMissingDataPathPatterns = @(
     }
 )
 $stage5ARequiredLauncherPatterns = @(
-    '$RequiredAuditProfileVersion = 60',
+    '$RequiredAuditProfileVersion = 61',
     '$RequiredSummarySchemaVersion = 55',
     'Test-PathEqualOrInside',
     'Get-DirectoryStateFingerprint',
@@ -2122,7 +2122,7 @@ $stage5ASourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5AExpectedWmc1510Count = 863
+$stage5AExpectedWmc1510Count = 867
 $stage5AActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -2241,7 +2241,7 @@ $stage5B1SourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B1ExpectedWmc1510Count = 863
+$stage5B1ExpectedWmc1510Count = 867
 $stage5B1ActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -2401,7 +2401,7 @@ $stage5B2ASourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B2AExpectedWmc1510Count = 863
+$stage5B2AExpectedWmc1510Count = 867
 $stage5B2AActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -2564,7 +2564,7 @@ $stage5B2BSourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B2BExpectedWmc1510Count = 863
+$stage5B2BExpectedWmc1510Count = 867
 $stage5B2BActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -2722,7 +2722,7 @@ $stage5B3ASourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B3AExpectedWmc1510Count = 863
+$stage5B3AExpectedWmc1510Count = 867
 $stage5B3AActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -2907,7 +2907,7 @@ $stage5B3BSourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B3BExpectedWmc1510Count = 863
+$stage5B3BExpectedWmc1510Count = 867
 $stage5B3BActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -3156,7 +3156,7 @@ $stage5B3CSourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B3CExpectedWmc1510Count = 863
+$stage5B3CExpectedWmc1510Count = 867
 $stage5B3CActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -3426,7 +3426,7 @@ $stage5B4ASourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4AExpectedWmc1510Count = 863
+$stage5B4AExpectedWmc1510Count = 867
 $stage5B4AActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -3851,7 +3851,7 @@ $stage5B4B1SourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4B1ExpectedWmc1510Count = 863
+$stage5B4B1ExpectedWmc1510Count = 867
 $stage5B4B1ActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -4030,7 +4030,7 @@ $stage5B4B2ASourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4B2AExpectedWmc1510Count = 863
+$stage5B4B2AExpectedWmc1510Count = 867
 $stage5B4B2AActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -4220,7 +4220,7 @@ $stage5B4B2B1SourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4B2B1ExpectedWmc1510Count = 863
+$stage5B4B2B1ExpectedWmc1510Count = 867
 $stage5B4B2B1ActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -4444,7 +4444,7 @@ $stage5B4B2B2ASourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4B2B2AExpectedWmc1510Count = 863
+$stage5B4B2B2AExpectedWmc1510Count = 867
 $stage5B4B2B2AActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -4668,7 +4668,7 @@ $stage5B4B2B2B1SourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4B2B2B1ExpectedWmc1510Count = 863
+$stage5B4B2B2B1ExpectedWmc1510Count = 867
 $stage5B4B2B2B1ActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -4926,7 +4926,7 @@ $stage5B4B2B2B2SourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4B2B2B2ExpectedWmc1510Count = 863
+$stage5B4B2B2B2ExpectedWmc1510Count = 867
 $stage5B4B2B2B2ActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -5171,7 +5171,7 @@ $stage5B4B2C1SourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4B2C1ExpectedWmc1510Count = 863
+$stage5B4B2C1ExpectedWmc1510Count = 867
 $stage5B4B2C1ActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -5361,7 +5361,7 @@ $stage5B4B2C2ASourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4B2C2AExpectedWmc1510Count = 863
+$stage5B4B2C2AExpectedWmc1510Count = 867
 $stage5B4B2C2AActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -5613,7 +5613,7 @@ $stage5B4B2C2BSourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4B2C2BExpectedWmc1510Count = 863
+$stage5B4B2C2BExpectedWmc1510Count = 867
 $stage5B4B2C2BActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -5868,7 +5868,7 @@ $stage5B4C1ASourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4C1AExpectedWmc1510Count = 863
+$stage5B4C1AExpectedWmc1510Count = 867
 $stage5B4C1AActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -6149,7 +6149,7 @@ $stage5B4C1B1SourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4C1B1ExpectedWmc1510Count = 863
+$stage5B4C1B1ExpectedWmc1510Count = 867
 $stage5B4C1B1ActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -6399,7 +6399,7 @@ $stage5B4C1B2ASourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4C1B2AExpectedWmc1510Count = 863
+$stage5B4C1B2AExpectedWmc1510Count = 867
 $stage5B4C1B2AActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -6639,7 +6639,7 @@ $stage5B4C1B2BSourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4C1B2BExpectedWmc1510Count = 863
+$stage5B4C1B2BExpectedWmc1510Count = 867
 $stage5B4C1B2BActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -6873,7 +6873,7 @@ $stage5B4C1C1SourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4C1C1ExpectedWmc1510Count = 863
+$stage5B4C1C1ExpectedWmc1510Count = 867
 $stage5B4C1C1ActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -7141,7 +7141,7 @@ $stage5B4C1C2ASourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4C1C2AExpectedWmc1510Count = 863
+$stage5B4C1C2AExpectedWmc1510Count = 867
 $stage5B4C1C2AActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -7312,7 +7312,7 @@ $stage5B4C2ASourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4C2AExpectedWmc1510Count = 863
+$stage5B4C2AExpectedWmc1510Count = 867
 $stage5B4C2AActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -7484,7 +7484,7 @@ $stage5B4C3ASourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4C3AExpectedWmc1510Count = 863
+$stage5B4C3AExpectedWmc1510Count = 867
 $stage5B4C3AActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -7664,7 +7664,7 @@ $stage5B4C3B1SourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4C3B1ExpectedWmc1510Count = 863
+$stage5B4C3B1ExpectedWmc1510Count = 867
 $stage5B4C3B1ActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -7848,7 +7848,7 @@ $stage5B4C3B2ASourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4C3B2AExpectedWmc1510Count = 863
+$stage5B4C3B2AExpectedWmc1510Count = 867
 $stage5B4C3B2AActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -7966,7 +7966,7 @@ $stage5B4C3B2B1RunnerSource =
 $stage5B4C3B2B1RequiredSmokeScriptPatterns = @(
     'TodoNotificationEnvelopeForwarding',
     'run-aot-todo-notification-forwarding-smoke.ps1',
-    '$requiredAuditProfileVersion = 60',
+    '$requiredAuditProfileVersion = 61',
     '$requiredSummarySchemaVersion = 55',
     '-NoStop',
     '-ExpectExistingInstance',
@@ -8040,7 +8040,7 @@ $stage5B4C3B2B1SourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4C3B2B1ExpectedWmc1510Count = 863
+$stage5B4C3B2B1ExpectedWmc1510Count = 867
 $stage5B4C3B2B1ActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -8136,7 +8136,7 @@ $stage5B4C3B2B2ARunnerSource =
 $stage5B4C3B2B2ARequiredSmokeScriptPatterns = @(
     'TodoNotificationSurfaceRouting',
     'run-aot-todo-notification-surface-smoke.ps1',
-    '$requiredAuditProfileVersion = 60',
+    '$requiredAuditProfileVersion = 61',
     '$requiredSummarySchemaVersion = 55',
     '-AllowEarlyExit',
     '-StartupWaitSeconds 1',
@@ -8201,7 +8201,7 @@ $stage5B4C3B2B2ASourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4C3B2B2AExpectedWmc1510Count = 863
+$stage5B4C3B2B2AExpectedWmc1510Count = 867
 $stage5B4C3B2B2AActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count
@@ -8306,7 +8306,7 @@ $stage5B4C3B2B2BRunnerSource =
     $stage5B4C3B2B2BSources[$stage5B4C3B2B2BSourceFiles[10]]
 $stage5B4C3B2B2BRequiredSmokeScriptPatterns = @(
     'RealWindowsNotificationUserClick',
-    '$requiredAuditProfileVersion = 60',
+    '$requiredAuditProfileVersion = 61',
     '$requiredSummarySchemaVersion = 55',
     '[switch]$IncludeColdStart',
     '-AllowEarlyExit',
@@ -8382,7 +8382,7 @@ $stage5B4C3B2B2BSourceWarningMessages = @(
         ForEach-Object { $_.Trim() } |
         Sort-Object -Unique
 )
-$stage5B4C3B2B2BExpectedWmc1510Count = 863
+$stage5B4C3B2B2BExpectedWmc1510Count = 867
 $stage5B4C3B2B2BActualWmc1510Count = @(
     $warningMatches | Where-Object { $_ -ieq "WMC1510" }
 ).Count

--- a/scripts/run-aot-hotkey-smoke.ps1
+++ b/scripts/run-aot-hotkey-smoke.ps1
@@ -526,7 +526,7 @@ try {
         generatedAtUtc = [DateTime]::UtcNow.ToString("O")
         runId = $runId
         scenario = $scenario
-        auditProfileVersion = 60
+        auditProfileVersion = 61
         auditSummarySchemaVersion = 51
         dataRoot = $DataRoot
         previewRootCleaned = $previewRootCleaned

--- a/scripts/run-aot-todo-notification-activation-smoke.ps1
+++ b/scripts/run-aot-todo-notification-activation-smoke.ps1
@@ -552,7 +552,7 @@ try {
         generatedAtUtc = [DateTime]::UtcNow.ToString("O")
         runId = $runId
         scenario = $scenario
-        auditProfileVersion = 60
+        auditProfileVersion = 61
         auditSummarySchemaVersion = 55
         dataRoot = $DataRoot
         previewRootCleaned = $previewRootCleaned

--- a/scripts/run-aot-todo-notification-forwarding-smoke.ps1
+++ b/scripts/run-aot-todo-notification-forwarding-smoke.ps1
@@ -11,7 +11,7 @@ param(
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-$requiredAuditProfileVersion = 60
+$requiredAuditProfileVersion = 61
 $requiredSummarySchemaVersion = 55
 $scenario = "EnvelopeAndSingleInstance"
 $smokeEnvironmentVariable =

--- a/scripts/run-aot-todo-notification-surface-smoke.ps1
+++ b/scripts/run-aot-todo-notification-surface-smoke.ps1
@@ -14,7 +14,7 @@ Set-StrictMode -Version Latest
 $scenario = "TodoNotificationSurfaceRouting"
 $smokeEnvironmentVariable =
     "DESKBOX_AOT_TODO_NOTIFICATION_SURFACE_SMOKE"
-$requiredAuditProfileVersion = 60
+$requiredAuditProfileVersion = 61
 $requiredSummarySchemaVersion = 55
 $runId = [Guid]::NewGuid().ToString("N")
 $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))

--- a/scripts/run-aot-todo-notification-user-click-smoke.ps1
+++ b/scripts/run-aot-todo-notification-user-click-smoke.ps1
@@ -37,7 +37,7 @@ $productionDataRoot = [System.IO.Path]::GetFullPath(
     (Join-Path $env:LOCALAPPDATA "DeskBox"))
 $ownedMarkerName = ".deskbox-aot-todo-notification-user-click-owned.json"
 $ownedMarkerKind = "DeskBox.Aot.TodoNotificationUserClickSmoke.v1"
-$requiredAuditProfileVersion = 60
+$requiredAuditProfileVersion = 61
 $requiredSummarySchemaVersion = 55
 
 function Test-PathEqual {

--- a/scripts/run-aot-todo-recurrence-reminder-smoke.ps1
+++ b/scripts/run-aot-todo-recurrence-reminder-smoke.ps1
@@ -578,7 +578,7 @@ try {
         generatedAtUtc = [DateTime]::UtcNow.ToString("O")
         runId = $runId
         scenario = $scenario
-        auditProfileVersion = 60
+        auditProfileVersion = 61
         auditSummarySchemaVersion = 51
         dataRoot = $DataRoot
         previewRootCleaned = $previewRootCleaned

--- a/scripts/start-aot-preview.ps1
+++ b/scripts/start-aot-preview.ps1
@@ -17,7 +17,7 @@ param(
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
-$RequiredAuditProfileVersion = 60
+$RequiredAuditProfileVersion = 61
 $RequiredSummarySchemaVersion = 55
 $RequiredRustAbiVersion = 2
 $RequiredRustCapabilities = 511

--- a/src/DeskBox/Services/MusicSettingsStore.cs
+++ b/src/DeskBox/Services/MusicSettingsStore.cs
@@ -1,0 +1,138 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DeskBox.Services;
+
+[JsonSourceGenerationOptions(
+    GenerationMode = JsonSourceGenerationMode.Metadata,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    UseStringEnumConverter = true,
+    WriteIndented = true)]
+[JsonSerializable(
+    typeof(MusicWidgetSettings),
+    TypeInfoPropertyName = "Settings")]
+internal sealed partial class MusicSettingsJsonContext : JsonSerializerContext
+{
+}
+
+/// <summary>
+/// Per-kind settings store for the Music feature (pluginization roadmap
+/// stage 2 pilot). Owns data/music/settings.json, deliberately separate from
+/// AppSettings like GlanceWidgetStore, so feature state can later be
+/// classified for sync/backup independently and moved out of the global
+/// settings file. The three legacy AppSettings fields (MusicUseArtworkBackdrop,
+/// MusicEnableCoverHoverMotion, MusicDisplayMode) are copied here by
+/// Migration_9_To_10 and remain as an inert compatibility source until the
+/// N+2 cleanup release removes them.
+/// </summary>
+public sealed class MusicSettingsStore
+{
+    private readonly string _storePath;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private MusicWidgetSettings? _cached;
+
+    public MusicSettingsStore()
+        : this(Path.Combine(
+            DeskBoxDataPathService.Current.DataDirectory,
+            "music"))
+    {
+    }
+
+    internal MusicSettingsStore(string musicDataDirectory)
+    {
+        Directory.CreateDirectory(musicDataDirectory);
+        _storePath = Path.Combine(musicDataDirectory, "settings.json");
+    }
+
+    internal string StorePath => _storePath;
+
+    /// <summary>
+    /// Loads settings for synchronous callers: the settings view model
+    /// initializes music properties during construction, before async
+    /// pipelines are available. File IO on a tiny settings file in
+    /// first-use construction mirrors what SettingsService itself does.
+    /// </summary>
+    public MusicWidgetSettings Load()
+    {
+        MusicWidgetSettings settings = LoadAsync().GetAwaiter().GetResult();
+        return settings;
+    }
+
+    public async Task<MusicWidgetSettings> LoadAsync()
+    {
+        await _gate.WaitAsync();
+        try
+        {
+            _cached ??= await ResilientJsonStore.LoadAsync(
+                _storePath,
+                json => Normalize(JsonSerializer.Deserialize(
+                    json,
+                    MusicSettingsJsonContext.Default.Settings)),
+                () => new MusicWidgetSettings(),
+                nameof(MusicSettingsStore));
+            return Clone(_cached);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task SaveAsync(MusicWidgetSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        await _gate.WaitAsync();
+        try
+        {
+            _cached = Normalize(Clone(settings));
+            await PersistLockedAsync();
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task PersistLockedAsync()
+    {
+        await ResilientJsonStore.SaveAsync(
+            _storePath,
+            JsonSerializer.Serialize(_cached!, MusicSettingsJsonContext.Default.Settings));
+    }
+
+    internal static MusicWidgetSettings Normalize(MusicWidgetSettings? settings)
+    {
+        settings ??= new MusicWidgetSettings();
+        if (settings.SchemaVersion < 1)
+        {
+            settings.SchemaVersion = 1;
+        }
+
+        settings.DisplayMode = SettingsService.NormalizeMusicDisplayMode(settings.DisplayMode);
+        return settings;
+    }
+
+    private static MusicWidgetSettings Clone(MusicWidgetSettings settings) => new()
+    {
+        SchemaVersion = settings.SchemaVersion,
+        UseArtworkBackdrop = settings.UseArtworkBackdrop,
+        EnableCoverHoverMotion = settings.EnableCoverHoverMotion,
+        DisplayMode = settings.DisplayMode,
+    };
+}
+
+/// <summary>
+/// Music feature settings (the three fields migrated out of AppSettings by
+/// schema version 10). Kept inside the store file so the feature inventory
+/// grows by exactly one file.
+/// </summary>
+public sealed class MusicWidgetSettings
+{
+    public int SchemaVersion { get; set; } = 1;
+
+    public bool UseArtworkBackdrop { get; set; } = true;
+
+    public bool EnableCoverHoverMotion { get; set; } = true;
+
+    public string DisplayMode { get; set; } = SettingsService.MusicDisplayModeAuto;
+}

--- a/src/DeskBox/Services/SettingsMigrationService.cs
+++ b/src/DeskBox/Services/SettingsMigrationService.cs
@@ -20,7 +20,7 @@ public interface ISettingsMigration
 public sealed class SettingsMigrationPipeline
 {
     /// <summary>The current schema version that the application expects.</summary>
-    public const int CurrentSchemaVersion = 9;
+    public const int CurrentSchemaVersion = 10;
 
     private readonly List<ISettingsMigration> _migrations = [];
 
@@ -36,6 +36,7 @@ public sealed class SettingsMigrationPipeline
         _migrations.Add(new Migration_6_To_7());
         _migrations.Add(new Migration_7_To_8());
         _migrations.Add(new Migration_8_To_9());
+        _migrations.Add(new Migration_9_To_10());
     }
 
     /// <summary>
@@ -302,3 +303,38 @@ internal sealed class Migration_7_To_8 : ISettingsMigration
                 settings.TransientWindowReleaseDelaySeconds);
     }
 }
+
+/// <summary>
+/// Copies the three Music feature fields out of the global AppSettings into
+/// the per-kind MusicSettingsStore (pluginization roadmap stage 2, the
+/// per-kind store pilot). Copy-style: the AppSettings fields are left in
+/// place as an inert compatibility source until the N+2 cleanup release
+/// removes them, so a downgrade within the window keeps working. The store
+/// is created only when it does not exist yet - re-running the migration
+/// never overwrites user changes made after the first cutover.
+/// </summary>
+internal sealed class Migration_9_To_10 : ISettingsMigration
+{
+    public int FromVersion => 9;
+
+    public void Migrate(AppSettings settings) =>
+        Migrate(settings, DeskBoxDataPathService.Current.DataDirectory);
+
+    internal static void Migrate(AppSettings settings, string dataDirectory)
+    {
+        string musicDataDirectory = Path.Combine(dataDirectory, "music");
+        string storePath = Path.Combine(musicDataDirectory, "settings.json");
+        if (File.Exists(storePath))
+        {
+            return;
+        }
+
+        var store = new MusicSettingsStore(musicDataDirectory);
+        var migrated = store.Load();
+        migrated.UseArtworkBackdrop = settings.MusicUseArtworkBackdrop;
+        migrated.EnableCoverHoverMotion = settings.MusicEnableCoverHoverMotion;
+        migrated.DisplayMode = SettingsService.NormalizeMusicDisplayMode(settings.MusicDisplayMode);
+        store.SaveAsync(migrated).GetAwaiter().GetResult();
+    }
+}
+

--- a/src/DeskBox/ViewModels/SettingsViewModel.FeatureCallbacks.cs
+++ b/src/DeskBox/ViewModels/SettingsViewModel.FeatureCallbacks.cs
@@ -304,8 +304,11 @@ public partial class SettingsViewModel
             return;
         }
 
-        _settingsService.Settings.MusicUseArtworkBackdrop = value;
-        _settingsService.SaveDebounced();
+        UpdateMusicSettings(store =>
+        {
+            store.UseArtworkBackdrop = value;
+            _settingsService.Settings.MusicUseArtworkBackdrop = value;
+        });
     }
 
     partial void OnMusicEnableCoverHoverMotionChanged(bool value)
@@ -315,8 +318,31 @@ public partial class SettingsViewModel
             return;
         }
 
-        _settingsService.Settings.MusicEnableCoverHoverMotion = value;
-        _settingsService.SaveDebounced();
+        UpdateMusicSettings(store =>
+        {
+            store.EnableCoverHoverMotion = value;
+            _settingsService.Settings.MusicEnableCoverHoverMotion = value;
+        });
+    }
+
+    /// <summary>
+    /// Music writes go to the per-kind store (fire-and-forget save, matching
+    /// the debounced global-settings behavior) and mirror into the legacy
+    /// AppSettings fields, which stay as an inert compatibility source until
+    /// the N+2 cleanup release removes them (roadmap stage 2 pilot).
+    /// </summary>
+    private void UpdateMusicSettings(Action<MusicWidgetSettings> update)
+    {
+        try
+        {
+            MusicWidgetSettings settings = _musicSettingsStore.Load();
+            update(settings);
+            _ = _musicSettingsStore.SaveAsync(settings);
+        }
+        catch (Exception ex)
+        {
+            App.Log($"[SettingsViewModel] Music settings store update failed: {ex.Message}");
+        }
     }
 
     private async Task SyncTodoEnabledAsync(bool enabled)

--- a/src/DeskBox/ViewModels/SettingsViewModel.FeatureOptions.cs
+++ b/src/DeskBox/ViewModels/SettingsViewModel.FeatureOptions.cs
@@ -358,8 +358,11 @@ public partial class SettingsViewModel
                 return;
             }
 
-            _settingsService.Settings.MusicDisplayMode = normalizedValue;
-            _settingsService.SaveDebounced();
+            UpdateMusicSettings(store =>
+            {
+                store.DisplayMode = normalizedValue;
+                _settingsService.Settings.MusicDisplayMode = normalizedValue;
+            });
         }
     }
 
@@ -791,6 +794,12 @@ set => WidgetOpacity = Math.Clamp(1.0 - value / 100d, SettingsService.MinWidgetO
                     _settingsService.Settings.MusicUseArtworkBackdrop = true;
                     _settingsService.Settings.MusicEnableCoverHoverMotion = true;
                     _settingsService.Settings.MusicDisplayMode = SettingsService.MusicDisplayModeAuto;
+                    UpdateMusicSettings(store =>
+                    {
+                        store.UseArtworkBackdrop = true;
+                        store.EnableCoverHoverMotion = true;
+                        store.DisplayMode = SettingsService.MusicDisplayModeAuto;
+                    });
                     break;
                 case WidgetKind.Weather:
                     WeatherAutoLocation = true;

--- a/src/DeskBox/ViewModels/SettingsViewModel.SettingsSync.cs
+++ b/src/DeskBox/ViewModels/SettingsViewModel.SettingsSync.cs
@@ -192,9 +192,10 @@ public partial class SettingsViewModel
             SelectedTodoReminderOffsetMinutes = SettingsService.NormalizeTodoReminderOffsetMinutes(
                 settings.TodoDefaultReminderOffsetMinutes);
 
-            MusicUseArtworkBackdrop = settings.MusicUseArtworkBackdrop;
-            MusicEnableCoverHoverMotion = settings.MusicEnableCoverHoverMotion;
-            SelectedMusicDisplayMode = SettingsService.NormalizeMusicDisplayMode(settings.MusicDisplayMode);
+            var musicSettingsSnapshot = _musicSettingsStore.Load();
+            MusicUseArtworkBackdrop = musicSettingsSnapshot.UseArtworkBackdrop;
+            MusicEnableCoverHoverMotion = musicSettingsSnapshot.EnableCoverHoverMotion;
+            SelectedMusicDisplayMode = SettingsService.NormalizeMusicDisplayMode(musicSettingsSnapshot.DisplayMode);
 
             WeatherAutoLocation = settings.WeatherAutoLocation;
             WeatherCityName = settings.WeatherCityName;

--- a/src/DeskBox/ViewModels/SettingsViewModel.cs
+++ b/src/DeskBox/ViewModels/SettingsViewModel.cs
@@ -63,6 +63,10 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     private readonly LocalizationService _localizationService;
     private readonly WidgetContentFactory _widgetContentFactory;
     private readonly IAppUpdateService _appUpdateService;
+    // Per-kind settings store for the Music pilot (roadmap stage 2); the
+    // legacy AppSettings fields are an inert compatibility source after the
+    // version-10 copy migration.
+    private readonly MusicSettingsStore _musicSettingsStore = new();
     private readonly CancellationTokenSource _lifetimeCts = new();
     private bool _isDisposed;
     private CancellationTokenSource? _updateOperationCts;
@@ -428,9 +432,10 @@ private string[]? _cachedWeatherRefreshIntervalDisplayNames;
         TodoUseWideDetailPane = _selectedTodoLayoutMode != SettingsService.TodoLayoutModeSinglePane;
         TodoAutoSelectFirstInWideLayout = settings.TodoAutoSelectFirstInWideLayout;
         TodoReminderEnabled = settings.TodoReminderEnabled;
-        MusicUseArtworkBackdrop = settings.MusicUseArtworkBackdrop;
-        MusicEnableCoverHoverMotion = settings.MusicEnableCoverHoverMotion;
-        _selectedMusicDisplayMode = SettingsService.NormalizeMusicDisplayMode(settings.MusicDisplayMode);
+        var musicSettings = _musicSettingsStore.Load();
+        MusicUseArtworkBackdrop = musicSettings.UseArtworkBackdrop;
+        MusicEnableCoverHoverMotion = musicSettings.EnableCoverHoverMotion;
+        _selectedMusicDisplayMode = SettingsService.NormalizeMusicDisplayMode(musicSettings.DisplayMode);
 WeatherAutoLocation = settings.WeatherAutoLocation;
 WeatherCityName = settings.WeatherCityName;
 _weatherCitySearchText = settings.WeatherCityName;

--- a/tests/DeskBox.Tests/AotPublishContractTests.cs
+++ b/tests/DeskBox.Tests/AotPublishContractTests.cs
@@ -519,7 +519,7 @@ public sealed class AotPublishContractTests
         Assert.Contains("exactly one root-level deskbox_native.dll", script, StringComparison.Ordinal);
         Assert.DoesNotContain("deskbox_search_core.dll", script, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", script, StringComparison.Ordinal);
-        Assert.Contains("auditProfileVersion = 60", script, StringComparison.Ordinal);
+        Assert.Contains("auditProfileVersion = 61", script, StringComparison.Ordinal);
         Assert.Contains("warningCodeCounts", script, StringComparison.Ordinal);
         Assert.Contains("targetedWarningCounts", script, StringComparison.Ordinal);
         Assert.Contains("workingTreeFingerprintBefore", script, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage4D1AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage4D1AContractTests.cs
@@ -59,7 +59,7 @@ public sealed class AotStage4D1AContractTests
     {
         string script = ReadRepositoryFile("scripts/publish-aot-audit.ps1");
 
-        Assert.Contains("$auditProfileVersion = 60", script, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", script, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", script, StringComparison.Ordinal);
         Assert.Contains("stage4D1AWarningMessages", script, StringComparison.Ordinal);
         Assert.Contains(

--- a/tests/DeskBox.Tests/AotStage4D1BContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage4D1BContractTests.cs
@@ -77,7 +77,7 @@ public sealed class AotStage4D1BContractTests
     {
         string script = ReadRepositoryFile("scripts/publish-aot-audit.ps1");
 
-        Assert.Contains("$auditProfileVersion = 60", script, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", script, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", script, StringComparison.Ordinal);
         Assert.Contains("stage4D1BWarningMessages", script, StringComparison.Ordinal);
         Assert.Contains("QuickCaptureSurfaceContent.xaml.cs", script, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage4D2ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage4D2ContractTests.cs
@@ -39,7 +39,7 @@ public sealed class AotStage4D2ContractTests
     {
         string script = ReadRepositoryFile("scripts/publish-aot-audit.ps1");
 
-        Assert.Contains("$auditProfileVersion = 60", script, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", script, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", script, StringComparison.Ordinal);
         Assert.Contains("stage4D2RemovedSourceFiles", script, StringComparison.Ordinal);
         Assert.Contains("stage4D2UnexpectedExistingSourceFiles", script, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage4D3AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage4D3AContractTests.cs
@@ -50,7 +50,7 @@ public sealed class AotStage4D3AContractTests
     {
         string script = ReadRepositoryFile("scripts/publish-aot-audit.ps1");
 
-        Assert.Contains("$auditProfileVersion = 60", script, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", script, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", script, StringComparison.Ordinal);
         Assert.Contains("stage4D3ALegacyRcwPatterns", script, StringComparison.Ordinal);
         Assert.Contains("stage4D3ALegacyRcwSourceMatches", script, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage4D3BContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage4D3BContractTests.cs
@@ -85,7 +85,7 @@ public sealed class AotStage4D3BContractTests
     {
         string script = ReadRepositoryFile("scripts/publish-aot-audit.ps1");
 
-        Assert.Contains("$auditProfileVersion = 60", script, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", script, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", script, StringComparison.Ordinal);
         Assert.Contains("stage4D3BSourceFiles", script, StringComparison.Ordinal);
         Assert.Contains("stage4D3BLegacyRegistrationPatterns", script, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage4D4AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage4D4AContractTests.cs
@@ -124,7 +124,7 @@ public sealed class AotStage4D4AContractTests
         Assert.Contains("deskbox_explorer_shell_launch_v1", buildScript, StringComparison.Ordinal);
         Assert.Contains("Rust native Stage 5B-4C1B2B capability mismatch: expected 511", buildScript, StringComparison.Ordinal);
 
-        Assert.Contains("$auditProfileVersion = 60", auditScript, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", auditScript, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", auditScript, StringComparison.Ordinal);
         Assert.Contains("stage4D4AWarningMessages", auditScript, StringComparison.Ordinal);
         Assert.Contains("ExplorerShellLaunchService.cs", auditScript, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage4D4BContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage4D4BContractTests.cs
@@ -140,7 +140,7 @@ public sealed class AotStage4D4BContractTests
         Assert.Contains("deskbox_quick_access_v1", buildScript, StringComparison.Ordinal);
         Assert.Contains("Rust native Stage 5B-4C1B2B capability mismatch: expected 511", buildScript, StringComparison.Ordinal);
 
-        Assert.Contains("$auditProfileVersion = 60", auditScript, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", auditScript, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", auditScript, StringComparison.Ordinal);
         Assert.Contains("stage4D4BWarningMessages", auditScript, StringComparison.Ordinal);
         Assert.Contains("QuickAccessNativeBackend.cs", auditScript, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage4D5ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage4D5ContractTests.cs
@@ -78,7 +78,7 @@ public sealed class AotStage4D5ContractTests
     {
         string audit = ReadRepositoryFile("scripts/publish-aot-audit.ps1");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage4D5SourceFiles", audit, StringComparison.Ordinal);
         Assert.Contains("stage4D5LegacyReflectionPatterns", audit, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage4E0ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage4E0ContractTests.cs
@@ -41,7 +41,7 @@ public sealed class AotStage4E0ContractTests
     {
         string audit = ReadRepositoryFile("scripts/publish-aot-audit.ps1");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage4E0SourceFiles", audit, StringComparison.Ordinal);
         Assert.Contains("stage4E0LegacyOneWaySourceMatches", audit, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage4E1ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage4E1ContractTests.cs
@@ -88,7 +88,7 @@ public sealed class AotStage4E1ContractTests
     {
         string audit = ReadRepositoryFile("scripts/publish-aot-audit.ps1");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage4E1SourceFiles", audit, StringComparison.Ordinal);
         Assert.Contains("stage4E1LegacyBindingSourceMatches", audit, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage4E2ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage4E2ContractTests.cs
@@ -91,7 +91,7 @@ public sealed class AotStage4E2ContractTests
     {
         string audit = ReadRepositoryFile("scripts/publish-aot-audit.ps1");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage4E2SourceFiles", audit, StringComparison.Ordinal);
         Assert.Contains("stage4E2LegacyBindingSourceMatches", audit, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage4E3ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage4E3ContractTests.cs
@@ -137,7 +137,7 @@ public sealed class AotStage4E3ContractTests
     {
         string audit = ReadRepositoryFile("scripts/publish-aot-audit.ps1");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage4E3SourceFiles", audit, StringComparison.Ordinal);
         Assert.Contains("stage4E3LegacyBindingSourceMatches", audit, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage4E4ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage4E4ContractTests.cs
@@ -149,7 +149,7 @@ public sealed class AotStage4E4ContractTests
     {
         string audit = ReadRepositoryFile("scripts/publish-aot-audit.ps1");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage4E4SourceFiles", audit, StringComparison.Ordinal);
         Assert.Contains("stage4E4LegacyBindingSourceMatches", audit, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage4E5ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage4E5ContractTests.cs
@@ -163,7 +163,7 @@ public sealed class AotStage4E5ContractTests
     {
         string audit = ReadRepositoryFile("scripts/publish-aot-audit.ps1");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage4E5SourceFiles", audit, StringComparison.Ordinal);
         Assert.Contains("stage4E5LegacyBindingSourceMatches", audit, StringComparison.Ordinal);
@@ -187,7 +187,7 @@ public sealed class AotStage4E5ContractTests
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
         Assert.Contains("$stage4E4MaximumWmc1510Count = 870", audit, StringComparison.Ordinal);
-        Assert.Contains("$stage4E5ExpectedWmc1510Count = 863", audit, StringComparison.Ordinal);
+        Assert.Contains("$stage4E5ExpectedWmc1510Count = 867", audit, StringComparison.Ordinal);
         Assert.Contains("Stage 4E-5 WMC1510 count changed", audit, StringComparison.Ordinal);
         Assert.Contains("Native AOT stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("eight compiled search-result row bindings", project, StringComparison.OrdinalIgnoreCase);

--- a/tests/DeskBox.Tests/AotStage5AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5AContractTests.cs
@@ -34,7 +34,7 @@ public sealed class AotStage5AContractTests
     {
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
 
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("sourceStableDuringAudit", launcher, StringComparison.Ordinal);
         Assert.Contains("runtimeIdentifier", launcher, StringComparison.Ordinal);
@@ -134,13 +134,13 @@ public sealed class AotStage5AContractTests
         string audit = ReadRepositoryFile("scripts/publish-aot-audit.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5ASourceFiles", audit, StringComparison.Ordinal);
         Assert.Contains("stage5AMissingDataPathPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5AMissingLauncherPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5AUnsafeLauncherPatterns", audit, StringComparison.Ordinal);
-        Assert.Contains("stage5AExpectedWmc1510Count = 863", audit, StringComparison.Ordinal);
+        Assert.Contains("stage5AExpectedWmc1510Count = 867", audit, StringComparison.Ordinal);
         Assert.Contains("Native AOT stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("AOT preview data-root isolation", project, StringComparison.OrdinalIgnoreCase);
     }

--- a/tests/DeskBox.Tests/AotStage5B1ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B1ContractTests.cs
@@ -134,14 +134,14 @@ public sealed class AotStage5B1ContractTests
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B1SourceFiles", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B1MissingRunnerPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B1MissingSmokeScriptPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B1UnsafeRunnerPatterns", audit, StringComparison.Ordinal);
-        Assert.Contains("stage5B1ExpectedWmc1510Count = 863", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("stage5B1ExpectedWmc1510Count = 867", audit, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("Native AOT stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("shortcut AOT-to-Rust smoke", project, StringComparison.OrdinalIgnoreCase);

--- a/tests/DeskBox.Tests/AotStage5B2AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B2AContractTests.cs
@@ -132,14 +132,14 @@ public sealed class AotStage5B2AContractTests
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B2ASourceFiles", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B2AMissingRunnerPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B2AMissingSmokeScriptPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B2AUnsafeMutationPatterns", audit, StringComparison.Ordinal);
-        Assert.Contains("stage5B2AExpectedWmc1510Count = 863", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("stage5B2AExpectedWmc1510Count = 867", audit, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("Native AOT stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("Explorer and Quick Access read-only", project, StringComparison.OrdinalIgnoreCase);

--- a/tests/DeskBox.Tests/AotStage5B2BContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B2BContractTests.cs
@@ -192,14 +192,14 @@ public sealed class AotStage5B2BContractTests
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B2BSourceFiles", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B2BMissingRunnerPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B2BMissingSmokeScriptPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B2BUnsafeRunnerPatterns", audit, StringComparison.Ordinal);
-        Assert.Contains("stage5B2BExpectedWmc1510Count = 863", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("stage5B2BExpectedWmc1510Count = 867", audit, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("Native AOT stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("Quick Access pin/unpin", project, StringComparison.OrdinalIgnoreCase);

--- a/tests/DeskBox.Tests/AotStage5B3AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B3AContractTests.cs
@@ -166,14 +166,14 @@ public sealed class AotStage5B3AContractTests
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B3ASourceFiles", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B3AMissingRunnerPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B3AUnsafeMutationPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B3AMissingSmokeScriptPatterns", audit, StringComparison.Ordinal);
-        Assert.Contains("stage5B3AExpectedWmc1510Count = 863", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("stage5B3AExpectedWmc1510Count = 867", audit, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("Native AOT stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("music-volume read-only smoke", project, StringComparison.OrdinalIgnoreCase);

--- a/tests/DeskBox.Tests/AotStage5B3BContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B3BContractTests.cs
@@ -161,14 +161,14 @@ public sealed class AotStage5B3BContractTests
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B3BSourceFiles", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B3BMissingRunnerPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B3BUnsafeMutationPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B3BMissingSmokeScriptPatterns", audit, StringComparison.Ordinal);
-        Assert.Contains("stage5B3BExpectedWmc1510Count = 863", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("stage5B3BExpectedWmc1510Count = 867", audit, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("Native AOT stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("system master-volume setter", project, StringComparison.OrdinalIgnoreCase);

--- a/tests/DeskBox.Tests/AotStage5B3CContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B3CContractTests.cs
@@ -270,14 +270,14 @@ public sealed class AotStage5B3CContractTests
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B3CSourceFiles", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B3CMissingRunnerPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B3CUnsafeMutationPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B3CMissingSmokeScriptPatterns", audit, StringComparison.Ordinal);
-        Assert.Contains("stage5B3CExpectedWmc1510Count = 863", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("stage5B3CExpectedWmc1510Count = 867", audit, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("Native AOT stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("session-volume", project, StringComparison.OrdinalIgnoreCase);

--- a/tests/DeskBox.Tests/AotStage5B4AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4AContractTests.cs
@@ -232,10 +232,10 @@ public sealed class AotStage5B4AContractTests
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4A", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("managed UI", project, StringComparison.OrdinalIgnoreCase);

--- a/tests/DeskBox.Tests/AotStage5B4B1ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4B1ContractTests.cs
@@ -301,8 +301,8 @@ public sealed class AotStage5B4B1ContractTests
         string baseline = ReadRepositoryFile("tests/DeskBox.Tests/JsonSerializationBaselineContractTests.cs");
         string source = ReadRepositoryFile("src/DeskBox/App.AotManagedUiSmoke.cs");
 
-        Assert.Contains("Assert.Equal(28, actual.Count);", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(64, actual.Values.Sum());", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(29, actual.Count);", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(66, actual.Values.Sum());", baseline, StringComparison.Ordinal);
         Assert.Contains("\"src/DeskBox/App.AotManagedUiSmoke.cs\"", baseline, StringComparison.Ordinal);
         Assert.Equal(1, CountOccurrences(source, "JsonSerializer.Serialize("));
     }
@@ -314,10 +314,10 @@ public sealed class AotStage5B4B1ContractTests
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4B1", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("deep settings", project, StringComparison.OrdinalIgnoreCase);
@@ -346,7 +346,7 @@ public sealed class AotStage5B4B1ContractTests
         Assert.Contains("stage5B4B1MissingRoutePatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4B1UnsafeMutationPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4B1SourceWarningMessages", audit, StringComparison.Ordinal);
-        Assert.Contains("stage5B4B1ExpectedWmc1510Count = 863", audit, StringComparison.Ordinal);
+        Assert.Contains("stage5B4B1ExpectedWmc1510Count = 867", audit, StringComparison.Ordinal);
     }
 
     private static int CountOccurrences(string value, string token)

--- a/tests/DeskBox.Tests/AotStage5B4B2AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4B2AContractTests.cs
@@ -158,9 +158,9 @@ public sealed class AotStage5B4B2AContractTests
     {
         string baseline = ReadRepositoryFile("tests/DeskBox.Tests/JsonSerializationBaselineContractTests.cs");
 
-        Assert.Contains("Assert.Equal(28, actual.Count);", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(64, actual.Values.Sum());", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(26, actualContextOwners.Length);", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(29, actual.Count);", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(66, actual.Values.Sum());", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(27, actualContextOwners.Length);", baseline, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -170,10 +170,10 @@ public sealed class AotStage5B4B2AContractTests
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4B2A", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("persistence", project, StringComparison.OrdinalIgnoreCase);
@@ -192,7 +192,7 @@ public sealed class AotStage5B4B2AContractTests
         Assert.Contains("stage5B4B2AForbiddenScopePatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4B2AJsonSerializeCallCount", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4B2ASourceWarningMessages", audit, StringComparison.Ordinal);
-        Assert.Contains("stage5B4B2AExpectedWmc1510Count = 863", audit, StringComparison.Ordinal);
+        Assert.Contains("stage5B4B2AExpectedWmc1510Count = 867", audit, StringComparison.Ordinal);
     }
 
     private static int CountOccurrences(string value, string token)

--- a/tests/DeskBox.Tests/AotStage5B4B2B1ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4B2B1ContractTests.cs
@@ -249,9 +249,9 @@ public sealed class AotStage5B4B2B1ContractTests
         string baseline = ReadRepositoryFile(
             "tests/DeskBox.Tests/JsonSerializationBaselineContractTests.cs");
 
-        Assert.Contains("Assert.Equal(28, actual.Count);", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(64, actual.Values.Sum());", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(26, actualContextOwners.Length);", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(29, actual.Count);", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(66, actual.Values.Sum());", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(27, actualContextOwners.Length);", baseline, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -261,10 +261,10 @@ public sealed class AotStage5B4B2B1ContractTests
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4B2B1", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("Quick Capture", project, StringComparison.Ordinal);
@@ -283,7 +283,7 @@ public sealed class AotStage5B4B2B1ContractTests
         Assert.Contains("stage5B4B2B1ForbiddenScopePatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4B2B1JsonSerializeCallCount", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4B2B1SourceWarningMessages", audit, StringComparison.Ordinal);
-        Assert.Contains("stage5B4B2B1ExpectedWmc1510Count = 863", audit, StringComparison.Ordinal);
+        Assert.Contains("stage5B4B2B1ExpectedWmc1510Count = 867", audit, StringComparison.Ordinal);
     }
 
     private static int CountOccurrences(string value, string token)

--- a/tests/DeskBox.Tests/AotStage5B4B2B2AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4B2B2AContractTests.cs
@@ -256,9 +256,9 @@ public sealed class AotStage5B4B2B2AContractTests
         string baseline = ReadRepositoryFile(
             "tests/DeskBox.Tests/JsonSerializationBaselineContractTests.cs");
 
-        Assert.Contains("Assert.Equal(28, actual.Count);", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(64, actual.Values.Sum());", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(26, actualContextOwners.Length);", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(29, actual.Count);", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(66, actual.Values.Sum());", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(27, actualContextOwners.Length);", baseline, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -268,10 +268,10 @@ public sealed class AotStage5B4B2B2AContractTests
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4B2B2A", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("Todo", project, StringComparison.Ordinal);
@@ -290,7 +290,7 @@ public sealed class AotStage5B4B2B2AContractTests
         Assert.Contains("stage5B4B2B2AForbiddenScopePatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4B2B2AJsonSerializeCallCount", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4B2B2ASourceWarningMessages", audit, StringComparison.Ordinal);
-        Assert.Contains("stage5B4B2B2AExpectedWmc1510Count = 863", audit, StringComparison.Ordinal);
+        Assert.Contains("stage5B4B2B2AExpectedWmc1510Count = 867", audit, StringComparison.Ordinal);
     }
 
     private static int CountOccurrences(string value, string token)

--- a/tests/DeskBox.Tests/AotStage5B4B2B2B1ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4B2B2B1ContractTests.cs
@@ -264,9 +264,9 @@ public sealed class AotStage5B4B2B2B1ContractTests
         string baseline = ReadRepositoryFile(
             "tests/DeskBox.Tests/JsonSerializationBaselineContractTests.cs");
 
-        Assert.Contains("Assert.Equal(28, actual.Count);", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(64, actual.Values.Sum());", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(26, actualContextOwners.Length);", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(29, actual.Count);", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(66, actual.Values.Sum());", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(27, actualContextOwners.Length);", baseline, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -276,10 +276,10 @@ public sealed class AotStage5B4B2B2B1ContractTests
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4B2B2B1", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("Todo steps", project, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage5B4B2B2B2ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4B2B2B2ContractTests.cs
@@ -302,9 +302,9 @@ public sealed class AotStage5B4B2B2B2ContractTests
         string baseline = ReadRepositoryFile(
             "tests/DeskBox.Tests/JsonSerializationBaselineContractTests.cs");
 
-        Assert.Contains("Assert.Equal(28, actual.Count);", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(64, actual.Values.Sum());", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(26, actualContextOwners.Length);", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(29, actual.Count);", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(66, actual.Values.Sum());", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(27, actualContextOwners.Length);", baseline, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -314,10 +314,10 @@ public sealed class AotStage5B4B2B2B2ContractTests
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4B2B2B2", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("Todo managed attachments", project, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage5B4B2C1ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4B2C1ContractTests.cs
@@ -244,10 +244,10 @@ public sealed class AotStage5B4B2C1ContractTests
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4B2C1", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("Glance owned-local-image/preferences/reload/restore/postflight", project, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage5B4B2C2AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4B2C2AContractTests.cs
@@ -201,10 +201,10 @@ public sealed class AotStage5B4B2C2AContractTests
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4B2C2A", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("Weather local settings/view-mode/reload/restore/postflight", project, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage5B4B2C2BContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4B2C2BContractTests.cs
@@ -292,10 +292,10 @@ public sealed class AotStage5B4B2C2BContractTests
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4B2C2B", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("deterministic non-empty WeatherData", project, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage5B4C1AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4C1AContractTests.cs
@@ -267,10 +267,10 @@ public sealed class AotStage5B4C1AContractTests
         string roadmap = ReadRepositoryFile(
             "docs/architecture/rust-native-aot-roadmap.md");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C1A", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("owned local-file", project, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage5B4C1B1ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4C1B1ContractTests.cs
@@ -250,10 +250,10 @@ public sealed class AotStage5B4C1B1ContractTests
         string roadmap = ReadRepositoryFile(
             "docs/architecture/rust-native-aot-roadmap.md");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C1B1", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredRustCapabilities = 511", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredRustExportCount = 10", launcher, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage5B4C1B2AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4C1B2AContractTests.cs
@@ -207,10 +207,10 @@ public sealed class AotStage5B4C1B2AContractTests
         string roadmap = ReadRepositoryFile(
             "docs/architecture/rust-native-aot-roadmap.md");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C1B2A", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredRustCapabilities = 511", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredRustExportCount = 10", launcher, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage5B4C1B2BContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4C1B2BContractTests.cs
@@ -197,13 +197,13 @@ public sealed class AotStage5B4C1B2BContractTests
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C1B2BMissingRunnerPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C1B2BForbiddenScopePatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C1B2BRustAbiUnchanged", audit, StringComparison.Ordinal);
-        Assert.Contains("stage5B4C1B2BExpectedWmc1510Count = 863", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("stage5B4C1B2BExpectedWmc1510Count = 867", audit, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("actual SHObjectProperties dialog", project, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage5B4C1C1ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4C1C1ContractTests.cs
@@ -229,14 +229,14 @@ public sealed class AotStage5B4C1C1ContractTests
         string launcher = ReadRepositoryFile("scripts/start-aot-preview.ps1");
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C1C1MissingRunnerPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C1C1MissingSmokeScriptPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C1C1ForbiddenScopePatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C1C1RustAbiUnchanged", audit, StringComparison.Ordinal);
-        Assert.Contains("stage5B4C1C1ExpectedWmc1510Count = 863", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("stage5B4C1C1ExpectedWmc1510Count = 867", audit, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("no-global-clipboard-mutation matrix", project, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage5B4C1C2AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4C1C2AContractTests.cs
@@ -187,7 +187,7 @@ public sealed class AotStage5B4C1C2AContractTests
         string project = ReadRepositoryFile("src/DeskBox/DeskBox.csproj");
         string rust = ReadRepositoryFile("native/deskbox-native/src/lib.rs");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C1C2ARequiredProductPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C1C2AMissingSmokeScriptPatterns", audit, StringComparison.Ordinal);
@@ -196,7 +196,7 @@ public sealed class AotStage5B4C1C2AContractTests
         Assert.Contains("$sourceFile -eq $stage5B4C1ASourceFiles[4]", audit, StringComparison.Ordinal);
         Assert.Contains("$pattern -eq 'NativeDrop'", audit, StringComparison.Ordinal);
         Assert.Contains("C1C2A applies its own narrow gate", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("Native AOT stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("assert_eq!(deskbox_native_capabilities(), 511);", rust, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage5B4C2AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4C2AContractTests.cs
@@ -110,12 +110,12 @@ public sealed class AotStage5B4C2AContractTests
         string project = Read("src/DeskBox/DeskBox.csproj");
         string rust = Read("native/deskbox-native/src/lib.rs");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C2ARequiredScenarioPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C2AMissingSmokeScriptPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C2ARustAbiUnchanged", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("Native AOT stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("assert_eq!(deskbox_native_capabilities(), 511);", rust, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage5B4C3AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4C3AContractTests.cs
@@ -123,12 +123,12 @@ public sealed class AotStage5B4C3AContractTests
         string project = Read("src/DeskBox/DeskBox.csproj");
         string rust = Read("native/deskbox-native/src/lib.rs");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C3ARequiredScenarioPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C3AMissingSmokeScriptPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C3ARustAbiUnchanged", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("Native AOT stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("assert_eq!(deskbox_native_capabilities(), 511);", rust, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage5B4C3B1ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4C3B1ContractTests.cs
@@ -106,12 +106,12 @@ public sealed class AotStage5B4C3B1ContractTests
         string project = Read("src/DeskBox/DeskBox.csproj");
         string rust = Read("native/deskbox-native/src/lib.rs");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C3B1RequiredScenarioPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C3B1MissingSmokeScriptPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C3B1RustAbiUnchanged", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("Native AOT stage 5B-4C3B2B1", project, StringComparison.Ordinal);
         Assert.Contains("assert_eq!(deskbox_native_capabilities(), 511);", rust, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage5B4C3B2AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4C3B2AContractTests.cs
@@ -119,12 +119,12 @@ public sealed class AotStage5B4C3B2AContractTests
         string report = Read("docs/architecture/stage-reports/aot-stage-5b-4c3b2a-report.md");
         string roadmap = Read("docs/architecture/rust-native-aot-roadmap.md");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C3B2ARequiredScenarioPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C3B2AMissingSmokeScriptPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C3B2ARustAbiUnchanged", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("Native AOT stage 5B-4C3B2B2A", project, StringComparison.Ordinal);
         Assert.Contains("real Windows notification click provenance", project, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage5B4C3B2B1ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4C3B2B1ContractTests.cs
@@ -131,7 +131,7 @@ public sealed class AotStage5B4C3B2B1ContractTests
             "scripts/run-aot-todo-notification-forwarding-smoke.ps1");
         string managedRunner = Read("scripts/run-aot-managed-ui-smoke.ps1");
 
-        Assert.Contains("$requiredAuditProfileVersion = 60", runner, StringComparison.Ordinal);
+        Assert.Contains("$requiredAuditProfileVersion = 61", runner, StringComparison.Ordinal);
         Assert.Contains("$requiredSummarySchemaVersion = 55", runner, StringComparison.Ordinal);
         Assert.Contains("-NoStop", runner, StringComparison.Ordinal);
         Assert.Contains("-ExpectExistingInstance", runner, StringComparison.Ordinal);
@@ -163,9 +163,9 @@ public sealed class AotStage5B4C3B2B1ContractTests
         string rust = Read("native/deskbox-native/src/lib.rs");
 
         Assert.Contains("TwentyEightFilesAndSixtyFourCalls", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(28, actual.Count)", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(64, actual.Values.Sum())", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(26, actualContextOwners.Length)", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(29, actual.Count)", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(66, actual.Values.Sum())", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(27, actualContextOwners.Length)", baseline, StringComparison.Ordinal);
         Assert.Contains(
             "App.AotTodoNotificationForwardingSmoke.cs\"] = 1",
             baseline,
@@ -187,12 +187,12 @@ public sealed class AotStage5B4C3B2B1ContractTests
         string report = Read("docs/architecture/stage-reports/aot-stage-5b-4c3b2b1-report.md");
         string roadmap = Read("docs/architecture/rust-native-aot-roadmap.md");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C3B2B1RequiredScenarioPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C3B2B1MissingSmokeScriptPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C3B2B1RustAbiUnchanged", audit, StringComparison.Ordinal);
-        Assert.Contains("$RequiredAuditProfileVersion = 60", launcher, StringComparison.Ordinal);
+        Assert.Contains("$RequiredAuditProfileVersion = 61", launcher, StringComparison.Ordinal);
         Assert.Contains("$RequiredSummarySchemaVersion = 55", launcher, StringComparison.Ordinal);
         Assert.Contains("Native AOT stage 5B-4C3B2B2A", project, StringComparison.Ordinal);
         Assert.Contains("real Windows notification click", project, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage5B4C3B2B2AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4C3B2B2AContractTests.cs
@@ -79,7 +79,7 @@ public sealed class AotStage5B4C3B2B2AContractTests
 
         foreach (string token in new[]
                  {
-                     "$requiredAuditProfileVersion = 60",
+                     "$requiredAuditProfileVersion = 61",
                      "$requiredSummarySchemaVersion = 55",
                      "[Guid]::NewGuid().ToString(\"N\")",
                      "-AllowEarlyExit",
@@ -118,10 +118,10 @@ public sealed class AotStage5B4C3B2B2AContractTests
             "AotTodoNotificationSurfaceEvidence? TodoNotificationSurface",
             managed,
             StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(28, actual.Count)", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(64, actual.Values.Sum())", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(29, actual.Count)", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(66, actual.Values.Sum())", baseline, StringComparison.Ordinal);
         Assert.Contains(
-            "Assert.Equal(26, actualContextOwners.Length)",
+            "Assert.Equal(27, actualContextOwners.Length)",
             baseline,
             StringComparison.Ordinal);
     }
@@ -135,7 +135,7 @@ public sealed class AotStage5B4C3B2B2AContractTests
             "docs/architecture/stage-reports/aot-stage-5b-4c3b2b2a-report.md");
         string roadmap = Read("docs/architecture/rust-native-aot-roadmap.md");
 
-        Assert.Contains("$auditProfileVersion = 60", audit, StringComparison.Ordinal);
+        Assert.Contains("$auditProfileVersion = 61", audit, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C3B2B2AMissingScenarioPatterns", audit, StringComparison.Ordinal);
         Assert.Contains("stage5B4C3B2B2AMissingProductPatterns", audit, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/AotStage5B4C3B2B2BContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4C3B2B2BContractTests.cs
@@ -109,7 +109,7 @@ public sealed class AotStage5B4C3B2B2BContractTests
 
         foreach (string token in new[]
                  {
-                     "$requiredAuditProfileVersion = 60",
+                     "$requiredAuditProfileVersion = 61",
                      "$requiredSummarySchemaVersion = 55",
                      "[switch]$IncludeColdStart",
                      "-AllowEarlyExit",
@@ -171,7 +171,7 @@ public sealed class AotStage5B4C3B2B2BContractTests
 
         foreach (string token in new[]
                  {
-                     "$auditProfileVersion = 60",
+                     "$auditProfileVersion = 61",
                      "schemaVersion = 55",
                      "stage5B4C3B2B2BMissingScenarioPatterns",
                      "stage5B4C3B2B2BMissingProductPatterns",
@@ -180,7 +180,7 @@ public sealed class AotStage5B4C3B2B2BContractTests
                      "stage5B4C3B2B2BRustAbiUnchanged",
                      "stage5B4C3B2B2BScenarioJsonSerializeCallCount",
                      "stage5B4C3B2B2BManagedUiJsonSerializeCallCount",
-                     "stage5B4C3B2B2BExpectedWmc1510Count = 863"
+                     "stage5B4C3B2B2BExpectedWmc1510Count = 867"
                  })
         {
             Assert.Contains(token, audit, StringComparison.Ordinal);

--- a/tests/DeskBox.Tests/ArchitectureContractTests.cs
+++ b/tests/DeskBox.Tests/ArchitectureContractTests.cs
@@ -69,7 +69,7 @@ public sealed class ArchitectureContractTests
         {
             ["Weather"] = 16,
             ["Todo"] = 36,
-            ["Music"] = 14,
+            ["Music"] = 15,
             ["Glance"] = 19,
             ["Search"] = 20,
             ["QuickCapture"] = 22,

--- a/tests/DeskBox.Tests/JsonSerializationBaselineContractTests.cs
+++ b/tests/DeskBox.Tests/JsonSerializationBaselineContractTests.cs
@@ -38,6 +38,7 @@ public sealed class JsonSerializationBaselineContractTests : IDisposable
             ["src/DeskBox/Services/GlanceImageService.cs"] = 2,
             ["src/DeskBox/Services/GlanceWidgetStore.cs"] = 7,
             ["src/DeskBox/Services/LocalizationService.cs"] = 1,
+            ["src/DeskBox/Services/MusicSettingsStore.cs"] = 2,
             ["src/DeskBox/Services/NativeNotificationActivationEnvelopeStore.cs"] = 2,
             ["src/DeskBox/Services/QuickCaptureStore.cs"] = 2,
             ["src/DeskBox/Services/SearchHistoryService.cs"] = 2,
@@ -64,8 +65,8 @@ public sealed class JsonSerializationBaselineContractTests : IDisposable
             Assert.Equal(expectedCount, actual[path]);
         }
 
-        Assert.Equal(28, actual.Count);
-        Assert.Equal(64, actual.Values.Sum());
+        Assert.Equal(29, actual.Count);
+        Assert.Equal(66, actual.Values.Sum());
 
         string[] expectedContextOwners =
         [
@@ -88,6 +89,7 @@ public sealed class JsonSerializationBaselineContractTests : IDisposable
             "src/DeskBox/Services/GlanceImageService.cs",
             "src/DeskBox/Services/GlanceWidgetStore.cs",
             "src/DeskBox/Services/LocalizationService.cs",
+            "src/DeskBox/Services/MusicSettingsStore.cs",
             "src/DeskBox/Services/NativeNotificationActivationEnvelopeStore.cs",
             "src/DeskBox/Services/QuickCaptureStore.cs",
             "src/DeskBox/Services/SearchHistoryService.cs",
@@ -104,7 +106,7 @@ public sealed class JsonSerializationBaselineContractTests : IDisposable
             .Order()
             .ToArray();
 
-        Assert.Equal(26, actualContextOwners.Length);
+        Assert.Equal(27, actualContextOwners.Length);
         Assert.Equal(expectedContextOwners, actualContextOwners);
     }
 

--- a/tests/DeskBox.Tests/MusicSettingsStoreTests.cs
+++ b/tests/DeskBox.Tests/MusicSettingsStoreTests.cs
@@ -1,0 +1,126 @@
+using DeskBox.Models;
+using DeskBox.Services;
+
+namespace DeskBox.Tests;
+
+/// <summary>
+/// Per-kind settings store pilot (Music, pluginization roadmap stage 2).
+/// All store and migration tests run against isolated temporary roots so
+/// the production data directory is never touched: stores use the internal
+/// constructor, and the migration uses its internal directory seam (the
+/// DeskBoxDataPathService.Current static caches on first touch, so an env
+/// var redirect is not reliable in serial full-suite runs).
+/// </summary>
+public sealed class MusicSettingsStoreTests : IDisposable
+{
+    private readonly string _tempRoot;
+
+    public MusicSettingsStoreTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "DeskBox.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempRoot);
+    }
+
+    [Fact]
+    public void Load_ReturnsDefaultsWhenStoreDoesNotExist()
+    {
+        var store = CreateStore();
+
+        var settings = store.Load();
+
+        Assert.True(settings.UseArtworkBackdrop);
+        Assert.True(settings.EnableCoverHoverMotion);
+        Assert.Equal(SettingsService.MusicDisplayModeAuto, settings.DisplayMode);
+    }
+
+    [Fact]
+    public async Task Save_PersistsAndReloadsThroughResilientStore()
+    {
+        var store = CreateStore();
+
+        await store.SaveAsync(new MusicWidgetSettings
+        {
+            UseArtworkBackdrop = false,
+            EnableCoverHoverMotion = false,
+            DisplayMode = "Cover"
+        });
+
+        var reloaded = new MusicSettingsStore(Path.Combine(_tempRoot, "store", "music")).Load();
+        Assert.False(reloaded.UseArtworkBackdrop);
+        Assert.False(reloaded.EnableCoverHoverMotion);
+        Assert.Equal("Cover", reloaded.DisplayMode);
+    }
+
+    [Fact]
+    public void Load_NormalizesInvalidDisplayMode()
+    {
+        var store = CreateStore();
+        Directory.CreateDirectory(Path.GetDirectoryName(store.StorePath)!);
+        File.WriteAllText(store.StorePath, "{\"displayMode\":\"Nonsense\"}");
+
+        var settings = store.Load();
+
+        Assert.Equal(SettingsService.MusicDisplayModeAuto, settings.DisplayMode);
+    }
+
+    [Fact]
+    public void Migration_9_To_10_CopiesLegacyFieldsAndIsIdempotent()
+    {
+        string dataDirectory = Path.Combine(_tempRoot, "data");
+        var settings = new AppSettings
+        {
+            MusicUseArtworkBackdrop = false,
+            MusicEnableCoverHoverMotion = true,
+            MusicDisplayMode = "RecordVertical"
+        };
+
+        Migration_9_To_10.Migrate(
+            settings, dataDirectory);
+
+        // The legacy fields stay as an inert compatibility source (N+2 removes them).
+        Assert.False(settings.MusicUseArtworkBackdrop);
+
+        string storePath = Path.Combine(dataDirectory, "music", "settings.json");
+        Assert.True(File.Exists(storePath), "Migration must create the music store.");
+        using (var document = System.Text.Json.JsonDocument.Parse(File.ReadAllText(storePath)))
+        {
+            Assert.False(document.RootElement.GetProperty("useArtworkBackdrop").GetBoolean());
+            Assert.Equal("RecordVertical", document.RootElement.GetProperty("displayMode").GetString());
+        }
+
+        // Idempotence: a second migration run never overwrites the store.
+        File.WriteAllText(storePath,
+            File.ReadAllText(storePath).Replace("RecordVertical", "Cover"));
+        Migration_9_To_10.Migrate(
+            new AppSettings(), dataDirectory);
+        using var reparsed = System.Text.Json.JsonDocument.Parse(File.ReadAllText(storePath));
+        Assert.Equal("Cover", reparsed.RootElement.GetProperty("displayMode").GetString());
+    }
+
+    [Fact]
+    public void Pipeline_RegistersTheMusicMigration()
+    {
+        string pipelineSource = File.ReadAllText(TestPaths.SourceFile(
+            "src/DeskBox/Services/SettingsMigrationService.cs"));
+        Assert.Contains("_migrations.Add(new Migration_9_To_10());", pipelineSource, StringComparison.Ordinal);
+        Assert.Contains("CurrentSchemaVersion = 10", pipelineSource, StringComparison.Ordinal);
+    }
+
+    private MusicSettingsStore CreateStore() =>
+        new(Path.Combine(_tempRoot, "store", "music"));
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempRoot))
+            {
+                Directory.Delete(_tempRoot, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup for files briefly held by antivirus.
+        }
+    }
+}

--- a/tests/DeskBox.Tests/MusicVolumeAotContractTests.cs
+++ b/tests/DeskBox.Tests/MusicVolumeAotContractTests.cs
@@ -144,7 +144,7 @@ public sealed class MusicVolumeAotContractTests
         string script = File.ReadAllText(
             TestPaths.FromRepository("scripts/publish-aot-audit.ps1"));
 
-        Assert.Contains("auditProfileVersion = 60", script, StringComparison.Ordinal);
+        Assert.Contains("auditProfileVersion = 61", script, StringComparison.Ordinal);
         Assert.Contains("schemaVersion = 55", script, StringComparison.Ordinal);
         Assert.Contains("musicVolumeAlwaysThrowMessages", script, StringComparison.Ordinal);
         Assert.Contains("musicVolumeBackendPolicy", script, StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

The Music pilot validates the per-kind store pattern end to end (roadmap stage 2):

- **MusicSettingsStore** owns `data/music/settings.json` (GlanceWidgetStore pattern): own JsonContext, ResilientJsonStore, display-mode normalization, internal-ctor test seam.
- **Migration_9_To_10** is copy-style and idempotent: the three legacy AppSettings fields stay as an inert compatibility source until the N+2 cleanup release; re-runs never overwrite post-cutover user data.
- **ViewModel rewiring**: synchronous load during construction, writes through UpdateMusicSettings (store + legacy mirror), default-reset and settings-snapshot follow.
- **Guardrail sync**: JSON baseline 29/66/27 (+7 mirrors), Music inventory 15, auditProfileVersion 61 (54 files), WMC1510 863 -> 867 (four warnings from the MusicSettingsSection.xaml extraction - verified by the audit run).

## Validation

- Full suite 3392/3392 green on x64.
- publish-aot-audit.ps1 exit 0 end to end on the committed profile-61 tree.
- Canonical Debug rebuilt and restarted.