### PR TITLE
Music store write-path hardening + plugin schema v0.1 (third review fixes)

### DIFF
--- a/docs/architecture/plugin-schema-v0-notes.md
+++ b/docs/architecture/plugin-schema-v0-notes.md
@@ -1,29 +1,43 @@
-# DeskBox Plugin Schema v0 — 语义注记
+# DeskBox Plugin Schema v0.1 — 语义注记
 
-配套 `plugin-schema-v0.json`。v0 是草案：给三路 spike（roadmap 阶段 3.5）、CLI validator（阶段 6）、商店规范（阶段 7）一个共同靶子，会迭代；契约测试只轻钉存在性与词汇，不逐字段冻结。
+配套 `plugin-schema-v0.json`。v0.1 是草案：给三路 spike（roadmap 阶段 3.5）、CLI validator（阶段 6）、商店规范（阶段 7）一个共同靶子，会迭代；契约测试只轻钉存在性与词汇，不逐字段冻结。
+
+## v0 → v0.1 变更（第三轮外部评审吸收，roadmap 16.7）
+
+| 变更 | 原因 |
+|---|---|
+| `widgets[]` → `contributions[]` + `type` discriminator | 消除 Plugin=WidgetPlugin 隐含；Package 可贡献 Command/AITool/Settings 等不含 widget 的类型，v0.1 只实现 widget 但结构不改 |
+| `category` → `runtime`（none/wasm/process） | 原枚举混合了内容类型（resource-pack）与运行时技术（wasm/out-of-proc）；runtime 描述执行技术，声明式 UI 在所有 runtime 下都是宿主渲染 |
+| `typeId` pattern + description 矛盾修复 | 原 description 说"以 package id 为前缀"（含点）但 pattern 禁点号；改为 local id + 宿主派生 canonical id（`{package-id}/{local-id}`） |
+| `signature` 自引用修复 | contentHash 覆盖域定义为"除 signature 块自身外的全部文件，manifest 规范化（signature=null、排序键、无空白）后参与哈希" |
+| `publisherKey` → `publisherSignature` | 字段名与语义错位（装的是签名不是公钥）；公钥指纹在顶层 publisher 字段 |
+| `capabilities[]` + `defaultSet` 删除 | 安全模型缺陷：不可信第三方不应通过 manifest 自我授权"默认授予"；改为纯 permissions[] + required/scope，授予决策归宿主策略引擎 |
+| `signature` 从 required 移除 | 开发模式（dev/pack 前）不应强制签名；签名是分发 envelope 的职责，商店安装时才强制 |
 
 ## 与已定决策的对应
 
 | Schema 条目 | 决策来源 |
 |---|---|
-| `category` 三枚举 | §13.1（声明式资源包首发品类；WASM/进程外一等 Runtime） |
-| `hostApi{min,max}` + 运行期 protocolVersion | §13.4 版本双闸（安装期挡不可能兼容的包，握手期不匹配回结构化错误附 supported 列表） |
-| 六模板枚举 | §13.5（Metric/List/Status/Gallery/ActionList/SimpleForm；v0 无自由布局原语，不发明小型 XAML） |
-| `payload.version` + per-element fallback | §13.5 分层规则（manifest 严格 / RPC envelope 宽容 / payload 按版本严格、未知元素 fallback→丢弃） |
-| `permissions`/`scopes`/`capabilities` + `defaultSet` | §13.2（Tauri ACL 词汇、JSON 格式不抄 TOML、deny 压 allow、防御性默认 deny 集） |
-| `activationEvents` | §5.8（实例恢复与运行时激活分离：窗口/布局恢复永远发生，事件只决定 Runtime 何时拉起） |
-| 三级 ID 分离 | §7 阶段 7（Package ≠ Widget Type ≠ Instance） |
-| `signature` 双字段 | §13.6 三级签名（完整性 SHA256 / 发布者 Ed25519 / Full-Trust 走 Windows 代码签名+Store/WinGet 渠道） |
-| `data.*SchemaVersion` | §9 插件 schema 迁移条款（宿主负责备份→迁移→验证→提交/回滚） |
+| `runtime` 三枚举 | §13.1 三分类（none=resource-pack / wasm / process） |
+| `hostApi{min,max}` + 运行期 protocolVersion | §13.4 版本双闸 |
+| 六模板枚举 | §13.5（不发明小型 XAML） |
+| `payload.version` + per-element fallback | §13.5 分层规则 |
+| `permissions[]` + `required` + scope | §13.2（Tauri 词汇，但授予决策归宿主——非 Tauri 的 default-set 语义） |
+| `activationEvents` | §5.8（实例恢复与运行时激活分离） |
+| 三级 ID 分离 | §7 阶段 7（Package ≠ Contribution ≠ Instance） |
+| `signature` 双字段 | §13.6 三级签名（contentHash + publisherSignature；Full-Trust 加 Windows 代码签名） |
+| `data.*SchemaVersion` | §9 插件 schema 迁移条款 |
 
 ## 通道三分法（引用 §13.4，写进包语义）
 
