### PR TITLE
fix: music store state consistency + migration stop-on-failure (review round 4)

### DIFF
--- a/src/DeskBox/Services/MusicSettingsStore.cs
+++ b/src/DeskBox/Services/MusicSettingsStore.cs
@@ -24,18 +24,47 @@ internal sealed partial class MusicSettingsJsonContext : JsonSerializerContext
 /// via the global settings debounce) until the N+2 cleanup release removes
 /// them.
 ///
-/// Write-path design (batch E fix): the cache lock is a plain monitor lock
-/// held only for in-memory operations, so UI-thread callers can never
-/// deadlock on a pending disk write. Disk persistence happens outside the
-/// lock as a fire-and-forget task with exception observation; the legacy
-/// AppSettings mirror is persisted through the global SaveDebounced by the
-/// caller so both stores converge.
+/// Write-path design (batch E fix + consistency fix): the cache lock is a
+/// plain monitor lock held only for in-memory operations, so UI-thread
+/// callers can never deadlock on a pending disk write. Disk persistence is
+/// serialized through a single background chain enqueued under the cache
+/// lock, so disk commit order always matches logical update order and one
+/// failed write never blocks later ones (exceptions are observed and
+/// logged). The store is consumed through the process-wide <see cref="Current"/>
+/// singleton: every consumer (settings page, widget) must share one cached
+/// state, or a second instance would pin its own stale cache forever. The
+/// legacy AppSettings mirror is persisted through the global SaveDebounced
+/// by the caller so both stores converge.
 /// </summary>
 public sealed class MusicSettingsStore
 {
+    private static readonly object s_currentGate = new();
+    private static MusicSettingsStore? s_current;
+
     private readonly object _lock = new();
+    private readonly object _persistGate = new();
+    private Task _persistChain = Task.CompletedTask;
     private readonly string _storePath;
     private MusicWidgetSettings? _cached;
+
+    /// <summary>
+    /// Process-wide authoritative instance. Consumers must never construct
+    /// their own store: each instance caches independently and would never
+    /// see another instance's updates (the settings page and the widget read
+    /// through this single instance so they observe the same state).
+    /// </summary>
+    public static MusicSettingsStore Current
+    {
+        get
+        {
+            lock (s_currentGate)
+            {
+                return s_current ??= new MusicSettingsStore();
+            }
+        }
+    }
+
+    internal static void ResetCurrentForTests() => s_current = null;
 
     public MusicSettingsStore()
         : this(Path.Combine(
@@ -70,24 +99,40 @@ public sealed class MusicSettingsStore
     /// <summary>
     /// Updates the cached settings synchronously (UI-safe), then persists
     /// asynchronously with exception logging. The update action runs under
-    /// the lock so concurrent updates serialize against each other; disk
-    /// writes run outside the lock so they never block callers.
+    /// the lock so concurrent updates serialize against each other; the
+    /// persistence write is enqueued under the same lock so the chain order
+    /// matches the update order, while disk I/O itself runs outside the lock
+    /// and never blocks callers.
     /// </summary>
     public void Update(Action<MusicWidgetSettings> update)
     {
         ArgumentNullException.ThrowIfNull(update);
-        MusicWidgetSettings snapshot;
         lock (_lock)
         {
             _cached ??= LoadFromDisk();
             update(_cached);
-            snapshot = Clone(_cached);
+            EnqueuePersist(Clone(_cached));
         }
-
-        _ = PersistAsync(snapshot);
     }
 
-    public async Task SaveAsync(MusicWidgetSettings settings)
+    public Task SaveAsync(MusicWidgetSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        lock (_lock)
+        {
+            _cached = Normalize(Clone(settings));
+            return EnqueuePersist(Clone(_cached));
+        }
+    }
+
+    /// <summary>
+    /// Synchronous, failure-propagating write used by the settings migration
+    /// pipeline (schema 9-to-10). Runs entirely synchronous I/O on the
+    /// calling thread - never blocks on an async continuation, which would
+    /// deadlock a UI-thread startup - and throws on failure so the pipeline
+    /// can stop and retry the migration on the next launch.
+    /// </summary>
+    internal void SaveSynchronously(MusicWidgetSettings settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
         MusicWidgetSettings snapshot;
@@ -97,7 +142,47 @@ public sealed class MusicSettingsStore
             snapshot = Clone(_cached);
         }
 
-        await PersistAsync(snapshot);
+        string json = SerializeSnapshot(snapshot);
+        Directory.CreateDirectory(Path.GetDirectoryName(_storePath)!);
+        string tempPath = $"{_storePath}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            File.WriteAllText(tempPath, json);
+            if (File.Exists(_storePath))
+            {
+                File.Replace(
+                    tempPath,
+                    _storePath,
+                    ResilientJsonStore.GetBackupPath(_storePath),
+                    ignoreMetadataErrors: true);
+            }
+            else
+            {
+                File.Move(tempPath, _storePath);
+            }
+        }
+        finally
+        {
+            TryDeleteFile(tempPath);
+        }
+    }
+
+    /// <summary>
+    /// Queues the write onto the single persistence chain and returns the
+    /// task for this write (awaiting it also drains earlier queued writes).
+    /// Called under the cache lock so the chain order can never diverge from
+    /// the update order. Failures inside the chain are caught and logged by
+    /// <see cref="PersistAsync"/>, so one failed write never faults the chain.
+    /// </summary>
+    private Task EnqueuePersist(MusicWidgetSettings snapshot)
+    {
+        lock (_persistGate)
+        {
+            _persistChain = _persistChain.ContinueWith(
+                _ => PersistAsync(snapshot),
+                TaskScheduler.Default).Unwrap();
+            return _persistChain;
+        }
     }
 
     private async Task PersistAsync(MusicWidgetSettings snapshot)
@@ -106,7 +191,7 @@ public sealed class MusicSettingsStore
         {
             await ResilientJsonStore.SaveAsync(
                 _storePath,
-                JsonSerializer.Serialize(snapshot, MusicSettingsJsonContext.Default.Settings));
+                SerializeSnapshot(snapshot));
         }
         catch (Exception ex)
         {
@@ -114,11 +199,17 @@ public sealed class MusicSettingsStore
         }
     }
 
