### PR TITLE
fix: round-5 hardening - migration gap detection + schema encoding pins

### DIFF
--- a/docs/architecture/plugin-schema-v0-notes.md
+++ b/docs/architecture/plugin-schema-v0-notes.md
@@ -11,15 +11,28 @@
 | 新增根级必填 `publisherPublicKey`（Ed25519 公钥，raw 32 字节 base64），`publisher` 语义改为 `sha256(publisherPublicKey)` 的十六进制指纹 | 只有指纹**不能验签**（指纹是身份句柄不是验证材料）；无账号阶段（GitHub manifest 仓库运营）包必须自带公钥（评审方案 A）。校验器必须检查 `publisher == sha256(publisherPublicKey)` |
 | 哈希规则钉死为 **JCS (RFC 8785) + package.integrity 清单**，废弃"排序键+无空白"的口述规范化 | 自发明的规范化在数字格式/转义/嵌套键序/ZIP 顺序/路径分隔符上都会产生逻辑等价但字节不同的哈希；JCS 是有测试向量的正式标准。包内容枚举同样需要确定性：`package.integrity` 文件按 `sha256  <path>` 行、路径正斜杠、ordinal 排序，`contentHash = sha256(package.integrity)` |
 
-### 验签流程（v0.2 语义，validator/安装器实现于阶段 6）
+### 验签流程（v0.2 语义，validator/安装器实现于阶段 6；编码细则=第五轮评审钉死）
+
+**哈希域**：`package.integrity` 列出全部 payload 文件 + `manifest.json`（以 JCS 规范形参与，signature 置 null）；**`package.integrity` 自身永不列入清单**——它自己的完整性由传递闭包覆盖（contentHash 哈希它、publisher 签名覆盖 contentHash），列入则自引用无解。清单行格式 `sha256␣␣<path>`（两个空格，sha256 为小写 hex，路径正斜杠、ordinal 排序）。
 
 1. 读 manifest，canonicalize（signature 字段置 null，JCS/RFC 8785）→ 得到 manifest 规范形；
-2. 读 `package.integrity`，找到 manifest.json 对应行，比对 `sha256(manifest 规范形)` ——防"清单与 manifest 不一致"；
-3. `contentHash = sha256(package.integrity 全文)`，与 `signature.contentHash` 比对；
-4. 用 `publisherPublicKey` 验 Ed25519 `publisherSignature`（签的是 contentHash）；
-5. 检查 `publisher == sha256(publisherPublicKey)`（十六进制）；指纹同时是首次安装时的信任锚（用户批准的就是这个指纹，升级必须一致）。
+2. 读 `package.integrity`，找到 manifest.json 对应行，比对 `sha256(manifest 规范形)`——防"清单与 manifest 不一致"；
+3. `contentHash = sha256(package.integrity 文件字节)`，与 `signature.contentHash`（小写 hex 表示）比对；
+4. 用 `publisherPublicKey`（base64，先解码为 raw 32 字节公钥）验 Ed25519 `publisherSignature`——**签名输入是 contentHash 的 raw 32 字节摘要，不是 hex 字符串**；
+5. 检查 `publisher == lowercase-hex(sha256(raw 公钥 32 字节))`——**哈希对象是解码后的公钥字节，不是 base64 文本**；指纹同时是首次安装时的信任锚（用户批准的就是这个指纹，升级必须一致）。
 
 无签名的 dev 包跳过 3-4，但 1-2 的哈希一致性仍然检查（防手改文件后清单对不上）。