-- **Capability Call**（插件→宿主，request/response，受权限+scope 控制）——被鼓励的正常流量；
-- **Lifecycle/Event**（宿主→插件，typed event，白名单：onActivate/onWidgetVisible/onFileChanged/onTimer/onSettingsChanged…）；
-- **任意宿主函数 invoke**——禁止。MCP 弃用反向请求的教训只适用于第三类。
+- **Capability Call**（插件→宿主，request/response，受权限+scope 控制）
+- **Lifecycle/Event**（宿主→插件，typed event，白名单）
+- **任意宿主函数 invoke**——禁止
 
-## v0 明确不包含（防止提前冻结）
+## v0.1 明确不包含（防止提前冻结）
 
 - 声明式 UI payload 的字段级 schema（六模板各自的 payload 结构留给 spike 输出后定 v1）；
-- 商店侧字段（价格/entitlement 是服务端元数据，§15：包本体是免费产物）；
-- 进程外/WASM 运行时的传输细节（stdio+LSP framing 是 Process Runtime 的事，不是 manifest 的事）。
+- `contributions[]` 的 command/ai-tool/settings 类型定义（v0.1 只有 widget；加新类型不改包级结构）；
+- wasm/process runtime 的入口/构件字段（entryPoint、wasmModule 路径——spike 三条腿的输出决定字段名）；
+- 商店侧字段（价格/entitlement 是服务端元数据，§15）；
+- 进程外/WASM 运行时的传输细节（stdio+LSP framing 是 Process Runtime 的事）。

--- a/docs/architecture/plugin-schema-v0.json
+++ b/docs/architecture/plugin-schema-v0.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://deskbox.fun/schemas/plugin-manifest-v0.json",
-  "title": "DeskBox Plugin Manifest (schema v0 draft)",
-  "description": "Draft manifest vocabulary for the DeskBox extension system. v0 exists to give the three-way runtime spike, the plugin CLI validator and the store specification one shared target; it will iterate and is intentionally lightly pinned by tests (existence + vocabulary, not field-by-field freezing). Design decisions: roadmap sections 13.2 (permissions), 13.4 (protocol skeleton), 13.5 (declarative UI), 14 (Extension Model) and 15 (store/commerce).",
+  "title": "DeskBox Plugin Manifest (schema v0.1 draft)",
+  "description": "Draft manifest vocabulary for the DeskBox extension system. v0.1 incorporates the third review round: contributions[] replaces widgets[]; the runtime field describes execution technology; the signature block avoids self-reference by excluding itself from the hash domain. Design decisions: roadmap sections 13.2, 13.4, 13.5, 14, 15 and 16.7.",
   "type": "object",