+    private static string SerializeSnapshot(MusicWidgetSettings snapshot) =>
+        JsonSerializer.Serialize(snapshot, MusicSettingsJsonContext.Default.Settings);
+
     /// <summary>
-    /// Direct synchronous disk read for the first cache fill. Reads the
-    /// primary file and falls back to the .bak, then to defaults - a sync
-    /// bootstrap that avoids the ResilientJsonStore async pipeline (and its
-    /// SemaphoreSlim) on the UI thread.
+    /// Direct synchronous disk read for the first cache fill. Mirrors the
+    /// ResilientJsonStore decision tree synchronously: a corrupt primary is
+    /// quarantined, the backup is tried both after a corrupt primary AND
+    /// when the primary is simply missing (an orphaned backup must not
+    /// silently reset user settings to defaults), and a recovered backup is
+    /// restored into the primary slot. The sync bootstrap avoids the async
+    /// pipeline (and its SemaphoreSlim) on the UI thread.
     /// </summary>
     private MusicWidgetSettings LoadFromDisk()
     {
@@ -133,25 +224,78 @@ public sealed class MusicSettingsStore
             catch (Exception ex)
             {
                 App.Log($"[MusicSettingsStore] Primary load failed, trying backup: {ex.Message}");
+                QuarantineCorruptFile();
             }
+        }
 
-            string backupPath = ResilientJsonStore.GetBackupPath(_storePath);
-            if (File.Exists(backupPath))
+        string backupPath = ResilientJsonStore.GetBackupPath(_storePath);
+        if (File.Exists(backupPath))
+        {
+            try
             {
-                try
-                {
-                    return Normalize(JsonSerializer.Deserialize(
-                        File.ReadAllText(backupPath),
-                        MusicSettingsJsonContext.Default.Settings));
-                }
-                catch (Exception ex)
-                {
-                    App.Log($"[MusicSettingsStore] Backup load failed, using defaults: {ex.Message}");
-                }
+                string backupJson = File.ReadAllText(backupPath);
+                MusicWidgetSettings recovered = Normalize(JsonSerializer.Deserialize(
+                    backupJson,
+                    MusicSettingsJsonContext.Default.Settings));
+                TryRestorePrimary(backupJson);
+                return recovered;
+            }
+            catch (Exception ex)
+            {
+                App.Log($"[MusicSettingsStore] Backup load failed, using defaults: {ex.Message}");
             }
         }
 
         return new MusicWidgetSettings();
