### PR TITLE
docs: plugin schema v0.2 - validation completeness + verification model (review round 4)

### DIFF
--- a/docs/architecture/plugin-schema-v0-notes.md
+++ b/docs/architecture/plugin-schema-v0-notes.md
@@ -1,6 +1,25 @@
-# DeskBox Plugin Schema v0.1 — 语义注记
+# DeskBox Plugin Schema v0.2 — 语义注记
 
-配套 `plugin-schema-v0.json`。v0.1 是草案：给三路 spike（roadmap 阶段 3.5）、CLI validator（阶段 6）、商店规范（阶段 7）一个共同靶子，会迭代；契约测试只轻钉存在性与词汇，不逐字段冻结。
+配套 `plugin-schema-v0.json`。v0.x 是草案：给三路 spike（roadmap 阶段 3.5）、CLI validator（阶段 6）、商店规范（阶段 7）一个共同靶子，会迭代；契约测试只轻钉存在性与词汇+关键校验语义，不逐字段冻结。
+
+## v0.1 → v0.2 变更（第四轮外部评审吸收）
+
+| 变更 | 原因 |
+|---|---|
+| widget 贡献收进 `$defs/widgetContribution`，`required: [type, id, displayName, template]` + `additionalProperties: false` | v0.1 只有共享 `required: [type, id]`，`{"type":"widget","id":"x"}` 这种残缺贡献能过校验，多余字段也不报错；后续 command/ai-tool/settings 类型作为新增 `$defs` 条目加入，不改包级结构 |
+| `signature` 块内部 `required: [contentHash, publisherSignature]` | 块整体可选（dev 模式）但**一旦存在必须完整**——v0.1 里 `"signature": {}` 是合法的 |
+| 新增根级必填 `publisherPublicKey`（Ed25519 公钥，raw 32 字节 base64），`publisher` 语义改为 `sha256(publisherPublicKey)` 的十六进制指纹 | 只有指纹**不能验签**（指纹是身份句柄不是验证材料）；无账号阶段（GitHub manifest 仓库运营）包必须自带公钥（评审方案 A）。校验器必须检查 `publisher == sha256(publisherPublicKey)` |
+| 哈希规则钉死为 **JCS (RFC 8785) + package.integrity 清单**，废弃"排序键+无空白"的口述规范化 | 自发明的规范化在数字格式/转义/嵌套键序/ZIP 顺序/路径分隔符上都会产生逻辑等价但字节不同的哈希；JCS 是有测试向量的正式标准。包内容枚举同样需要确定性：`package.integrity` 文件按 `sha256  <path>` 行、路径正斜杠、ordinal 排序，`contentHash = sha256(package.integrity)` |
+
+### 验签流程（v0.2 语义，validator/安装器实现于阶段 6）
+
+1. 读 manifest，canonicalize（signature 字段置 null，JCS/RFC 8785）→ 得到 manifest 规范形；
+2. 读 `package.integrity`，找到 manifest.json 对应行，比对 `sha256(manifest 规范形)` ——防"清单与 manifest 不一致"；
+3. `contentHash = sha256(package.integrity 全文)`，与 `signature.contentHash` 比对；
+4. 用 `publisherPublicKey` 验 Ed25519 `publisherSignature`（签的是 contentHash）；
+5. 检查 `publisher == sha256(publisherPublicKey)`（十六进制）；指纹同时是首次安装时的信任锚（用户批准的就是这个指纹，升级必须一致）。
+
+无签名的 dev 包跳过 3-4，但 1-2 的哈希一致性仍然检查（防手改文件后清单对不上）。
 
 ## v0 → v0.1 变更（第三轮外部评审吸收，roadmap 16.7）
 
@@ -34,7 +53,7 @@
 - **Lifecycle/Event**（宿主→插件，typed event，白名单）
 - **任意宿主函数 invoke**——禁止
 
-## v0.1 明确不包含（防止提前冻结）
+## v0.2 明确不包含（防止提前冻结）
 
 - 声明式 UI payload 的字段级 schema（六模板各自的 payload 结构留给 spike 输出后定 v1）；
 - `contributions[]` 的 command/ai-tool/settings 类型定义（v0.1 只有 widget；加新类型不改包级结构）；