-  "required": ["schemaVersion", "id", "version", "publisher", "category", "hostApi", "widgets", "signature"],
+  "required": ["schemaVersion", "id", "version", "publisher", "runtime", "hostApi", "contributions"],
   "additionalProperties": false,
   "properties": {
     "schemaVersion": {
@@ -14,7 +14,7 @@
     "id": {
       "type": "string",
       "pattern": "^[a-z0-9][a-z0-9-]*(\\.[a-z0-9][a-z0-9-]*)+$",
-      "description": "Package id, reverse-DNS style (e.g. com.github.stats). Package id != widget type id != widget instance id (three-level separation)."
+      "description": "Package id, reverse-DNS style (e.g. com.github.stats)."
     },
     "version": {
       "type": "string",
@@ -24,11 +24,11 @@
     "publisher": {
       "type": "string",
       "minLength": 1,
-      "description": "Publisher identity. In the pre-account phase this is the Ed25519 publisher key fingerprint; later it binds to a registered account."
+      "description": "Publisher identity. In the pre-account phase this is the Ed25519 public key fingerprint; later it binds to a registered account."
     },
-    "category": {
-      "enum": ["resource-pack", "wasm", "out-of-proc"],
-      "description": "resource-pack: declarative-only, no code executes, store launch category. wasm: sandboxed component. out-of-proc: full-trust process (Windows code signing channel required, L1 review)."
+    "runtime": {
+      "enum": ["none", "wasm", "process"],
+      "description": "Execution technology for this package. none = declarative-only (resource-pack class; no code executes). wasm = sandboxed component (in-process, WIT-based). process = full-trust executable (requires Windows code signing, L1 store review, Store/WinGet channel). A package has exactly one runtime; its declarative contributions (UI etc.) are always host-rendered regardless of runtime."
     },
     "hostApi": {
       "type": "object",
@@ -40,88 +40,86 @@
       },
       "description": "Install-time half of the version double-gate; the runtime handshake protocolVersion is the other half (roadmap 13.4)."
     },
-    "widgets": {
+    "contributions": {
       "type": "array",
       "minItems": 1,
+      "description": "Things this package contributes to the host. Each entry has a type discriminator; v0.1 defines only the widget type - command, ai-tool, settings and other types will be added without changing the package-level structure.",
       "items": {
         "type": "object",
-        "required": ["typeId", "displayName", "template"],
-        "additionalProperties": false,
-        "properties": {
-          "typeId": {
-            "type": "string",
-            "pattern": "^[a-z0-9][a-z0-9-]*$",
-            "description": "Widget type id, unique within the package; conventionally prefixed by the package id."
-          },
-          "displayName": { "type": "string", "minLength": 1 },
-          "template": {
-            "enum": ["metric", "list", "status", "gallery", "action-list", "simple-form"],
-            "description": "Host-rendered declarative template (roadmap 13.5). v0 deliberately has no free-form layout primitives."
-          },
-          "payload": {
-            "type": "object",
-            "required": ["version"],
+        "required": ["type", "id"],
+        "oneOf": [
+          {
             "properties": {
-              "version": {
-                "type": "integer",
-                "minimum": 1,
-                "description": "Payload schema version; the host picks the parser by version, strict within a known version, unknown elements fall back per-element then drop."
+              "type": { "const": "widget" },
+              "id": {
+                "type": "string",
+                "pattern": "^[a-z0-9][a-z0-9-]*$",
+                "description": "Local contribution id, unique within the package (e.g. 'overview'). The host derives the canonical contribution id as {package-id}/{local-id} (e.g. com.github.stats/overview). This is distinct from the package id and from runtime widget instance ids (three-level separation)."
+              },
+              "displayName": { "type": "string", "minLength": 1 },
+              "template": {
+                "enum": ["metric", "list", "status", "gallery", "action-list", "simple-form"],
+                "description": "Host-rendered declarative template (roadmap 13.5). v0 deliberately has no free-form layout primitives."
+              },
+              "payload": {
+                "type": "object",
+                "required": ["version"],
+                "properties": {
+                  "version": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Payload schema version; the host picks the parser by version, strict within a known version, unknown elements fall back per-element then drop."
+                  }
+                },
+                "additionalProperties": true,
+                "description": "Template payload data + bindings. HostConfig owns theming; the payload never carries style."
+              },
+              "defaultSize": {
+                "type": "object",
+                "properties": { "width": { "type": "number" }, "height": { "type": "number" } },
+                "additionalProperties": false
+              },
+              "activationEvents": {
+                "type": "array",
+                "items": {
+                  "enum": ["onStartupFinished", "onWidgetOpen", "onCommand", "onSchedule", "onFileAssociation", "onEvent"]
+                },
+                "description": "Declarative activation events (roadmap 5.8): widgets restore their window/layout always; these decide when the plugin runtime starts."
               }
-            },
-            "additionalProperties": true,
-            "description": "Template payload data + bindings. HostConfig owns theming; the payload never carries style."
-          },
-          "defaultSize": {
-            "type": "object",
-            "properties": { "width": { "type": "number" }, "height": { "type": "number" } },
-            "additionalProperties": false
-          },
-          "activationEvents": {
-            "type": "array",
-            "items": {
-              "enum": ["onStartupFinished", "onWidgetOpen", "onCommand", "onSchedule", "onFileAssociation", "onEvent"]
-            },
-            "description": "Declarative activation events (roadmap 5.8): widgets restore their window/layout always; these decide when the plugin runtime starts."
+            }
           }
-        }
+        ]
       }
     },
     "permissions": {
       "type": "array",
       "items": {
-        "type": "string",
-        "pattern": "^[a-z0-9-]+:[a-z0-9-]+$",
-        "description": "Tauri-style identifier plugin-name:permission-name referencing a capability declaration. Granting happens through capabilities, not by listing here."
-      },
-      "default": []
-    },
-    "scopes": {
-      "type": "array",
-      "items": {
         "type": "object",
-        "required": ["permission"],
+        "required": ["id"],
         "properties": {
-          "permission": { "type": "string" },
-          "allow": { "type": "array", "items": { "type": "string" }, "description": "e.g. directory globs (Downloads/**), URL filters (api.github.com), quotas (100/day)." },
-          "deny": { "type": "array", "items": { "type": "string" }, "description": "Deny always wins over allow (Tauri rule); the host additionally maintains defensive default-denies (own config/credential dirs)." }
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+(\\.[a-z0-9-]+)+$",
+            "description": "Permission identifier referencing the host's permission registry (e.g. network.fetch, files.read). Third-party packages cannot invent new permission ids; unknown ids are rejected at validation time."
+          },
+          "required": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether the package needs this permission to function. Optional permissions can be declined by the user at install."
+          },
+          "scope": {
+            "type": "object",
+            "properties": {
+              "allow": { "type": "array", "items": { "type": "string" }, "description": "e.g. directory globs (Downloads/**), URL filters (api.github.com), quotas (100/day)." },
+              "deny": { "type": "array", "items": { "type": "string" }, "description": "Deny always wins over allow; the host additionally maintains defensive default-denies (own config/credential dirs)." }
+            },
+            "additionalProperties": false
+          }
         },
         "additionalProperties": false
       },
-      "default": []
-    },
-    "capabilities": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["permission"],
-        "properties": {
-          "permission": { "type": "string" },
-          "context": { "type": "string", "description": "Which plugin context (package / widget type) receives the grant." },
-          "defaultSet": { "type": "boolean", "default": false, "description": "Granted automatically at install with explicit UI notice (Tauri default.toml semantics)." }
-        },
-        "additionalProperties": false
-      },
-      "default": []
+      "default": [],
+      "description": "Permission requests. The host policy engine (not the package) decides whether a permission is auto-granted, prompted, or denied - a package cannot self-grant via manifest fields."
     },
     "data": {
       "type": "object",
@@ -134,10 +132,16 @@
     },
     "signature": {
       "type": "object",
-      "required": ["contentHash", "publisherKey"],
+      "description": "OPTIONAL in dev mode; REQUIRED for store-distributed packages. The contentHash covers every file in the package EXCEPT this signature block itself (the manifest is canonicalized with the signature field set to null before hashing). The publisherSignature is the Ed25519 signature over the contentHash. Full-trust executables additionally require Windows code signing (tier 3) and ship through Store/WinGet channels.",
       "properties": {
-        "contentHash": { "type": "string", "description": "SHA-256 of the package contents (integrity, tier 1 of the three-tier signing model)." },
-        "publisherKey": { "type": "string", "description": "Ed25519 signature over the content hash (publisher identity, tier 2). Full-trust executables additionally require Windows code signing (tier 3) and ship through Store/WinGet channels." }
+        "contentHash": {
+          "type": "string",
+          "description": "SHA-256 of the package contents excluding this signature block. The manifest is canonicalized (signature = null, sorted keys, no whitespace) before being included in the hash input."
+        },
+        "publisherSignature": {
+          "type": "string",
+          "description": "Ed25519 signature over the contentHash, made with the publisher's private key. The corresponding public key fingerprint is the top-level publisher field."
+        }
       },
       "additionalProperties": false
     },