+    }
+
+    private void QuarantineCorruptFile()
+    {
+        string corruptPath = $"{_storePath}.corrupt-{DateTime.UtcNow:yyyyMMdd-HHmmss}-{Guid.NewGuid():N}";
+        try
+        {
+            File.Move(_storePath, corruptPath);
+            App.Log($"[MusicSettingsStore] Preserved corrupt store as '{Path.GetFileName(corruptPath)}'.");
+        }
+        catch (Exception ex)
+        {
+            App.Log($"[MusicSettingsStore] Failed to quarantine corrupt store: {ex.Message}");
+        }
+    }
+
+    private void TryRestorePrimary(string backupJson)
+    {
+        string tempPath = $"{_storePath}.{Guid.NewGuid():N}.recovery.tmp";
+        try
+        {
+            File.WriteAllText(tempPath, backupJson);
+            File.Move(tempPath, _storePath, overwrite: true);
+            App.Log($"[MusicSettingsStore] Restored store from backup.");
+        }
+        catch (Exception ex)
+        {
+            // A locked or read-only data directory must not turn a valid
+            // backup into an apparent total settings loss.
+            App.Log($"[MusicSettingsStore] Backup loaded, but primary restore failed: {ex.Message}");
+        }
+        finally
+        {
+            TryDeleteFile(tempPath);
+        }
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+        }
     }
 
     internal static MusicWidgetSettings Normalize(MusicWidgetSettings? settings)

--- a/src/DeskBox/Services/SettingsMigrationService.cs
+++ b/src/DeskBox/Services/SettingsMigrationService.cs
@@ -25,23 +25,41 @@ public sealed class SettingsMigrationPipeline
     private readonly List<ISettingsMigration> _migrations = [];
 
     public SettingsMigrationPipeline()
+        : this(
+        [
+            new Migration_0_To_1(),
+            new Migration_1_To_2(),
+            new Migration_2_To_3(),
+            new Migration_3_To_4(),
+            new Migration_4_To_5(),
+            new Migration_5_To_6(),
+            new Migration_6_To_7(),
+            new Migration_7_To_8(),
+            new Migration_8_To_9(),
+            new Migration_9_To_10()
+        ])
     {
-        // Register migrations in order
-        _migrations.Add(new Migration_0_To_1());
-        _migrations.Add(new Migration_1_To_2());
-        _migrations.Add(new Migration_2_To_3());
-        _migrations.Add(new Migration_3_To_4());
-        _migrations.Add(new Migration_4_To_5());
-        _migrations.Add(new Migration_5_To_6());
-        _migrations.Add(new Migration_6_To_7());
-        _migrations.Add(new Migration_7_To_8());
-        _migrations.Add(new Migration_8_To_9());
-        _migrations.Add(new Migration_9_To_10());
+    }
+
+    /// <summary>
+    /// Test seam: runs an explicit migration list against isolated state so
+    /// pipeline semantics (stop-on-failure, version bookkeeping) can be
+    /// verified without touching the production data root.
+    /// </summary>
+    internal SettingsMigrationPipeline(IEnumerable<ISettingsMigration> migrations)
+    {
+        _migrations.AddRange(migrations);
     }
 
     /// <summary>
     /// Runs all necessary migrations to bring the settings from their current
     /// schema version up to <see cref="CurrentSchemaVersion"/>.
+    /// A migration that throws stops the pipeline: the schema version stays
+    /// at the last successful step (never stamped past a failed step) so the
+    /// failed migration is retried on the next launch. Migrations that write
+    /// external stores (Migration_9_To_10 creating data/music/settings.json)
+    /// depend on this - stamping the version past a failed file write would
+    /// strand the user's data in the legacy fields forever.
     /// Returns true if any migration was applied.
     /// </summary>
     public bool RunMigrations(AppSettings settings)
@@ -61,14 +79,19 @@ public sealed class SettingsMigrationPipeline
                 try
                 {
                     migration.Migrate(settings);
-                    version = migration.FromVersion + 1;
-                    anyApplied = true;
-                    App.Log($"[SettingsMigration] Applied migration from version {migration.FromVersion} to {version}");
                 }
                 catch (Exception ex)
                 {
-                    App.Log($"[SettingsMigration] Migration from {migration.FromVersion} failed: {ex.Message}");
+                    App.Log(
+                        $"[SettingsMigration] Migration from version {migration.FromVersion} FAILED " +
+                        $"and will retry on next launch: {ex.Message}");
+                    settings.SchemaVersion = version;
+                    return anyApplied;
                 }