+
+> 编码细则（哈希对象、hex/base64、大小写、行格式）一旦 TS CLI、C# 安装器、Rust 运行时三套实现各自理解一套就全线失配，故在 schema 描述与本节双重钉死。
+
+## v0.2 补充钉死（第五轮外部评审）
+
+| 钉死项 | 内容 |
+|---|---|
+| integrity 自引用排除 | `package.integrity` 不进入自身清单（传递闭包覆盖），哈希域=payload+JCS(manifest) |
+| 指纹推导 | `sha256(raw 32 字节公钥)`，先 base64 解码再哈希，小写 hex——不是对 base64 文本哈希 |
+| 签名输入 | `publisherSignature` 签 contentHash 的 raw 32 字节摘要，非 hex 字符串 |
+| contentHash 表示 | 小写 hex 存储；清单行 `sha256␣␣<path>` 两空格分隔 |
 
 ## v0 → v0.1 变更（第三轮外部评审吸收，roadmap 16.7）
 

--- a/docs/architecture/plugin-schema-v0.json
+++ b/docs/architecture/plugin-schema-v0.json
@@ -69,12 +69,12 @@
     "publisher": {
       "type": "string",
       "minLength": 1,
-      "description": "Publisher identity: the hex-encoded SHA-256 fingerprint of publisherPublicKey (derivable, kept as the pinning/trust-display handle). In the account phase this additionally binds to a registered account."
+      "description": "Publisher identity: the lowercase-hex SHA-256 of the RAW 32-byte Ed25519 public key (base64-decode publisherPublicKey first, then hash the decoded bytes - not the base64 text). Derivable, kept as the pinning/trust-display handle. In the account phase this additionally binds to a registered account."
     },
     "publisherPublicKey": {
       "type": "string",
       "minLength": 1,
-      "description": "Ed25519 public key, base64 (raw 32-byte form). Verification material for signature.publisherSignature: a fingerprint alone cannot verify a signature, so the package carries the key itself (pre-account option A). Validation must check publisher == sha256(publisherPublicKey)."
+      "description": "Ed25519 public key, base64 of the raw 32-byte key. Verification material for signature.publisherSignature: a fingerprint alone cannot verify a signature, so the pre-account package carries the key itself (review option A). Validation must check publisher == sha256(raw key bytes) as lowercase hex."
     },
     "runtime": {
       "enum": ["none", "wasm", "process"],
@@ -142,15 +142,15 @@
     "signature": {
       "type": "object",
       "required": ["contentHash", "publisherSignature"],
-      "description": "OPTIONAL in dev mode; REQUIRED for store-distributed packages. When present it must be complete: contentHash + publisherSignature are both required. The contentHash is the SHA-256 of package.integrity (see contentHash). The publisherSignature is the Ed25519 signature over the contentHash, verified with the top-level publisherPublicKey. Full-trust executables additionally require Windows code signing (tier 3) and ship through Store/WinGet channels.",
+      "description": "OPTIONAL in dev mode; REQUIRED for store-distributed packages. When present it must be complete: contentHash + publisherSignature are both required. The contentHash is the SHA-256 of package.integrity (see contentHash). The publisherSignature is the Ed25519 signature over the RAW 32-byte contentHash digest (not the hex string), verified with the top-level publisherPublicKey. Full-trust executables additionally require Windows code signing (tier 3) and ship through Store/WinGet channels.",
       "properties": {
         "contentHash": {
           "type": "string",
-          "description": "SHA-256 of package.integrity: a file listing every package file as 'sha256  <path>' lines (forward slashes, ordinal sort by path). manifest.json participates as its JCS (RFC 8785) canonicalization with the signature field set to null, which keeps the hash domain free of self-reference without inventing an ad-hoc sorted-keys rule (number formatting, escapes, and nested key order are all pinned by JCS)."
+          "description": "SHA-256 of the package.integrity file bytes, stored as lowercase hex. package.integrity lists every package payload file plus manifest.json (participating as its JCS/RFC 8785 canonicalization with the signature field set to null, which keeps the hash domain free of self-reference without inventing an ad-hoc sorted-keys rule - number formatting, escapes, and nested key order are all pinned by JCS). package.integrity itself is NEVER listed in package.integrity: its own integrity is covered transitively, because contentHash hashes it and the publisher signature covers contentHash. Lines are 'sha256  <path>' (two spaces), forward slashes, ordinal sort by path."
         },
         "publisherSignature": {
           "type": "string",
-          "description": "Ed25519 signature over the contentHash bytes, made with the publisher's private key. Verified with the top-level publisherPublicKey; the publisher field must equal sha256(publisherPublicKey)."
+          "description": "Ed25519 signature over the raw 32-byte contentHash digest (not the hex string), made with the publisher's private key, base64-encoded. Verified with the top-level publisherPublicKey; the publisher field must equal the lowercase-hex SHA-256 of the raw public key bytes."
         }
       },
       "additionalProperties": false

--- a/docs/architecture/pluginization-roadmap.md
+++ b/docs/architecture/pluginization-roadmap.md
@@ -421,6 +421,16 @@ P0：§6 重写为 Runtime 矩阵（删除 A→B→C 旧结论，与 §14 唯一
 
 **Why:** 第四轮评审抓到的双实例缓存/迁移事务性是数据层真风险，在复制 store 模式到 Weather/Todo 前修掉成本最低；端口语义趁零调用者修正免费。
 
+### 16.9 第五轮外部评审吸收（v1.8 补遗，2026-09-07，评审 9.2/10 判定可进 3b）
+
+评审确认 #245/#246/#247 方向全对、路线不变，补三件小事（本批落地）：
+
+1. **迁移管线 exact-step + gap 检测**：`FromVersion >= version` 改为逐步精确匹配——注册表缺一步（删/漏 migration）时旧行为会静默跳过缺失步骤直接跑后面的，现在 gap 即停（版本停在缺口处+日志显式报 GAP），与失败迁移同语义。生产注册表当前连续，属防未来回归的加固。
+2. **Schema v0.2 编码钉死**：①`package.integrity` 自身**永不列入**自身清单（自引用无解；其完整性由传递闭包覆盖=contentHash 哈希它+签名覆盖 contentHash）；②指纹=对 base64 **解码后的 raw 32 字节公钥**做 sha256、小写 hex（不是对 base64 文本哈希）；③publisherSignature 签 contentHash 的 **raw 32 字节摘要**（非 hex 字符串）——TS CLI/C# 安装器/Rust 运行时三套实现必须同一理解。
+3. **`MusicSettingsStore.Current` 过渡性声明**：Current 是修复双实例缓存回归的最小改动=static service locator，**不是 per-kind store 最终形态**；Weather/Todo/QuickCapture store 不复制 static Current，Feature 拥有 context 时改为 context 注入单例（store 类头已加 LIFECYCLE 注释）。
+
+**3b 验收标准（评审改述采纳）**：不是"FeatureWidgets.cs 少多少行"，而是**调用方（App/QuickCapture/Todo）不再知道 TodoWidgetContent/FileSurfaceContent/WidgetManager 内部字典/App.Current 服务**，只依赖能力端口；观察实现真实依赖集，需要十几个 internal getter 才能搬=不该搬，留在 WidgetManager 经接口暴露。**3b 实现注意：IFileWidgetImportTarget 的取消要真兑现**（File.Copy/Task.Run 改 FileStream.CopyToAsync(token)，不是开始前查一次 token）。
+
 ## 附录 A：关键证据文件索引
 
 | 主题 | 文件 |

--- a/src/DeskBox/Contracts/README.md
+++ b/src/DeskBox/Contracts/README.md
@@ -21,6 +21,12 @@
    若搬移需要给 `WidgetManager` 暴露一批 internal getter/dictionary，就先
    不搬——那只是把 God Class 变成 God Class + friend class。
 
+**验收标准**：不是 FeatureWidgets.cs 少了多少行，而是调用方（App /
+QuickCapture / Todo）不再知道 `TodoWidgetContent`、`FileSurfaceContent`、
+`WidgetManager` 内部字典、`App.Current` 服务——只依赖能力端口。实现侧
+`IFileWidgetImportTarget` 的 CancellationToken 必须真兑现（流式
+`CopyToAsync(token)`，不是开始前查一次）。
+
 ## 现有端口
 
 | 端口 | 切点 | 语义要点 |

--- a/src/DeskBox/Services/MusicSettingsStore.cs
+++ b/src/DeskBox/Services/MusicSettingsStore.cs
@@ -35,6 +35,13 @@ internal sealed partial class MusicSettingsJsonContext : JsonSerializerContext
 /// state, or a second instance would pin its own stale cache forever. The
 /// legacy AppSettings mirror is persisted through the global SaveDebounced
 /// by the caller so both stores converge.
+///
+/// LIFECYCLE NOTE: <see cref="Current"/> is a transitional shared instance
+/// (the minimal fix for the two-instance stale-cache regression). It is a
+/// static service locator, NOT the final per-kind store model - do not copy
+/// this pattern to Weather/Todo/QuickCapture stores. When features gain
+/// their own context, the store is injected as a singleton through the
+/// feature/host context instead.
 /// </summary>
 public sealed class MusicSettingsStore
 {

--- a/src/DeskBox/Services/SettingsMigrationService.cs
+++ b/src/DeskBox/Services/SettingsMigrationService.cs
@@ -53,13 +53,14 @@ public sealed class SettingsMigrationPipeline
 
     /// <summary>
     /// Runs all necessary migrations to bring the settings from their current
-    /// schema version up to <see cref="CurrentSchemaVersion"/>.
-    /// A migration that throws stops the pipeline: the schema version stays
-    /// at the last successful step (never stamped past a failed step) so the
-    /// failed migration is retried on the next launch. Migrations that write
-    /// external stores (Migration_9_To_10 creating data/music/settings.json)
-    /// depend on this - stamping the version past a failed file write would
-    /// strand the user's data in the legacy fields forever.
+    /// schema version up to <see cref="CurrentSchemaVersion"/>. Migrations
+    /// advance one exact step at a time; a migration that throws OR a gap in
+    /// the registered steps (a step removed/never added) stops the pipeline:
+    /// the schema version stays at the last successful step (never stamped
+    /// past a failed or missing step) so the failed migration is retried on
+    /// the next launch and the registry gap is visible in the log instead of
+    /// silently skipping a step. Migrations that write external stores
+    /// (Migration_9_To_10 creating data/music/settings.json) depend on this.
     /// Returns true if any migration was applied.
     /// </summary>
     public bool RunMigrations(AppSettings settings)
@@ -74,25 +75,48 @@ public sealed class SettingsMigrationPipeline
 
         foreach (var migration in _migrations.OrderBy(m => m.FromVersion))
         {
-            if (migration.FromVersion >= version && migration.FromVersion < CurrentSchemaVersion)
+            if (version >= CurrentSchemaVersion)
             {
-                try
-                {
-                    migration.Migrate(settings);
-                }
-                catch (Exception ex)
-                {
-                    App.Log(
-                        $"[SettingsMigration] Migration from version {migration.FromVersion} FAILED " +
-                        $"and will retry on next launch: {ex.Message}");
-                    settings.SchemaVersion = version;
-                    return anyApplied;
-                }
-
-                version = migration.FromVersion + 1;
-                anyApplied = true;
-                App.Log($"[SettingsMigration] Applied migration from version {migration.FromVersion} to {version}");
+                break;
             }
+
+            if (migration.FromVersion < version)
+            {
+                // Applied on an earlier launch; skip.
+                continue;
+            }
+
+            if (migration.FromVersion > version)
+            {
+                // Registry gap: a step is missing (removed or never added).
+                // The old >= comparison would have run later steps here,
+                // silently skipping the missing one. Stop exactly like a
+                // failing migration - the version stays put and the
+                // misconfigured registry becomes visible in the log.
+                App.Log(
+                    $"[SettingsMigration] Migration registry GAP at version {version}: " +
+                    $"the next registered step starts at {migration.FromVersion}. " +
+                    "Stopping so no migration is silently skipped.");
+                settings.SchemaVersion = version;
+                return anyApplied;
+            }
+
+            try
+            {
+                migration.Migrate(settings);
+            }
+            catch (Exception ex)
+            {
+                App.Log(
+                    $"[SettingsMigration] Migration from version {migration.FromVersion} FAILED " +
+                    $"and will retry on next launch: {ex.Message}");
+                settings.SchemaVersion = version;
+                return anyApplied;
+            }
+
+            version = migration.FromVersion + 1;
+            anyApplied = true;
+            App.Log($"[SettingsMigration] Applied migration from version {migration.FromVersion} to {version}");
         }
 
         settings.SchemaVersion = CurrentSchemaVersion;

--- a/tests/DeskBox.Tests/MusicSettingsStoreTests.cs
+++ b/tests/DeskBox.Tests/MusicSettingsStoreTests.cs
@@ -215,6 +215,39 @@ public sealed class MusicSettingsStoreTests : IDisposable
     }
 
     [Fact]
+    public void Pipeline_StopsWhenARegistryGapIsDetected()
+    {
+        // Registry missing the 6->7 step: the old >= comparison ran 7->8
+        // directly and silently skipped it; exact-step matching must stop.
+        var settings = new AppSettings { SchemaVersion = 5 };
+
+        bool applied = new SettingsMigrationPipeline(
+        [
+            new FakeMigration(5, succeeded: true),
+            new FakeMigration(7, succeeded: true)
+        ]).RunMigrations(settings);
+
+        Assert.True(applied);
+        Assert.Equal(6, settings.SchemaVersion);
+    }
+
+    [Fact]
+    public void Pipeline_NeverRunsStepsBeyondTheCurrentVersion()
+    {
+        // A step registered for a future schema version must never execute.
+        var settings = new AppSettings { SchemaVersion = 9 };
+
+        bool applied = new SettingsMigrationPipeline(
+        [
+            new FakeMigration(9, succeeded: true),
+            new FakeMigration(10, succeeded: true)
+        ]).RunMigrations(settings);
+
+        Assert.True(applied);
+        Assert.Equal(SettingsMigrationPipeline.CurrentSchemaVersion, settings.SchemaVersion);
+    }
+
+    [Fact]
     public void Migration_9_To_10_PropagatesExternalWriteFailures()
     {
         string dataDirectory = Path.Combine(_tempRoot, "blocked-data");
@@ -281,6 +314,12 @@ public sealed class MusicSettingsStoreTests : IDisposable
         // fire-and-forget task.
         Assert.Contains("EnqueuePersist(Clone(_cached));", storeSource, StringComparison.Ordinal);
         Assert.DoesNotContain("_ = PersistAsync(", storeSource, StringComparison.Ordinal);
+
+        // Round 5: Current is explicitly transitional (static service
+        // locator, not the final per-kind store model) so the pattern is
+        // not copied to Weather/Todo/QuickCapture stores.
+        Assert.Contains("LIFECYCLE NOTE", storeSource, StringComparison.Ordinal);
+        Assert.Contains("do not copy", storeSource, StringComparison.Ordinal);
 
         // Migration: synchronous failure-propagating write, never a blocking
         // wait on an async continuation (UI-thread startup deadlock).

--- a/tests/DeskBox.Tests/PluginSchemaContractTests.cs
+++ b/tests/DeskBox.Tests/PluginSchemaContractTests.cs
@@ -141,14 +141,16 @@ public sealed class PluginSchemaContractTests
 
         // v0.2: a fingerprint alone cannot verify an Ed25519 signature; the
         // pre-account package carries the public key itself and the
-        // publisher field must equal sha256(publisherPublicKey).
+        // publisher field must equal the fingerprint of the RAW key bytes.
         Assert.Contains(
             "publisherPublicKey",
             required.EnumerateArray().Select(v => v.GetString()));
 
         string schemaText = File.ReadAllText(
             TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json"));
-        Assert.Contains("sha256(publisherPublicKey)", schemaText, StringComparison.Ordinal);
+        Assert.Contains("sha256(raw key bytes)", schemaText, StringComparison.Ordinal);
+        Assert.Contains("raw 32-byte", schemaText, StringComparison.Ordinal);
+        Assert.Contains("lowercase hex", schemaText, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -167,6 +169,14 @@ public sealed class PluginSchemaContractTests
         Assert.Contains("RFC 8785", notes, StringComparison.Ordinal);
         Assert.Contains("package.integrity", notes, StringComparison.Ordinal);
         Assert.Contains("publisherPublicKey", notes, StringComparison.Ordinal);
+
+        // Round 5: the integrity manifest never lists itself (self-reference
+        // has no fixed point; its integrity is covered transitively), and
+        // hash/signature inputs are pinned to raw bytes so three independent
+        // implementations cannot each pick a different reading.
+        Assert.Contains("NEVER listed", schemaText, StringComparison.Ordinal);
+        Assert.Contains("永不列入", notes, StringComparison.Ordinal);
+        Assert.Contains("raw 32 字节", notes, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
fix: round-5 hardening - migration gap detection + schema encoding pins

Fifth review round confirmed the #245/#246/#247 direction (9.2/10, clear
to enter stage 3b) and asked for three small items before wiring; all
three land here.

1. Migration pipeline exact-step + gap detection: the registered steps
   now advance one exact version at a time. The old
   `FromVersion >= version` comparison would have silently skipped a
   missing step if a migration is ever removed or never added (registry
   gap) and run later steps directly; a gap now stops the pipeline exactly
   like a failing migration - the schema version stays at the gap and the
   log names it. Steps registered beyond CurrentSchemaVersion (future
   steps) can never execute. The production registry is contiguous today,
   so this is future-regression hardening, not a behavior change.

2. Schema v0.2 encoding pins (the three-implementation divergence trap):
   - package.integrity is NEVER listed inside package.integrity - listing
     itself has no fixed point; its own integrity is covered transitively
     (contentHash hashes it, the publisher signature covers contentHash).
   - The publisher fingerprint is SHA-256 of the RAW 32-byte Ed25519
     public key (base64-decode first, then hash the bytes - not the base64
     text), stored as lowercase hex.
   - publisherSignature signs the RAW 32-byte contentHash digest, not the
     hex string.
   Pinned in both the schema descriptions and the notes walkthrough, so
   the future TS CLI, C# installer, and Rust runtime cannot each pick a
   different reading.

3. MusicSettingsStore.Current is transitional: a LIFECYCLE note on the
   class states it is a static service locator (the minimal fix for the
   two-instance stale-cache regression), NOT the final per-kind store
   model - do not copy it to Weather/Todo/QuickCapture; the final form is
   a context-injected singleton once features have their own context.
   Roadmap 16.9 records this plus the stage 3b acceptance restated by the
   review: callers (App/QuickCapture/Todo) no longer knowing
   TodoWidgetContent/FileSurfaceContent/WidgetManager dictionaries/
   App.Current services - not "lines removed from FeatureWidgets.cs" -
   and IFileWidgetImportTarget cancellation must be honored for real
   (streaming CopyToAsync(token), not a start-only token check).

Tests: +2 pipeline semantics (gap stop, never-run-beyond-current),
publisher fingerprint assertions moved to the pinned raw-bytes wording,
integrity self-exclusion + raw-byte pins in schema/notes, LIFECYCLE note
pinned on the store. 3410/3410 green x64. Canonical Debug rebuilt and
restarted (pid 13504).