--- a/src/DeskBox/Services/MusicSettingsStore.cs
+++ b/src/DeskBox/Services/MusicSettingsStore.cs
@@ -18,17 +18,23 @@ internal sealed partial class MusicSettingsJsonContext : JsonSerializerContext
 /// <summary>
 /// Per-kind settings store for the Music feature (pluginization roadmap
 /// stage 2 pilot). Owns data/music/settings.json, deliberately separate from
-/// AppSettings like GlanceWidgetStore, so feature state can later be
-/// classified for sync/backup independently and moved out of the global
-/// settings file. The three legacy AppSettings fields (MusicUseArtworkBackdrop,
-/// MusicEnableCoverHoverMotion, MusicDisplayMode) are copied here by
-/// Migration_9_To_10 and remain as an inert compatibility source until the
-/// N+2 cleanup release removes them.
+/// AppSettings like GlanceWidgetStore. The three legacy AppSettings fields
+/// (MusicUseArtworkBackdrop, MusicEnableCoverHoverMotion, MusicDisplayMode)
+/// are copied here by Migration_9_To_10 and kept as a real mirror (persisted
+/// via the global settings debounce) until the N+2 cleanup release removes
+/// them.
+///
+/// Write-path design (batch E fix): the cache lock is a plain monitor lock
+/// held only for in-memory operations, so UI-thread callers can never
+/// deadlock on a pending disk write. Disk persistence happens outside the
+/// lock as a fire-and-forget task with exception observation; the legacy
+/// AppSettings mirror is persisted through the global SaveDebounced by the
+/// caller so both stores converge.
 /// </summary>
 public sealed class MusicSettingsStore
 {
+    private readonly object _lock = new();
     private readonly string _storePath;
-    private readonly SemaphoreSlim _gate = new(1, 1);
     private MusicWidgetSettings? _cached;
 
     public MusicSettingsStore()
@@ -47,57 +53,105 @@ public sealed class MusicSettingsStore
     internal string StorePath => _storePath;
 
     /// <summary>
-    /// Loads settings for synchronous callers: the settings view model
-    /// initializes music properties during construction, before async
-    /// pipelines are available. File IO on a tiny settings file in
-    /// first-use construction mirrors what SettingsService itself does.
+    /// Synchronous load from the in-memory cache; the first call reads the
+    /// tiny settings file from disk. Safe to call from UI property setters -
+    /// the monitor lock is only held for memory operations and the initial
+    /// sequential file read, never for an async write.
     /// </summary>
     public MusicWidgetSettings Load()
     {
-        MusicWidgetSettings settings = LoadAsync().GetAwaiter().GetResult();
-        return settings;
-    }
-
-    public async Task<MusicWidgetSettings> LoadAsync()
-    {
-        await _gate.WaitAsync();
-        try
+        lock (_lock)
         {
-            _cached ??= await ResilientJsonStore.LoadAsync(
-                _storePath,
-                json => Normalize(JsonSerializer.Deserialize(
-                    json,
-                    MusicSettingsJsonContext.Default.Settings)),
-                () => new MusicWidgetSettings(),
-                nameof(MusicSettingsStore));
+            _cached ??= LoadFromDisk();
             return Clone(_cached);
         }
-        finally
+    }
+
+    /// <summary>
+    /// Updates the cached settings synchronously (UI-safe), then persists
+    /// asynchronously with exception logging. The update action runs under
+    /// the lock so concurrent updates serialize against each other; disk
+    /// writes run outside the lock so they never block callers.
+    /// </summary>
+    public void Update(Action<MusicWidgetSettings> update)
+    {
+        ArgumentNullException.ThrowIfNull(update);
+        MusicWidgetSettings snapshot;
+        lock (_lock)
         {
-            _gate.Release();
+            _cached ??= LoadFromDisk();
+            update(_cached);
+            snapshot = Clone(_cached);
         }
+
+        _ = PersistAsync(snapshot);
     }
 
     public async Task SaveAsync(MusicWidgetSettings settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
-        await _gate.WaitAsync();
-        try
+        MusicWidgetSettings snapshot;
+        lock (_lock)
         {
             _cached = Normalize(Clone(settings));
-            await PersistLockedAsync();
+            snapshot = Clone(_cached);
         }
-        finally
+
+        await PersistAsync(snapshot);
+    }
+
+    private async Task PersistAsync(MusicWidgetSettings snapshot)
+    {
+        try
         {
-            _gate.Release();
+            await ResilientJsonStore.SaveAsync(
+                _storePath,
+                JsonSerializer.Serialize(snapshot, MusicSettingsJsonContext.Default.Settings));
+        }
+        catch (Exception ex)
+        {
+            App.Log($"[MusicSettingsStore] Failed to persist '{_storePath}': {ex.Message}");
         }
     }
 
-    private async Task PersistLockedAsync()
+    /// <summary>
+    /// Direct synchronous disk read for the first cache fill. Reads the
+    /// primary file and falls back to the .bak, then to defaults - a sync
+    /// bootstrap that avoids the ResilientJsonStore async pipeline (and its
+    /// SemaphoreSlim) on the UI thread.
+    /// </summary>
+    private MusicWidgetSettings LoadFromDisk()
     {
-        await ResilientJsonStore.SaveAsync(
-            _storePath,
-            JsonSerializer.Serialize(_cached!, MusicSettingsJsonContext.Default.Settings));
+        if (File.Exists(_storePath))
+        {
+            try
+            {
+                return Normalize(JsonSerializer.Deserialize(
+                    File.ReadAllText(_storePath),
+                    MusicSettingsJsonContext.Default.Settings));
+            }
+            catch (Exception ex)
+            {
+                App.Log($"[MusicSettingsStore] Primary load failed, trying backup: {ex.Message}");
+            }
+
+            string backupPath = ResilientJsonStore.GetBackupPath(_storePath);
+            if (File.Exists(backupPath))
+            {
+                try
+                {
+                    return Normalize(JsonSerializer.Deserialize(
+                        File.ReadAllText(backupPath),
+                        MusicSettingsJsonContext.Default.Settings));
+                }
+                catch (Exception ex)
+                {
+                    App.Log($"[MusicSettingsStore] Backup load failed, using defaults: {ex.Message}");
+                }
+            }
+        }
+
+        return new MusicWidgetSettings();
     }
 
     internal static MusicWidgetSettings Normalize(MusicWidgetSettings? settings)

--- a/src/DeskBox/ViewModels/MusicWidgetViewModel.cs
+++ b/src/DeskBox/ViewModels/MusicWidgetViewModel.cs
@@ -83,6 +83,10 @@ public sealed partial class MusicWidgetViewModel : ObservableObject, IDisposable
     private string _displayMode = SettingsService.MusicDisplayModeAuto;
     private Color _artworkColor = AccentColorHelper.DefaultAccentColor;
     private bool _hasArtworkColor;
+    // Per-kind store (roadmap stage 2 pilot): the widget reads music settings
+    // from the same store the settings page writes to, so both surfaces stay
+    // in sync even if the legacy AppSettings mirror lags behind.
+    private readonly MusicSettingsStore _musicSettingsStore = new();
     private MusicPlaybackMode _playbackMode = MusicPlaybackMode.Normal;
 
     public MusicWidgetViewModel(
@@ -907,9 +911,14 @@ public sealed partial class MusicWidgetViewModel : ObservableObject, IDisposable
 
     private void ApplyMusicSettings(AppSettings settings)
     {
-        UseArtworkBackdrop = settings.MusicUseArtworkBackdrop;
-        EnableCoverHoverMotion = settings.MusicEnableCoverHoverMotion;
-        DisplayMode = settings.MusicDisplayMode;
+        // The per-kind store is the authoritative source; the legacy
+        // AppSettings fields are a mirror that the global debounce persists.
+        // Reading from the store keeps this widget in sync with the settings
+        // page even when the mirror has not yet been flushed to disk.
+        MusicWidgetSettings musicSettings = _musicSettingsStore.Load();
+        UseArtworkBackdrop = musicSettings.UseArtworkBackdrop;
+        EnableCoverHoverMotion = musicSettings.EnableCoverHoverMotion;
+        DisplayMode = musicSettings.DisplayMode;
         OnPropertyChanged(nameof(ArtworkBackdropCornerRadius));
     }
 

--- a/src/DeskBox/ViewModels/SettingsViewModel.FeatureCallbacks.cs
+++ b/src/DeskBox/ViewModels/SettingsViewModel.FeatureCallbacks.cs
@@ -304,11 +304,9 @@ public partial class SettingsViewModel
             return;
         }
 
-        UpdateMusicSettings(store =>
-        {
-            store.UseArtworkBackdrop = value;
-            _settingsService.Settings.MusicUseArtworkBackdrop = value;
-        });
+        _settingsService.Settings.MusicUseArtworkBackdrop = value;
+        _musicSettingsStore.Update(store => store.UseArtworkBackdrop = value);
+        _settingsService.SaveDebounced();
     }
 
     partial void OnMusicEnableCoverHoverMotionChanged(bool value)