+
+                version = migration.FromVersion + 1;
+                anyApplied = true;
+                App.Log($"[SettingsMigration] Applied migration from version {migration.FromVersion} to {version}");
             }
         }
 
@@ -334,7 +357,12 @@ internal sealed class Migration_9_To_10 : ISettingsMigration
         migrated.UseArtworkBackdrop = settings.MusicUseArtworkBackdrop;
         migrated.EnableCoverHoverMotion = settings.MusicEnableCoverHoverMotion;
         migrated.DisplayMode = SettingsService.NormalizeMusicDisplayMode(settings.MusicDisplayMode);
-        store.SaveAsync(migrated).GetAwaiter().GetResult();
+        // Synchronous write that THROWS on failure: a swallowed write error
+        // here would let the pipeline stamp SchemaVersion=10 while the store
+        // was never created, permanently stranding the legacy values. It
+        // must also never block on an async continuation (UI-thread startup
+        // deadlock), hence the synchronous save path.
+        store.SaveSynchronously(migrated);
     }
 }
 

--- a/src/DeskBox/ViewModels/MusicWidgetViewModel.cs
+++ b/src/DeskBox/ViewModels/MusicWidgetViewModel.cs
@@ -86,7 +86,7 @@ public sealed partial class MusicWidgetViewModel : ObservableObject, IDisposable
     // Per-kind store (roadmap stage 2 pilot): the widget reads music settings
     // from the same store the settings page writes to, so both surfaces stay
     // in sync even if the legacy AppSettings mirror lags behind.