--- a/docs/architecture/plugin-schema-v0.json
+++ b/docs/architecture/plugin-schema-v0.json
@@ -1,10 +1,55 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://deskbox.fun/schemas/plugin-manifest-v0.json",
-  "title": "DeskBox Plugin Manifest (schema v0.1 draft)",
-  "description": "Draft manifest vocabulary for the DeskBox extension system. v0.1 incorporates the third review round: contributions[] replaces widgets[]; the runtime field describes execution technology; the signature block avoids self-reference by excluding itself from the hash domain. Design decisions: roadmap sections 13.2, 13.4, 13.5, 14, 15 and 16.7.",
+  "title": "DeskBox Plugin Manifest (schema v0.2 draft)",
+  "description": "Draft manifest vocabulary for the DeskBox extension system. v0.1 incorporated the third review round (contributions[] replaces widgets[]; runtime describes execution technology; the signature block avoids self-reference). v0.2 incorporates the fourth review round: widget contributions must be complete (displayName/template required, no additional properties), the signature block must be complete when present, packages carry the Ed25519 publisherPublicKey (fingerprint-only publishers cannot be verified), and hashing is pinned to JCS (RFC 8785) canonicalization + a package.integrity manifest. Design decisions: roadmap sections 13.2, 13.4, 13.5, 14, 15 and 16.7.",
   "type": "object",