@@ -318,31 +316,9 @@ public partial class SettingsViewModel
             return;
         }
 
-        UpdateMusicSettings(store =>
-        {
-            store.EnableCoverHoverMotion = value;
-            _settingsService.Settings.MusicEnableCoverHoverMotion = value;
-        });
-    }
-
-    /// <summary>
-    /// Music writes go to the per-kind store (fire-and-forget save, matching
-    /// the debounced global-settings behavior) and mirror into the legacy
-    /// AppSettings fields, which stay as an inert compatibility source until
-    /// the N+2 cleanup release removes them (roadmap stage 2 pilot).
-    /// </summary>
-    private void UpdateMusicSettings(Action<MusicWidgetSettings> update)
-    {
-        try
-        {
-            MusicWidgetSettings settings = _musicSettingsStore.Load();
-            update(settings);
-            _ = _musicSettingsStore.SaveAsync(settings);
-        }
-        catch (Exception ex)
-        {
-            App.Log($"[SettingsViewModel] Music settings store update failed: {ex.Message}");
-        }
+        _settingsService.Settings.MusicEnableCoverHoverMotion = value;
+        _musicSettingsStore.Update(store => store.EnableCoverHoverMotion = value);
+        _settingsService.SaveDebounced();
     }
 
     private async Task SyncTodoEnabledAsync(bool enabled)