-    private readonly MusicSettingsStore _musicSettingsStore = new();
+    private readonly MusicSettingsStore _musicSettingsStore = MusicSettingsStore.Current;
     private MusicPlaybackMode _playbackMode = MusicPlaybackMode.Normal;
 
     public MusicWidgetViewModel(

--- a/src/DeskBox/ViewModels/SettingsViewModel.cs
+++ b/src/DeskBox/ViewModels/SettingsViewModel.cs
@@ -66,7 +66,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     // Per-kind settings store for the Music pilot (roadmap stage 2); the
     // legacy AppSettings fields are an inert compatibility source after the
     // version-10 copy migration.
-    private readonly MusicSettingsStore _musicSettingsStore = new();
+    private readonly MusicSettingsStore _musicSettingsStore = MusicSettingsStore.Current;
     private readonly CancellationTokenSource _lifetimeCts = new();
     private bool _isDisposed;
     private CancellationTokenSource? _updateOperationCts;

--- a/tests/DeskBox.Tests/MusicSettingsStoreTests.cs
+++ b/tests/DeskBox.Tests/MusicSettingsStoreTests.cs
@@ -98,12 +98,195 @@ public sealed class MusicSettingsStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task Load_RecoversFromOrphanedBackupWhenPrimaryIsMissing()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(new MusicWidgetSettings
+        {
+            UseArtworkBackdrop = false,
+            DisplayMode = "Cover"
+        });
+        await store.SaveAsync(new MusicWidgetSettings
+        {
+            UseArtworkBackdrop = true,
+            DisplayMode = "Auto"
+        });
+        File.Delete(store.StorePath);
+
+        // The .bak is one generation behind (File.Replace semantics): losing
+        // only the primary must recover that generation, not reset to defaults.
+        var recovered = new MusicSettingsStore(
+            Path.Combine(_tempRoot, "store", "music")).Load();
+
+        Assert.False(recovered.UseArtworkBackdrop);
+        Assert.Equal("Cover", recovered.DisplayMode);
+        Assert.True(File.Exists(store.StorePath), "Load must restore the primary from the backup.");
+    }
+
+    [Fact]
+    public async Task Load_QuarantinesCorruptPrimaryAndReadsBackup()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(new MusicWidgetSettings
+        {
+            UseArtworkBackdrop = false,
+            DisplayMode = "Cover"
+        });
+        await store.SaveAsync(new MusicWidgetSettings
+        {
+            UseArtworkBackdrop = true,
+            DisplayMode = "Auto"
+        });
+        File.WriteAllText(store.StorePath, "{ not valid json");
+
+        var recovered = new MusicSettingsStore(
+            Path.Combine(_tempRoot, "store", "music")).Load();
+
+        Assert.False(recovered.UseArtworkBackdrop);
+        Assert.Equal("Cover", recovered.DisplayMode);
+        Assert.NotEmpty(Directory.GetFiles(
+            Path.GetDirectoryName(store.StorePath)!,
+            "settings.json.corrupt-*"));
+        string restoredPrimary = File.ReadAllText(store.StorePath);
+        Assert.Contains("Cover", restoredPrimary, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SaveSynchronously_WritesThroughAtomicReplaceAndThrowsOnFailure()
+    {
+        var store = CreateStore();
+        await store.SaveAsync(new MusicWidgetSettings
+        {
+            UseArtworkBackdrop = false,
+            DisplayMode = "Cover"
+        });
+
+        store.SaveSynchronously(new MusicWidgetSettings
+        {
+            UseArtworkBackdrop = true,
+            DisplayMode = "Auto"
+        });
+
+        Assert.Contains("Auto", File.ReadAllText(store.StorePath), StringComparison.Ordinal);
+        Assert.Contains(
+            "Cover",
+            File.ReadAllText(ResilientJsonStore.GetBackupPath(store.StorePath)),
+            StringComparison.Ordinal);
+
+        // A primary that cannot be replaced must throw so the migration
+        // pipeline can stop instead of stamping the schema version.
+        File.Delete(store.StorePath);
+        Directory.CreateDirectory(store.StorePath);
+        Assert.Throws<IOException>(() =>
+            store.SaveSynchronously(new MusicWidgetSettings()));
+        Directory.Delete(store.StorePath);
+    }
+
+    [Fact]
+    public void Pipeline_LeavesVersionAtLastSuccessWhenAMigrationFails()
+    {
+        var settings = new AppSettings { SchemaVersion = 5 };
+
+        bool applied = new SettingsMigrationPipeline(
+        [
+            new FakeMigration(5, succeeded: true),
+            new FakeMigration(6, succeeded: false),
+            new FakeMigration(7, succeeded: true)
+        ]).RunMigrations(settings);
+
+        // Partial progress is kept (so it is saved and not redone), the
+        // failed step is retried next launch, and later steps never run.
+        Assert.True(applied);
+        Assert.Equal(6, settings.SchemaVersion);
+    }
+
+    [Fact]
+    public void Pipeline_StampsCurrentVersionWhenAllMigrationsSucceed()
+    {
+        var settings = new AppSettings { SchemaVersion = 9 };
+
+        bool applied = new SettingsMigrationPipeline(
+        [
+            new FakeMigration(9, succeeded: true)
+        ]).RunMigrations(settings);
+
+        Assert.True(applied);
+        Assert.Equal(SettingsMigrationPipeline.CurrentSchemaVersion, settings.SchemaVersion);
+    }
+
+    [Fact]
+    public void Migration_9_To_10_PropagatesExternalWriteFailures()
+    {
+        string dataDirectory = Path.Combine(_tempRoot, "blocked-data");
+        Directory.CreateDirectory(dataDirectory);
+        // A file named "music" makes the store's directory creation throw -
+        // exactly a failed external write during migration 9-to-10. The
+        // migration must let it propagate so the pipeline can stop.
+        File.WriteAllText(Path.Combine(dataDirectory, "music"), "blocker");
+
+        Assert.ThrowsAny<Exception>(() =>
+            Migration_9_To_10.Migrate(new AppSettings(), dataDirectory));
+    }
+
+    private sealed class FakeMigration(int fromVersion, bool succeeded) : ISettingsMigration
+    {
+        public int FromVersion { get; } = fromVersion;
+
+        public void Migrate(AppSettings settings)
+        {
+            if (!succeeded)
+            {
+                throw new InvalidOperationException("Injected migration failure.");
+            }
+        }
+    }
+
+    [Fact]
     public void Pipeline_RegistersTheMusicMigration()
     {
         string pipelineSource = File.ReadAllText(TestPaths.SourceFile(
             "src/DeskBox/Services/SettingsMigrationService.cs"));
-        Assert.Contains("_migrations.Add(new Migration_9_To_10());", pipelineSource, StringComparison.Ordinal);
+        Assert.Contains("new Migration_9_To_10()", pipelineSource, StringComparison.Ordinal);
         Assert.Contains("CurrentSchemaVersion = 10", pipelineSource, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Consumers_UseTheProcessWideSingletonAndSerializedWritePath()
+    {
+        string storeSource = File.ReadAllText(TestPaths.SourceFile(
+            "src/DeskBox/Services/MusicSettingsStore.cs"));
+        string migrationSource = File.ReadAllText(TestPaths.SourceFile(
+            "src/DeskBox/Services/SettingsMigrationService.cs"));
+        string settingsVmSource = File.ReadAllText(TestPaths.SourceFile(
+            "src/DeskBox/ViewModels/SettingsViewModel.cs"));
+        string widgetVmSource = File.ReadAllText(TestPaths.SourceFile(
+            "src/DeskBox/ViewModels/MusicWidgetViewModel.cs"));
+
+        // Singleton: two independently constructed stores would each pin a
+        // private cache forever and the widget would never see settings-page
+        // updates (the live-sync regression this pins shut).
+        Assert.Contains(
+            "private readonly MusicSettingsStore _musicSettingsStore = MusicSettingsStore.Current;",
+            settingsVmSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "private readonly MusicSettingsStore _musicSettingsStore = MusicSettingsStore.Current;",
+            widgetVmSource,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("new MusicSettingsStore()", settingsVmSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("new MusicSettingsStore()", widgetVmSource, StringComparison.Ordinal);
+
+        // Persistence: writes go through the serialized chain enqueued under
+        // the cache lock (disk order == update order), never a free-running
+        // fire-and-forget task.
+        Assert.Contains("EnqueuePersist(Clone(_cached));", storeSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("_ = PersistAsync(", storeSource, StringComparison.Ordinal);
+
+        // Migration: synchronous failure-propagating write, never a blocking
+        // wait on an async continuation (UI-thread startup deadlock).
+        Assert.Contains("store.SaveSynchronously(migrated);", migrationSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("GetAwaiter().GetResult()", migrationSource, StringComparison.Ordinal);
+        Assert.Contains("settings.SchemaVersion = version;", migrationSource, StringComparison.Ordinal);
     }
 
     private MusicSettingsStore CreateStore() =>


### PR DESCRIPTION
fix: music store state consistency + migration stop-on-failure (review round 4)

Fourth review round verified against main 2709d7f0; this fixes the two
P0 findings and the two P1 store findings before stage 3b wiring.

State consistency (P0 - live-sync regression):
- MusicSettingsStore is now consumed through a process-wide Current
  singleton. SettingsViewModel and MusicWidgetViewModel each constructed
  their own store, and Load() never re-reads disk after the first fill,
  so a live music widget kept its creation-time cache forever and never
  saw settings-page changes (a regression introduced by the stage 2
  pilot; before it, the widget read the live AppSettings mirror).

Persistence ordering (P1):
- Update/SaveAsync now enqueue writes onto a single persistence chain
  (under the cache lock, disk I/O on TaskScheduler.Default) so disk
  commit order always matches logical update order; a free-running
  fire-and-forget task could let an older snapshot finish last (the
  File.Replace retry loop widened that window).

Migration transactionality (P0):
- RunMigrations stops at the first failing migration and leaves
  SchemaVersion at the last successful step, so a failed external write
  is retried on the next launch instead of being stamped past forever.
- Migration_9_To_10 uses a new synchronous SaveSynchronously seam that
  propagates write failures (the async path swallows exceptions for
  observability, which made migration failures invisible) and never
  blocks on an async continuation from UI-thread startup - removing the
  last sync-over-async GetResult deadlock hazard in this path.

Backup recovery (P1):
- LoadFromDisk now mirrors the ResilientJsonStore decision tree: an
  orphaned backup (primary missing) is recovered instead of silently
  returning defaults, and a corrupt primary is quarantined with the
  backup restored into the primary slot.

Tests: +7 (orphaned backup recovery, corrupt-primary quarantine,
SaveSynchronously atomic replace + failure propagation, pipeline
stop-on-failure with partial progress, pipeline success stamp, real
migration write-failure propagation, source-scan pins for the singleton
wiring / serialized write path / no GetResult). 3401/3401 green x64.
JSON serialization baseline unchanged (shared SerializeSnapshot keeps
the file at 3 calls). Canonical Debug rebuilt and restarted (pid 8024).