-  "required": ["schemaVersion", "id", "version", "publisher", "runtime", "hostApi", "contributions"],
+  "required": ["schemaVersion", "id", "version", "publisher", "publisherPublicKey", "runtime", "hostApi", "contributions"],
+  "$defs": {
+    "widgetContribution": {
+      "type": "object",
+      "required": ["type", "id", "displayName", "template"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "widget" },
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$",
+          "description": "Local contribution id, unique within the package (e.g. 'overview'). The host derives the canonical contribution id as {package-id}/{local-id} (e.g. com.github.stats/overview). This is distinct from the package id and from runtime widget instance ids (three-level separation)."
+        },
+        "displayName": { "type": "string", "minLength": 1 },
+        "template": {
+          "enum": ["metric", "list", "status", "gallery", "action-list", "simple-form"],
+          "description": "Host-rendered declarative template (roadmap 13.5). v0 deliberately has no free-form layout primitives."
+        },
+        "payload": {
+          "type": "object",
+          "required": ["version"],
+          "properties": {
+            "version": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Payload schema version; the host picks the parser by version, strict within a known version, unknown elements fall back per-element then drop."
+            }
+          },
+          "additionalProperties": true,
+          "description": "Template payload data + bindings. HostConfig owns theming; the payload never carries style."
+        },
+        "defaultSize": {
+          "type": "object",
+          "properties": { "width": { "type": "number" }, "height": { "type": "number" } },
+          "additionalProperties": false
+        },
+        "activationEvents": {
+          "type": "array",
+          "items": {
+            "enum": ["onStartupFinished", "onWidgetOpen", "onCommand", "onSchedule", "onFileAssociation", "onEvent"]
+          },
+          "description": "Declarative activation events (roadmap 5.8): widgets restore their window/layout always; these decide when the plugin runtime starts."
+        }
+      }
+    }
+  },
   "additionalProperties": false,
   "properties": {
     "schemaVersion": {
@@ -24,7 +69,12 @@
     "publisher": {
       "type": "string",
       "minLength": 1,
-      "description": "Publisher identity. In the pre-account phase this is the Ed25519 public key fingerprint; later it binds to a registered account."
+      "description": "Publisher identity: the hex-encoded SHA-256 fingerprint of publisherPublicKey (derivable, kept as the pinning/trust-display handle). In the account phase this additionally binds to a registered account."
+    },
+    "publisherPublicKey": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Ed25519 public key, base64 (raw 32-byte form). Verification material for signature.publisherSignature: a fingerprint alone cannot verify a signature, so the package carries the key itself (pre-account option A). Validation must check publisher == sha256(publisherPublicKey)."
     },
     "runtime": {
       "enum": ["none", "wasm", "process"],
@@ -43,51 +93,10 @@
     "contributions": {
       "type": "array",
       "minItems": 1,
-      "description": "Things this package contributes to the host. Each entry has a type discriminator; v0.1 defines only the widget type - command, ai-tool, settings and other types will be added without changing the package-level structure.",
+      "description": "Things this package contributes to the host. Each entry has a type discriminator; v0.2 defines only the widget type under $defs - command, ai-tool, settings and other types will be added as further $defs entries without changing the package-level structure.",
       "items": {
-        "type": "object",
-        "required": ["type", "id"],
         "oneOf": [
-          {
-            "properties": {
-              "type": { "const": "widget" },
-              "id": {
-                "type": "string",
-                "pattern": "^[a-z0-9][a-z0-9-]*$",
-                "description": "Local contribution id, unique within the package (e.g. 'overview'). The host derives the canonical contribution id as {package-id}/{local-id} (e.g. com.github.stats/overview). This is distinct from the package id and from runtime widget instance ids (three-level separation)."
-              },
-              "displayName": { "type": "string", "minLength": 1 },
-              "template": {
-                "enum": ["metric", "list", "status", "gallery", "action-list", "simple-form"],
-                "description": "Host-rendered declarative template (roadmap 13.5). v0 deliberately has no free-form layout primitives."
-              },
-              "payload": {
-                "type": "object",
-                "required": ["version"],
-                "properties": {
-                  "version": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "description": "Payload schema version; the host picks the parser by version, strict within a known version, unknown elements fall back per-element then drop."
-                  }
-                },
-                "additionalProperties": true,
-                "description": "Template payload data + bindings. HostConfig owns theming; the payload never carries style."
-              },
-              "defaultSize": {
-                "type": "object",
-                "properties": { "width": { "type": "number" }, "height": { "type": "number" } },
-                "additionalProperties": false
-              },
-              "activationEvents": {
-                "type": "array",
-                "items": {
-                  "enum": ["onStartupFinished", "onWidgetOpen", "onCommand", "onSchedule", "onFileAssociation", "onEvent"]
-                },
-                "description": "Declarative activation events (roadmap 5.8): widgets restore their window/layout always; these decide when the plugin runtime starts."
-              }
-            }
-          }
+          { "$ref": "#/$defs/widgetContribution" }
         ]
       }
     },
@@ -132,15 +141,16 @@
     },
     "signature": {
       "type": "object",
-      "description": "OPTIONAL in dev mode; REQUIRED for store-distributed packages. The contentHash covers every file in the package EXCEPT this signature block itself (the manifest is canonicalized with the signature field set to null before hashing). The publisherSignature is the Ed25519 signature over the contentHash. Full-trust executables additionally require Windows code signing (tier 3) and ship through Store/WinGet channels.",
+      "required": ["contentHash", "publisherSignature"],
+      "description": "OPTIONAL in dev mode; REQUIRED for store-distributed packages. When present it must be complete: contentHash + publisherSignature are both required. The contentHash is the SHA-256 of package.integrity (see contentHash). The publisherSignature is the Ed25519 signature over the contentHash, verified with the top-level publisherPublicKey. Full-trust executables additionally require Windows code signing (tier 3) and ship through Store/WinGet channels.",
       "properties": {
         "contentHash": {
           "type": "string",
-          "description": "SHA-256 of the package contents excluding this signature block. The manifest is canonicalized (signature = null, sorted keys, no whitespace) before being included in the hash input."
+          "description": "SHA-256 of package.integrity: a file listing every package file as 'sha256  <path>' lines (forward slashes, ordinal sort by path). manifest.json participates as its JCS (RFC 8785) canonicalization with the signature field set to null, which keeps the hash domain free of self-reference without inventing an ad-hoc sorted-keys rule (number formatting, escapes, and nested key order are all pinned by JCS)."
         },
         "publisherSignature": {
           "type": "string",
-          "description": "Ed25519 signature over the contentHash, made with the publisher's private key. The corresponding public key fingerprint is the top-level publisher field."
+          "description": "Ed25519 signature over the contentHash bytes, made with the publisher's private key. Verified with the top-level publisherPublicKey; the publisher field must equal sha256(publisherPublicKey)."
         }
       },
       "additionalProperties": false

--- a/tests/DeskBox.Tests/PluginSchemaContractTests.cs
+++ b/tests/DeskBox.Tests/PluginSchemaContractTests.cs
@@ -3,15 +3,16 @@ using System.Text.Json;
 namespace DeskBox.Tests;
 
 /// <summary>
-/// Light pin for the plugin manifest schema v0.1 draft (roadmap stage 2.5).
-/// Deliberately pins existence and vocabulary only - the draft will iterate
-/// with the runtime spike, so field-by-field freezing is explicitly avoided
-/// (see plugin-schema-v0-notes.md).
+/// Light pin for the plugin manifest schema v0.2 draft (roadmap stage 2.5).
+/// Deliberately pins existence, vocabulary and the key validation semantics
+/// tightened in v0.2 - the draft will still iterate with the runtime spike,
+/// so field-by-field freezing is explicitly avoided (see
+/// plugin-schema-v0-notes.md).
 /// </summary>
 public sealed class PluginSchemaContractTests
 {
     [Fact]
-    public void SchemaV01_ExistsAndParses()
+    public void Schema_ExistsAndParses()
     {
         string schemaPath = TestPaths.FromRepository(
             "docs/architecture/plugin-schema-v0.json");
@@ -27,7 +28,7 @@ public sealed class PluginSchemaContractTests
     }
 
     [Fact]
-    public void SchemaV01_RuntimeVocabulary_MatchesThreeRuntimes()
+    public void Schema_RuntimeVocabulary_MatchesThreeRuntimes()
     {
         using JsonDocument schema = JsonDocument.Parse(File.ReadAllText(
             TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json")));
@@ -42,7 +43,7 @@ public sealed class PluginSchemaContractTests
     }
 
     [Fact]
-    public void SchemaV01_ContributionsReplaceWidgets()
+    public void Schema_ContributionsReplaceWidgets()
     {
         using JsonDocument schema = JsonDocument.Parse(File.ReadAllText(
             TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json")));
@@ -59,7 +60,7 @@ public sealed class PluginSchemaContractTests
     }
 
     [Fact]
-    public void SchemaV01_TemplateVocabulary_MatchesSixTemplateDecision()
+    public void Schema_TemplateVocabulary_MatchesSixTemplateDecision()
     {
         using JsonDocument schema = JsonDocument.Parse(File.ReadAllText(
             TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json")));
@@ -76,7 +77,7 @@ public sealed class PluginSchemaContractTests
     }
 
     [Fact]
-    public void SchemaV01_SignatureIsOptionalAndCorrectlyNamed()
+    public void Schema_SignatureIsOptionalButCompleteWhenPresent()
     {
         using JsonDocument schema = JsonDocument.Parse(File.ReadAllText(
             TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json")));
@@ -85,15 +86,91 @@ public sealed class PluginSchemaContractTests
         // Signature must NOT be required (dev mode); dev packages ship without it.
         Assert.False(required.EnumerateArray().Any(v => v.GetString() == "signature"));
 
+        // v0.2: when present it must be complete - an empty or half-filled
+        // signature block used to validate.
+        JsonElement signature = schema.RootElement.GetProperty("properties")
+            .GetProperty("signature");
+        string[] signatureRequired = signature.GetProperty("required")
+            .EnumerateArray()
+            .Select(v => v.GetString()!)
+            .Order()
+            .ToArray();
+        Assert.Equal(["contentHash", "publisherSignature"], signatureRequired);
+
         string schemaText = File.ReadAllText(
             TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json"));
         Assert.Contains("publisherSignature", schemaText, StringComparison.Ordinal);
-        Assert.DoesNotContain("publisherKey", schemaText, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"publisherKey\"", schemaText, StringComparison.Ordinal);
         Assert.DoesNotContain("defaultSet", schemaText, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void SchemaV01_Notes_ExistAndCoverV01Changes()
+    public void Schema_WidgetContribution_MustBeCompleteAndClosed()
+    {
+        using JsonDocument schema = JsonDocument.Parse(File.ReadAllText(
+            TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json")));
+        JsonElement widget = schema.RootElement.GetProperty("$defs")
+            .GetProperty("widgetContribution");
+
+        // v0.2: displayName/template are required per contribution (the
+        // shared [type, id] required let stub widgets through) and unknown
+        // properties are rejected instead of ignored.
+        string[] required = widget.GetProperty("required")
+            .EnumerateArray()
+            .Select(v => v.GetString()!)
+            .Order()
+            .ToArray();
+        Assert.Equal(["displayName", "id", "template", "type"], required);
+        Assert.False(widget.GetProperty("additionalProperties").GetBoolean());
+
+        // contributions items dispatch through the $defs entry so later
+        // contribution types (command/ai-tool/settings) extend the oneOf.
+        JsonElement items = schema.RootElement.GetProperty("properties")
+            .GetProperty("contributions").GetProperty("items");
+        Assert.Equal(
+            "#/$defs/widgetContribution",
+            items.GetProperty("oneOf")[0].GetProperty("$ref").GetString());
+    }
+
+    [Fact]
+    public void Schema_PublisherPublicKey_IsRequiredForVerification()
+    {
+        using JsonDocument schema = JsonDocument.Parse(File.ReadAllText(
+            TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json")));
+        JsonElement required = schema.RootElement.GetProperty("required");
+
+        // v0.2: a fingerprint alone cannot verify an Ed25519 signature; the
+        // pre-account package carries the public key itself and the
+        // publisher field must equal sha256(publisherPublicKey).
+        Assert.Contains(
+            "publisherPublicKey",
+            required.EnumerateArray().Select(v => v.GetString()));
+
+        string schemaText = File.ReadAllText(
+            TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json"));
+        Assert.Contains("sha256(publisherPublicKey)", schemaText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SchemaAndNotes_PinJcsCanonicalizationAndIntegrityManifest()
+    {
+        string schemaText = File.ReadAllText(
+            TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json"));
+        string notes = File.ReadAllText(TestPaths.FromRepository(
+            "docs/architecture/plugin-schema-v0-notes.md"));
+
+        // v0.2: canonicalization is pinned to the formal standard (not an
+        // ad-hoc sorted-keys rule) and package contents hash through a
+        // deterministic package.integrity manifest.
+        Assert.Contains("RFC 8785", schemaText, StringComparison.Ordinal);
+        Assert.Contains("package.integrity", schemaText, StringComparison.Ordinal);
+        Assert.Contains("RFC 8785", notes, StringComparison.Ordinal);
+        Assert.Contains("package.integrity", notes, StringComparison.Ordinal);
+        Assert.Contains("publisherPublicKey", notes, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Schema_Notes_ExistAndCoverVocabulary()
     {
         string notes = File.ReadAllText(TestPaths.FromRepository(
             "docs/architecture/plugin-schema-v0-notes.md"));


### PR DESCRIPTION
docs: plugin schema v0.2 - validation completeness + verification model (review round 4)

Fourth review round found two direct schema bugs and two undefined
verification semantics; all four are pinned in this revision.

- contributions: the widget variant moves to $defs/widgetContribution with
  required [type, id, displayName, template] and additionalProperties:false.
  The shared [type, id] required let stub widgets like
  {"type":"widget","id":"x"} validate, and unknown properties were silently
  accepted. Later contribution types (command/ai-tool/settings) extend the
  items oneOf with further $defs entries.
- signature: the block stays optional (dev mode) but must be complete when
  present - contentHash and publisherSignature are both required, so
  "signature": {} no longer validates.
- publisherPublicKey (new, root-required): a fingerprint cannot verify an
  Ed25519 signature, so the pre-account package carries the public key
  itself (review option A); publisher becomes the hex sha256 fingerprint of
  that key and validation must check the derivation. The fingerprint
  remains the user-facing trust/pinning handle.
- Hashing pinned to JCS (RFC 8785) canonicalization plus a
  package.integrity manifest (sorted "sha256  <path>" lines) instead of the
  ad-hoc "sorted keys, no whitespace" rule; number formatting, escapes,
  nested key order and file enumeration order all had divergence potential.
  The notes document the full five-step verification walkthrough.

Tests: schema contract suite extended to 8 (widget completeness + closed
properties + $defs dispatch, signature completeness, publisherPublicKey
requirement + derivation rule, JCS/package.integrity pins in schema and
notes). 3404/3404 green x64. Docs-only change - no application code
touched.