--- a/src/DeskBox/ViewModels/SettingsViewModel.FeatureOptions.cs
+++ b/src/DeskBox/ViewModels/SettingsViewModel.FeatureOptions.cs
@@ -358,11 +358,9 @@ public partial class SettingsViewModel
                 return;
             }
 
-            UpdateMusicSettings(store =>
-            {
-                store.DisplayMode = normalizedValue;
-                _settingsService.Settings.MusicDisplayMode = normalizedValue;
-            });
+            _settingsService.Settings.MusicDisplayMode = normalizedValue;
+            _musicSettingsStore.Update(store => store.DisplayMode = normalizedValue);
+            _settingsService.SaveDebounced();
         }
     }
 
@@ -794,12 +792,13 @@ set => WidgetOpacity = Math.Clamp(1.0 - value / 100d, SettingsService.MinWidgetO
                     _settingsService.Settings.MusicUseArtworkBackdrop = true;
                     _settingsService.Settings.MusicEnableCoverHoverMotion = true;
                     _settingsService.Settings.MusicDisplayMode = SettingsService.MusicDisplayModeAuto;
-                    UpdateMusicSettings(store =>
+                    _musicSettingsStore.Update(store =>
                     {
                         store.UseArtworkBackdrop = true;
                         store.EnableCoverHoverMotion = true;
                         store.DisplayMode = SettingsService.MusicDisplayModeAuto;
                     });
+                    _settingsService.SaveDebounced();
                     break;
                 case WidgetKind.Weather:
                     WeatherAutoLocation = true;

--- a/tests/DeskBox.Tests/AotStage5B4B1ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4B1ContractTests.cs
@@ -302,7 +302,7 @@ public sealed class AotStage5B4B1ContractTests
         string source = ReadRepositoryFile("src/DeskBox/App.AotManagedUiSmoke.cs");
 
         Assert.Contains("Assert.Equal(29, actual.Count);", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(66, actual.Values.Sum());", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(67, actual.Values.Sum());", baseline, StringComparison.Ordinal);
         Assert.Contains("\"src/DeskBox/App.AotManagedUiSmoke.cs\"", baseline, StringComparison.Ordinal);
         Assert.Equal(1, CountOccurrences(source, "JsonSerializer.Serialize("));
     }

--- a/tests/DeskBox.Tests/AotStage5B4B2AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4B2AContractTests.cs
@@ -159,7 +159,7 @@ public sealed class AotStage5B4B2AContractTests
         string baseline = ReadRepositoryFile("tests/DeskBox.Tests/JsonSerializationBaselineContractTests.cs");
 
         Assert.Contains("Assert.Equal(29, actual.Count);", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(66, actual.Values.Sum());", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(67, actual.Values.Sum());", baseline, StringComparison.Ordinal);
         Assert.Contains("Assert.Equal(27, actualContextOwners.Length);", baseline, StringComparison.Ordinal);
     }
 

--- a/tests/DeskBox.Tests/AotStage5B4B2B1ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4B2B1ContractTests.cs
@@ -250,7 +250,7 @@ public sealed class AotStage5B4B2B1ContractTests
             "tests/DeskBox.Tests/JsonSerializationBaselineContractTests.cs");
 
         Assert.Contains("Assert.Equal(29, actual.Count);", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(66, actual.Values.Sum());", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(67, actual.Values.Sum());", baseline, StringComparison.Ordinal);
         Assert.Contains("Assert.Equal(27, actualContextOwners.Length);", baseline, StringComparison.Ordinal);
     }
 

--- a/tests/DeskBox.Tests/AotStage5B4B2B2AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4B2B2AContractTests.cs
@@ -257,7 +257,7 @@ public sealed class AotStage5B4B2B2AContractTests
             "tests/DeskBox.Tests/JsonSerializationBaselineContractTests.cs");
 
         Assert.Contains("Assert.Equal(29, actual.Count);", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(66, actual.Values.Sum());", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(67, actual.Values.Sum());", baseline, StringComparison.Ordinal);
         Assert.Contains("Assert.Equal(27, actualContextOwners.Length);", baseline, StringComparison.Ordinal);
     }
 

--- a/tests/DeskBox.Tests/AotStage5B4B2B2B1ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4B2B2B1ContractTests.cs
@@ -265,7 +265,7 @@ public sealed class AotStage5B4B2B2B1ContractTests
             "tests/DeskBox.Tests/JsonSerializationBaselineContractTests.cs");
 
         Assert.Contains("Assert.Equal(29, actual.Count);", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(66, actual.Values.Sum());", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(67, actual.Values.Sum());", baseline, StringComparison.Ordinal);
         Assert.Contains("Assert.Equal(27, actualContextOwners.Length);", baseline, StringComparison.Ordinal);
     }
 

--- a/tests/DeskBox.Tests/AotStage5B4B2B2B2ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4B2B2B2ContractTests.cs
@@ -303,7 +303,7 @@ public sealed class AotStage5B4B2B2B2ContractTests
             "tests/DeskBox.Tests/JsonSerializationBaselineContractTests.cs");
 
         Assert.Contains("Assert.Equal(29, actual.Count);", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(66, actual.Values.Sum());", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(67, actual.Values.Sum());", baseline, StringComparison.Ordinal);
         Assert.Contains("Assert.Equal(27, actualContextOwners.Length);", baseline, StringComparison.Ordinal);
     }
 

--- a/tests/DeskBox.Tests/AotStage5B4C3B2B1ContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4C3B2B1ContractTests.cs
@@ -164,7 +164,7 @@ public sealed class AotStage5B4C3B2B1ContractTests
 
         Assert.Contains("TwentyEightFilesAndSixtyFourCalls", baseline, StringComparison.Ordinal);
         Assert.Contains("Assert.Equal(29, actual.Count)", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(66, actual.Values.Sum())", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(67, actual.Values.Sum())", baseline, StringComparison.Ordinal);
         Assert.Contains("Assert.Equal(27, actualContextOwners.Length)", baseline, StringComparison.Ordinal);
         Assert.Contains(
             "App.AotTodoNotificationForwardingSmoke.cs\"] = 1",

--- a/tests/DeskBox.Tests/AotStage5B4C3B2B2AContractTests.cs
+++ b/tests/DeskBox.Tests/AotStage5B4C3B2B2AContractTests.cs
@@ -119,7 +119,7 @@ public sealed class AotStage5B4C3B2B2AContractTests
             managed,
             StringComparison.Ordinal);
         Assert.Contains("Assert.Equal(29, actual.Count)", baseline, StringComparison.Ordinal);
-        Assert.Contains("Assert.Equal(66, actual.Values.Sum())", baseline, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(67, actual.Values.Sum())", baseline, StringComparison.Ordinal);
         Assert.Contains(
             "Assert.Equal(27, actualContextOwners.Length)",
             baseline,

--- a/tests/DeskBox.Tests/JsonSerializationBaselineContractTests.cs
+++ b/tests/DeskBox.Tests/JsonSerializationBaselineContractTests.cs
@@ -38,7 +38,7 @@ public sealed class JsonSerializationBaselineContractTests : IDisposable
             ["src/DeskBox/Services/GlanceImageService.cs"] = 2,
             ["src/DeskBox/Services/GlanceWidgetStore.cs"] = 7,
             ["src/DeskBox/Services/LocalizationService.cs"] = 1,
-            ["src/DeskBox/Services/MusicSettingsStore.cs"] = 2,
+            ["src/DeskBox/Services/MusicSettingsStore.cs"] = 3,
             ["src/DeskBox/Services/NativeNotificationActivationEnvelopeStore.cs"] = 2,
             ["src/DeskBox/Services/QuickCaptureStore.cs"] = 2,
             ["src/DeskBox/Services/SearchHistoryService.cs"] = 2,
@@ -66,7 +66,7 @@ public sealed class JsonSerializationBaselineContractTests : IDisposable
         }
 
         Assert.Equal(29, actual.Count);
-        Assert.Equal(66, actual.Values.Sum());
+        Assert.Equal(67, actual.Values.Sum());
 
         string[] expectedContextOwners =
         [

--- a/tests/DeskBox.Tests/PluginSchemaContractTests.cs
+++ b/tests/DeskBox.Tests/PluginSchemaContractTests.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 namespace DeskBox.Tests;
 
 /// <summary>
-/// Light pin for the plugin manifest schema v0 draft (roadmap stage 2.5).
+/// Light pin for the plugin manifest schema v0.1 draft (roadmap stage 2.5).
 /// Deliberately pins existence and vocabulary only - the draft will iterate
 /// with the runtime spike, so field-by-field freezing is explicitly avoided
 /// (see plugin-schema-v0-notes.md).
@@ -11,7 +11,7 @@ namespace DeskBox.Tests;
 public sealed class PluginSchemaContractTests
 {
     [Fact]
-    public void SchemaV0_ExistsAndParses()
+    public void SchemaV01_ExistsAndParses()
     {
         string schemaPath = TestPaths.FromRepository(
             "docs/architecture/plugin-schema-v0.json");
@@ -27,47 +27,80 @@ public sealed class PluginSchemaContractTests
     }
 
     [Fact]
-    public void SchemaV0_CategoryVocabulary_MatchesRuntimeMatrix()
+    public void SchemaV01_RuntimeVocabulary_MatchesThreeRuntimes()
     {
         using JsonDocument schema = JsonDocument.Parse(File.ReadAllText(
             TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json")));
-        JsonElement category = schema.RootElement.GetProperty("properties")
-            .GetProperty("category").GetProperty("enum");
+        JsonElement runtime = schema.RootElement.GetProperty("properties")
+            .GetProperty("runtime").GetProperty("enum");
 
-        string[] categories = category.EnumerateArray()
+        string[] values = runtime.EnumerateArray()
             .Select(value => value.GetString()!)
             .Order()
             .ToArray();
-        Assert.Equal(["out-of-proc", "resource-pack", "wasm"], categories);
+        Assert.Equal(["none", "process", "wasm"], values);
     }
 
     [Fact]
-    public void SchemaV0_TemplateVocabulary_MatchesSixTemplateDecision()
+    public void SchemaV01_ContributionsReplaceWidgets()
     {
         using JsonDocument schema = JsonDocument.Parse(File.ReadAllText(
             TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json")));
-        // Walk to widgets[].items.properties.template.enum
-        JsonElement template = schema.RootElement.GetProperty("properties")
-            .GetProperty("widgets").GetProperty("items")
-            .GetProperty("properties").GetProperty("template")
-            .GetProperty("enum");
+        JsonElement properties = schema.RootElement.GetProperty("properties");
 
-        string[] templates = template.EnumerateArray()
-            .Select(value => value.GetString()!)
-            .Order()
-            .ToArray();
-        Assert.Equal(
-            ["action-list", "gallery", "list", "metric", "simple-form", "status"],
-            templates);
+        Assert.True(properties.TryGetProperty("contributions", out _));
+        Assert.False(properties.TryGetProperty("widgets", out _));
+        Assert.False(properties.TryGetProperty("category", out _));
+
+        // The contribution type discriminator must include "widget".
+        string schemaText = File.ReadAllText(
+            TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json"));
+        Assert.Contains("\"widget\"", schemaText, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void SchemaV0_Notes_ExistAndReferenceChannelTrichotomy()
+    public void SchemaV01_TemplateVocabulary_MatchesSixTemplateDecision()
+    {
+        using JsonDocument schema = JsonDocument.Parse(File.ReadAllText(
+            TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json")));
+        string schemaText = File.ReadAllText(
+            TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json"));
+
+        foreach (string template in new[]
+                 {
+                     "metric", "list", "status", "gallery", "action-list", "simple-form"
+                 })
+        {
+            Assert.Contains($"\"{template}\"", schemaText, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void SchemaV01_SignatureIsOptionalAndCorrectlyNamed()
+    {
+        using JsonDocument schema = JsonDocument.Parse(File.ReadAllText(
+            TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json")));
+        JsonElement required = schema.RootElement.GetProperty("required");
+
+        // Signature must NOT be required (dev mode); dev packages ship without it.
+        Assert.False(required.EnumerateArray().Any(v => v.GetString() == "signature"));
+
+        string schemaText = File.ReadAllText(
+            TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json"));
+        Assert.Contains("publisherSignature", schemaText, StringComparison.Ordinal);
+        Assert.DoesNotContain("publisherKey", schemaText, StringComparison.Ordinal);
+        Assert.DoesNotContain("defaultSet", schemaText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SchemaV01_Notes_ExistAndCoverV01Changes()
     {
         string notes = File.ReadAllText(TestPaths.FromRepository(
             "docs/architecture/plugin-schema-v0-notes.md"));
         Assert.Contains("Capability Call", notes, StringComparison.Ordinal);
         Assert.Contains("Lifecycle/Event", notes, StringComparison.Ordinal);
         Assert.Contains("任意宿主函数 invoke", notes, StringComparison.Ordinal);
+        Assert.Contains("contributions", notes, StringComparison.Ordinal);
+        Assert.Contains("publisherSignature", notes, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
## Summary

Third external review round fixes (batch E), two areas:

**MusicSettingsStore write path** (the pilot pattern that will be copied to Weather/Todo):
- Deadlock eliminated: monitor lock replaces SemaphoreSlim; held only for memory ops, disk writes run outside it
- Fire-and-forget exception loss fixed: persistence is observed with logging
- SaveDebounced restored after legacy mirror writes (real compatibility source for the N/N+1/N+2 downgrade window)
- MusicWidgetViewModel reads from the store (not legacy fields) - eliminates crash-induced split-brain between settings page and widget

**Plugin schema v0.1** (the future protocol that spike/CLI/store will depend on):
- widgets -> contributions[] with type discriminator (package can contribute commands/AI tools etc.)
- category -> runtime (none/wasm/process)
- typeId fixed: local id + host derives canonical id (resolves pattern contradiction)
- Signature self-reference resolved (hash domain excludes signature block)
- publisherKey -> publisherSignature (name matches semantics)
- defaultSet/capabilities removed (host policy decides grants, not the package)
- Signature optional in dev mode

## Validation

- Full suite 3394/3394 green on x64
- Canonical Debug rebuilt and restarted (pid 28548)