### PR TITLE
feat: stage 3b dependency-inversion wiring across the three cut points

### DIFF
--- a/docs/architecture/pluginization-roadmap.md
+++ b/docs/architecture/pluginization-roadmap.md
@@ -3,7 +3,7 @@
 - 方案日期：2026-09-07；v1.1-v1.5（评审收敛+复盘修订）；v1.6/v1.7（评审纪律入册）；v1.8（第四轮评审吸收，§16.7/16.8）
 - 代码基线：main `2709d7f0`（阶段 3a 能力端口合入）；第四轮评审修复批次=PR #245（store 一致性+迁移事务性）/#246（schema v0.2）/#247（端口语义修正）
 - 评审记录：§12（v1.0→v1.1）、§13（v1.1→v1.2）、§16（v1.5-v1.8）
-- 当前状态：**阶段 3b（依赖倒置接线）准备中**——已落地的是 host 内部能力端口（capability ports），**不是 Capability Broker**（registry/权限判定/调度/审计/运行时 adapter 均未开始）；进度自述基准见 §16.8 末
+- 当前状态：**阶段 3b（依赖倒置接线）已落地**——三切点调用方（App 两处 Todo 路径/QuickCapture 三处落盘/App 回调 switch）全部改走 `DeskBox.Contracts` 端口，WidgetManager 就地实现三接口，功能行为零变化；物理搬移（3c）按依赖集观察后置。已落地的是 host 内部能力端口（capability ports），**不是 Capability Broker**（registry/权限判定/调度/审计/运行时 adapter 均未开始）
 
 ---
 
@@ -430,6 +430,8 @@ P0：§6 重写为 Runtime 矩阵（删除 A→B→C 旧结论，与 §14 唯一
 3. **`MusicSettingsStore.Current` 过渡性声明**：Current 是修复双实例缓存回归的最小改动=static service locator，**不是 per-kind store 最终形态**；Weather/Todo/QuickCapture store 不复制 static Current，Feature 拥有 context 时改为 context 注入单例（store 类头已加 LIFECYCLE 注释）。
 
 **3b 验收标准（评审改述采纳）**：不是"FeatureWidgets.cs 少多少行"，而是**调用方（App/QuickCapture/Todo）不再知道 TodoWidgetContent/FileSurfaceContent/WidgetManager 内部字典/App.Current 服务**，只依赖能力端口；观察实现真实依赖集，需要十几个 internal getter 才能搬=不该搬，留在 WidgetManager 经接口暴露。**3b 实现注意：IFileWidgetImportTarget 的取消要真兑现**（File.Copy/Task.Run 改 FileStream.CopyToAsync(token)，不是开始前查一次 token）。
+
+**2026-09-07 3b 接线完工（同日）**：WidgetManager 声明实现三端口；切点 1=`PresentReminderTargetAsync` 包装现有流程+富诊断日志（HWND/Visible/XamlRoot）移入实现侧、App 两处调用改走 `TodoReminderPresenter` 端口属性；切点 2=QuickCapture 的 item→file 翻译（命名/.url 格式）归 `QuickCaptureService.BuildFileImportPlan`（生产者自有知识），File-widget 内部（目标校验/文件夹解析/写入+取消/刷新+Reveal）归 `TryImportFileAsync/TryImportTextAsync`（流式 CopyToAsync 真兑现取消），`QuickCaptureFileWidgetTarget`→`FileWidgetImportTarget` 移入 Contracts，Menus 三处改走 `App.Current.FileWidgetImport`；切点 3=`SetFeatureWidgetEnabledState` 的 App.Current switch 替换为 `FeatureStateChanged` 事件（按订阅者异常隔离 raise，UI 线程），App 侧 `OnFeatureStateChanged` 自持三个服务刷新。行为测试迁移至端口路径+新增接线契约测试与 plan 边界测试。
 
 ## 附录 A：关键证据文件索引
 

--- a/src/DeskBox/App.xaml.cs
+++ b/src/DeskBox/App.xaml.cs
@@ -1,6 +1,7 @@
 // Copyright (c) DeskBox. All rights reserved.
 
 using CommunityToolkit.Mvvm.Input;
+using DeskBox.Contracts;
 using DeskBox.Controls.WidgetContents;
 using DeskBox.Helpers;
 using DeskBox.Models;
@@ -154,6 +155,15 @@ public partial class App : Application
         _everythingSearchService?.CurrentSnapshot.State == EverythingConnectionState.Connected;
     internal int SearchMetaCacheCount => _fileMetaService?.CachedIconCount ?? 0;
     public WidgetManager? WidgetManager { get; private set; }
+
+    /// <summary>
+    /// Stage 3b capability-port views of the widget manager: callers depend
+    /// on these port types instead of the concrete manager (pluginization
+    /// roadmap stage 3, wire-first).
+    /// </summary>
+    public ITodoReminderPresenter? TodoReminderPresenter => WidgetManager;
+    public IFileWidgetImportTarget? FileWidgetImport => WidgetManager;
+
     public ResizeGuideOverlayService ResizeGuideOverlay { get; private set; } = null!;
     public NativeAppNotificationService? NativeNotificationService => _nativeNotificationService;
     public DisplayAreaWatcherService? DisplayAreaWatcher => _displayAreaWatcher;
@@ -949,6 +959,11 @@ public partial class App : Application
 
             WidgetManager = new WidgetManager(SettingsService, FileService, OrganizerService, themeService, quickCaptureService, localizationService);
             WidgetManager.TrayLayerStateChanged += UpdateTrayLayerStateText;
+            // Stage 3b, cut point 3: the App owns its services and reacts to
+            // feature enable-state changes through the port event instead of
+            // the manager reaching back into App.Current (host-lifetime
+            // subscription; the manager is created exactly once).
+            WidgetManager.FeatureStateChanged += OnFeatureStateChanged;
             DesktopDoubleClickActivationService = new DesktopDoubleClickActivationService(
                 SettingsService,
                 ToggleWidgetsFromDesktopDoubleClickAsync);
@@ -1635,22 +1650,15 @@ public partial class App : Application
         string? itemId = null,
         bool preferTodayFilter = false)
     {
-        if (WidgetManager is null)
+        if (TodoReminderPresenter is not { } presenter)
         {
             return false;
         }
 
-        TodoReminderTargetPresentationResult presentation =
-            await WidgetManager.ShowTodoReminderTargetAsync(
-                widgetId,
-                itemId,
-                preferTodayFilter);
-        Log(
-            $"[Notification] Todo target presentation widget={presentation.WidgetId} " +
-            $"item={presentation.ItemId ?? "none"} hwnd={presentation.WindowHandle} " +
-            $"visible={presentation.Visible} xamlRoot={presentation.HasXamlRoot} " +
-            $"itemPresented={presentation.ItemPresented} " +
-            $"targetPresented={presentation.TargetPresented}");
+        TodoReminderPresentationResult presentation = await presenter.PresentReminderTargetAsync(
+            widgetId,
+            itemId,
+            preferTodayFilter);
         return presentation.TargetPresented;
     }
 
@@ -4349,6 +4357,27 @@ public partial class App : Application
         return _searchEngineService;
     }
 
+    /// <summary>
+    /// Stage 3b, cut point 3: reacts to feature enable-state changes raised
+    /// through IFeatureStateEvents. Mirrors the service refreshes that the
+    /// WidgetManager used to call directly via App.Current.
+    /// </summary>
+    private void OnFeatureStateChanged(FeatureStateChangedEventArgs e)
+    {
+        if (e.FeatureId == DeskBoxFeatureIds.Search)
+        {
+            SetSearchFeatureEnabled(e.Enabled);
+        }
+        else if (e.FeatureId == DeskBoxFeatureIds.QuickCapture)
+        {
+            RefreshQuickCaptureClipboardService();
+        }
+        else if (e.FeatureId == DeskBoxFeatureIds.Todo)
+        {
+            RefreshTodoReminderService();
+        }
+    }
+
     internal void SetSearchFeatureEnabled(bool enabled)
     {
         if (!UiDispatcherQueue.HasThreadAccess)
@@ -4559,7 +4588,7 @@ public partial class App : Application
 
     private async Task HandleSearchContentAsync(Models.SearchResultItem item)
     {
-        if (WidgetManager is null)
+        if (WidgetManager is null || TodoReminderPresenter is not { } presenter)
         {
             return;
         }
@@ -4567,7 +4596,7 @@ public partial class App : Application
         switch (item.Kind)
         {
             case Models.SearchResultKind.Todo:
-                await WidgetManager.ShowTodoReminderTargetAsync(
+                await presenter.PresentReminderTargetAsync(
                     item.TodoWidgetId,
                     item.TodoItemId,
                     preferTodayFilter: false);

--- a/src/DeskBox/Contracts/IFileWidgetImportTarget.cs
+++ b/src/DeskBox/Contracts/IFileWidgetImportTarget.cs
@@ -21,10 +21,23 @@ namespace DeskBox.Contracts;
 public interface IFileWidgetImportTarget
 {
     /// <summary>
+    /// Lists the file widgets that are valid import targets right now
+    /// (enabled, not deleted, with a resolvable writable backing folder).
+    /// </summary>
+    IReadOnlyList<FileWidgetImportTarget> GetImportTargets();
+
+    /// <summary>
+    /// The most recently used import target, or null when none was used yet
+    /// or the stored target is no longer valid.
+    /// </summary>
+    FileWidgetImportTarget? GetLastImportTarget();
+
+    /// <summary>
     /// Imports a file already materialized on disk into the target file
     /// widget's backing folder. Returns the destination path, or null when
     /// the target is invalid, disabled, or the folder is not accessible.
-    /// Implementations honor cancellation for large transfers.
+    /// Implementations honor cancellation for large transfers (streaming
+    /// copy, not a start-only token check).
     /// </summary>
     Task<string?> TryImportFileAsync(
         string sourceFilePath,
@@ -42,3 +55,9 @@ public interface IFileWidgetImportTarget
         string targetWidgetId,
         CancellationToken cancellationToken = default);
 }
+
+/// <summary>An importable file widget: id, display name, backing folder.</summary>
+public sealed record FileWidgetImportTarget(
+    string WidgetId,
+    string Name,
+    string FolderPath);

--- a/src/DeskBox/Contracts/README.md
+++ b/src/DeskBox/Contracts/README.md
@@ -16,7 +16,8 @@
 ## 接线顺序（v1.8 修订：先接线，后搬移）
 
 1. `WidgetManager` 就地实现/委托这三个接口，App 与功能调用方全部改成只
-   依赖接口——**功能行为必须零变化**。
+   依赖接口——**功能行为必须零变化**。**（3b 已完成：App 两处 Todo 路径、
+   QuickCapture 三处落盘、App 回调 switch 全部改走端口。）**
 2. 依赖集稳定后（adapter 只需少量稳定宿主能力）再决定是否物理搬移实现。
    若搬移需要给 `WidgetManager` 暴露一批 internal getter/dictionary，就先
    不搬——那只是把 God Class 变成 God Class + friend class。

--- a/src/DeskBox/Services/QuickCaptureService.cs
+++ b/src/DeskBox/Services/QuickCaptureService.cs
@@ -25,6 +25,19 @@ public sealed record QuickCaptureWriteResult(
     bool WasTruncated,
     QuickCaptureItem? Item);
 
+/// <summary>
+/// Producer-side translation of a captured item into a file-widget import
+/// (pluginization roadmap stage 3b, cut point 2): QuickCapture owns its
+/// item types, naming, and the .url InternetShortcut format; the
+/// File-widget import port owns folders and writes. Exactly one of
+/// SourceFilePath / Text is set; BuildFileImportPlan returns null when the
+/// item has nothing importable (missing image file, empty body).
+/// </summary>
+internal sealed record QuickCaptureFileImportPlan(
+    string? SourceFilePath,
+    string? Text,
+    string FileName);
+
 public sealed class QuickCaptureService
 {
     public const int DefaultRecentLimit = 30;
@@ -1830,6 +1843,98 @@ public sealed class QuickCaptureService
 
         string extension = NormalizeImageExtension(sourceImagePath);
         return $"{prefix} {timestamp.ToLocalTime():yyyy-MM-dd HH-mm-ss}{extension}";
+    }
+
+    /// <summary>
+    /// Producer-side translation of a captured item into a file-widget
+    /// import (pluginization roadmap stage 3b, cut point 2): QuickCapture
+    /// owns its item types, naming, and the .url InternetShortcut format;
+    /// the File-widget import port owns folders and writes. Exactly one of
+    /// SourceFilePath / Text is set. BuildFileImportPlan returns null when
+    /// the item has nothing importable (missing image file, empty body).
+    /// </summary>
+    internal static QuickCaptureFileImportPlan? BuildFileImportPlan(
+        QuickCaptureItem item,
+        string? imageFileNamePrefix,
+        string? textFileNamePrefix,
+        string? linkFileNamePrefix)
+    {
+        switch (item.Type)
+        {
+            case QuickCaptureItemType.Image:
+                if (string.IsNullOrWhiteSpace(item.ImagePath) || !File.Exists(item.ImagePath))
+                {
+                    return null;
+                }
+
+                return new QuickCaptureFileImportPlan(
+                    item.ImagePath,
+                    Text: null,
+                    BuildImageExportFileName(
+                        imageFileNamePrefix,
+                        item.UpdatedAt == default ? item.CreatedAt : item.UpdatedAt,
+                        item.ImagePath));
+
+            case QuickCaptureItemType.Link:
+                string url = string.IsNullOrWhiteSpace(item.Url)
+                    ? item.Body?.Trim() ?? string.Empty
+                    : item.Url.Trim();
+                if (Uri.TryCreate(url, UriKind.Absolute, out Uri? uri))
+                {
+                    string baseText = string.IsNullOrWhiteSpace(uri.Host) ? uri.AbsoluteUri : uri.Host;
+                    return new QuickCaptureFileImportPlan(
+                        SourceFilePath: null,
+                        Text: $"[InternetShortcut]{Environment.NewLine}URL={uri.AbsoluteUri}{Environment.NewLine}",
+                        BuildQuickCaptureContentFileName(baseText, linkFileNamePrefix, ".url"));
+                }
+
+                return BuildTextImportPlan(item, textFileNamePrefix);
+
+            default:
+                return BuildTextImportPlan(item, textFileNamePrefix);
+        }
+    }
+
+    private static QuickCaptureFileImportPlan? BuildTextImportPlan(
+        QuickCaptureItem item,
+        string? textFileNamePrefix)
+    {
+        string body = item.Body?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return null;
+        }
+
+        return new QuickCaptureFileImportPlan(
+            SourceFilePath: null,
+            Text: body,
+            BuildQuickCaptureContentFileName(body, textFileNamePrefix, ".txt"));
+    }
+
+    private static string BuildQuickCaptureContentFileName(string? body, string? fallbackName, string extension)
+    {
+        string firstLine = body?
+            .Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault() ?? string.Empty;
+        string baseName = FileService.SanitizeFileSystemName(firstLine);
+        if (baseName.Length > 36)
+        {
+            baseName = baseName[..36].Trim().TrimEnd('.');
+        }
+
+        if (string.IsNullOrWhiteSpace(baseName))
+        {
+            baseName = FileService.SanitizeFileSystemName(fallbackName);
+        }
+
+        if (string.IsNullOrWhiteSpace(baseName))
+        {
+            baseName = "Quick Capture";
+        }
+
+        return baseName.EndsWith(extension, StringComparison.OrdinalIgnoreCase)
+            ? baseName
+            : baseName + extension;
     }
 
     private void CleanupOldExportFiles()

--- a/src/DeskBox/Services/WidgetManager.FeatureWidgets.cs
+++ b/src/DeskBox/Services/WidgetManager.FeatureWidgets.cs
@@ -1,5 +1,6 @@
 ﻿﻿// Copyright (c) DeskBox. All rights reserved.
 
+using DeskBox.Contracts;
 using DeskBox.Models;
 using DeskBox.Helpers;
 using DeskBox.Controls.WidgetContents;
@@ -193,6 +194,32 @@ public sealed partial class WidgetManager
         {
             App.Log($"[WidgetManager] Failed to seed Todo guide: {ex}");
         }
+    }
+
+    /// <summary>
+    /// ITodoReminderPresenter implementation (stage 3b, cut point 1).
+    /// Delegates to the existing reminder-target flow and keeps the
+    /// host-specific diagnostics (window handle, visibility, XamlRoot
+    /// commit state) in the adapter's logging; port consumers see the
+    /// end-to-end TargetPresented success signal only.
+    /// </summary>
+    public async Task<TodoReminderPresentationResult> PresentReminderTargetAsync(
+        string? widgetId,
+        string? itemId,
+        bool preferTodayFilter)
+    {
+        TodoReminderTargetPresentationResult presentation =
+            await ShowTodoReminderTargetAsync(widgetId, itemId, preferTodayFilter);
+        App.Log(
+            $"[Notification] Todo target presentation widget={presentation.WidgetId} " +
+            $"item={presentation.ItemId ?? "none"} hwnd={presentation.WindowHandle} " +
+            $"visible={presentation.Visible} xamlRoot={presentation.HasXamlRoot} " +
+            $"itemPresented={presentation.ItemPresented} " +
+            $"targetPresented={presentation.TargetPresented}");
+        return new TodoReminderPresentationResult(
+            presentation.WidgetId,
+            presentation.ItemPresented,
+            presentation.TargetPresented);
     }
 
     internal async Task<TodoReminderTargetPresentationResult> ShowTodoReminderTargetAsync(
@@ -643,7 +670,7 @@ public sealed partial class WidgetManager
         }
     }
 
-    public IReadOnlyList<QuickCaptureFileWidgetTarget> GetQuickCaptureFileWidgetTargets()
+    public IReadOnlyList<FileWidgetImportTarget> GetImportTargets()
     {
         return _settingsService.Settings.Widgets
             .Where(widget => widget.WidgetKind == WidgetKind.File &&
@@ -653,12 +680,12 @@ public sealed partial class WidgetManager
             .Select(widget =>
             {
                 TryGetFileWidgetFolderPath(widget, out string folderPath);
-                return new QuickCaptureFileWidgetTarget(widget.Id, widget.Name, folderPath);
+                return new FileWidgetImportTarget(widget.Id, widget.Name, folderPath);
             })
             .ToList();
     }
 
-    public QuickCaptureFileWidgetTarget? GetLastQuickCaptureFileWidgetTarget()
+    public FileWidgetImportTarget? GetLastImportTarget()
     {
         string lastTargetId = _settingsService.Settings.LastQuickCaptureFileWidgetId;
         if (string.IsNullOrWhiteSpace(lastTargetId))
@@ -666,57 +693,100 @@ public sealed partial class WidgetManager
             return null;
         }
 
-        return GetQuickCaptureFileWidgetTargets()
+        return GetImportTargets()
             .FirstOrDefault(target => string.Equals(target.WidgetId, lastTargetId, StringComparison.Ordinal));
     }
 
-    public async Task<string?> SaveQuickCaptureItemToFileWidgetAsync(
-        QuickCaptureItem item,
+    /// <summary>
+    /// IFileWidgetImportTarget implementation (stage 3b, cut point 2). The
+    /// QuickCapture-specific item-to-file translation (naming, .url
+    /// InternetShortcut format, content-derived names) lives on the
+    /// producer side (QuickCaptureService.BuildFileImportPlan); this side
+    /// owns the File-widget internals: target validation, folder
+    /// resolution, the write itself, and the post-import refresh/reveal.
+    /// </summary>
+    public async Task<string?> TryImportFileAsync(
+        string sourceFilePath,
         string targetWidgetId,
-        string? imageFileNamePrefix = null)
+        string? preferredFileName = null,
+        CancellationToken cancellationToken = default)
     {
-        if (item.IsDeleted ||
-            string.IsNullOrWhiteSpace(targetWidgetId) ||
-            FindConfig(targetWidgetId) is not { } targetConfig ||
-            targetConfig.WidgetKind != WidgetKind.File ||
-            targetConfig.IsDisabled ||
-            IsDeleted(targetWidgetId) ||
-            !TryGetFileWidgetFolderPath(targetConfig, out string targetFolderPath))
+        if (!TryResolveImportTarget(targetWidgetId, out string targetFolderPath))
         {
             return null;
         }
 
         Directory.CreateDirectory(targetFolderPath);
-        string? destinationPath = item.Type switch
+        string fileName = string.IsNullOrWhiteSpace(preferredFileName)
+            ? Path.GetFileName(sourceFilePath)
+            : preferredFileName;
+        string destinationPath = FileService.GetAvailablePath(Path.Combine(targetFolderPath, fileName));
+        await using (FileStream source = File.OpenRead(sourceFilePath))
+        await using (FileStream destination = File.Create(destinationPath))
         {
-            QuickCaptureItemType.Image => await SaveQuickCaptureImageToFolderAsync(item, targetFolderPath, imageFileNamePrefix),
-            QuickCaptureItemType.Link => await SaveQuickCaptureLinkToFolderAsync(item, targetFolderPath),
-            _ => await SaveQuickCaptureTextToFolderAsync(item, targetFolderPath)
-        };
+            // Streaming copy so cancellation is honored mid-transfer, unlike
+            // File.Copy/Task.Run (round-5 review requirement).
+            await source.CopyToAsync(destination, cancellationToken);
+        }
 
-        if (!string.IsNullOrWhiteSpace(destinationPath))
+        return await FinalizeImportAsync(targetWidgetId, destinationPath);
+    }
+
+    public async Task<string?> TryImportTextAsync(
+        string text,
+        string fileName,
+        string targetWidgetId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(text) || string.IsNullOrWhiteSpace(fileName))
         {
-            RememberLastQuickCaptureFileWidgetTarget(targetWidgetId);
-            if (_fileWidgets.TryGetValue(targetWidgetId, out var targetEntry))
+            return null;
+        }
+
+        if (!TryResolveImportTarget(targetWidgetId, out string targetFolderPath))
+        {
+            return null;
+        }
+
+        Directory.CreateDirectory(targetFolderPath);
+        string destinationPath = FileService.GetAvailablePath(Path.Combine(targetFolderPath, fileName));
+        await File.WriteAllTextAsync(destinationPath, text, cancellationToken);
+        return await FinalizeImportAsync(targetWidgetId, destinationPath);
+    }
+
+    private bool TryResolveImportTarget(string targetWidgetId, out string targetFolderPath)
+    {
+        targetFolderPath = string.Empty;
+        return !string.IsNullOrWhiteSpace(targetWidgetId) &&
+               FindConfig(targetWidgetId) is { } targetConfig &&
+               targetConfig.WidgetKind == WidgetKind.File &&
+               !targetConfig.IsDisabled &&
+               !IsDeleted(targetWidgetId) &&
+               TryGetFileWidgetFolderPath(targetConfig, out targetFolderPath);
+    }
+
+    private async Task<string?> FinalizeImportAsync(string targetWidgetId, string destinationPath)
+    {
+        RememberLastQuickCaptureFileWidgetTarget(targetWidgetId);
+        if (_fileWidgets.TryGetValue(targetWidgetId, out var targetEntry))
+        {
+            await targetEntry.ViewModel.RefreshFromConfigAsync();
+            targetEntry.RevealSavedItem(destinationPath);
+        }
+        else
+        {
+            ContentWidgetWindow? contentWindow = _contentWidgets.Values
+                .Distinct()
+                .FirstOrDefault(window =>
+                    window.CurrentContent is FileSurfaceContent surface &&
+                    string.Equals(
+                        surface.WidgetId,
+                        targetWidgetId,
+                        StringComparison.Ordinal));
+            if (contentWindow?.CurrentContent is FileSurfaceContent fileSurface)
             {
-                await targetEntry.ViewModel.RefreshFromConfigAsync();
-                targetEntry.RevealSavedItem(destinationPath);
-            }
-            else
-            {
-                ContentWidgetWindow? contentWindow = _contentWidgets.Values
-                    .Distinct()
-                    .FirstOrDefault(window =>
-                        window.CurrentContent is FileSurfaceContent surface &&
-                        string.Equals(
-                            surface.WidgetId,
-                            targetWidgetId,
-                            StringComparison.Ordinal));
-                if (contentWindow?.CurrentContent is FileSurfaceContent fileSurface)
-                {
-                    await fileSurface.ViewModel.RefreshFromConfigAsync();
-                    fileSurface.RevealSavedItem(destinationPath);
-                }
+                await fileSurface.ViewModel.RefreshFromConfigAsync();
+                fileSurface.RevealSavedItem(destinationPath);
             }
         }
 
@@ -732,86 +802,6 @@ public sealed partial class WidgetManager
 
         _settingsService.Settings.LastQuickCaptureFileWidgetId = widgetId;
         _settingsService.SaveDebounced(notifySubscribers: false);
-    }
-
-    private async Task<string?> SaveQuickCaptureImageToFolderAsync(
-        QuickCaptureItem item,
-        string targetFolderPath,
-        string? imageFileNamePrefix)
-    {
-        if (string.IsNullOrWhiteSpace(item.ImagePath) || !File.Exists(item.ImagePath))
-        {
-            return null;
-        }
-
-        string fileName = QuickCaptureService.BuildImageExportFileName(
-            imageFileNamePrefix,
-            item.UpdatedAt == default ? item.CreatedAt : item.UpdatedAt,
-            item.ImagePath);
-        string destinationPath = FileService.GetAvailablePath(Path.Combine(targetFolderPath, fileName));
-        await Task.Run(() => File.Copy(item.ImagePath, destinationPath));
-        return destinationPath;
-    }
-
-    private async Task<string?> SaveQuickCaptureTextToFolderAsync(QuickCaptureItem item, string targetFolderPath)
-    {
-        string body = item.Body?.Trim() ?? string.Empty;
-        if (string.IsNullOrWhiteSpace(body))
-        {
-            return null;
-        }
-
-        string fileName = BuildQuickCaptureContentFileName(
-            body,
-            _localizationService.T("QuickCapture.TextFileNamePrefix"),
-            ".txt");
-        string destinationPath = FileService.GetAvailablePath(Path.Combine(targetFolderPath, fileName));
-        await File.WriteAllTextAsync(destinationPath, body);
-        return destinationPath;
-    }
-
-    private async Task<string?> SaveQuickCaptureLinkToFolderAsync(QuickCaptureItem item, string targetFolderPath)
-    {
-        string url = string.IsNullOrWhiteSpace(item.Url) ? item.Body?.Trim() ?? string.Empty : item.Url.Trim();
-        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
-        {
-            return await SaveQuickCaptureTextToFolderAsync(item, targetFolderPath);
-        }
-
-        string baseText = string.IsNullOrWhiteSpace(uri.Host) ? uri.AbsoluteUri : uri.Host;
-        string fileName = BuildQuickCaptureContentFileName(
-            baseText,
-            _localizationService.T("QuickCapture.LinkFileNamePrefix"),
-            ".url");
-        string destinationPath = FileService.GetAvailablePath(Path.Combine(targetFolderPath, fileName));
-        await File.WriteAllTextAsync(destinationPath, $"[InternetShortcut]{Environment.NewLine}URL={uri.AbsoluteUri}{Environment.NewLine}");
-        return destinationPath;
-    }
-
-    private static string BuildQuickCaptureContentFileName(string? body, string fallbackName, string extension)
-    {
-        string firstLine = body?
-            .Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .FirstOrDefault() ?? string.Empty;
-        string baseName = FileService.SanitizeFileSystemName(firstLine);
-        if (baseName.Length > 36)
-        {
-            baseName = baseName[..36].Trim().TrimEnd('.');
-        }
-
-        if (string.IsNullOrWhiteSpace(baseName))
-        {
-            baseName = FileService.SanitizeFileSystemName(fallbackName);
-        }
-
-        if (string.IsNullOrWhiteSpace(baseName))
-        {
-            baseName = "Quick Capture";
-        }
-
-        return baseName.EndsWith(extension, StringComparison.OrdinalIgnoreCase)
-            ? baseName
-            : baseName + extension;
     }
 
     private bool TryGetFileWidgetFolderPath(WidgetConfig widget, out string folderPath)
@@ -1326,21 +1316,57 @@ public sealed partial class WidgetManager
         return FeatureWidgetSettings.IsFeatureWidget(kind);
     }
 
+    /// <summary>
+    /// IFeatureStateEvents implementation (stage 3b, cut point 3): instead
+    /// of a hardcoded switch calling App.Current service refreshers, the
+    /// state change is raised as an event and the App-side subscriber owns
+    /// its services. Per-subscriber exception isolation keeps one failing
+    /// listener from breaking the others (contract pinned in the port).
+    /// </summary>
+    public event Action<FeatureStateChangedEventArgs>? FeatureStateChanged;
+
     private void SetFeatureWidgetEnabledState(WidgetKind kind, bool enabled)
     {
         FeatureWidgetSettings.SetEnabled(_settingsService.Settings, kind, enabled);
         _lastFeatureWidgetEnabledStates[kind] = enabled;
-        switch (kind)
+        if (TryGetFeatureId(kind) is { } featureId)
         {
-            case WidgetKind.Search:
-                App.Current.SetSearchFeatureEnabled(enabled);
-                break;
-            case WidgetKind.QuickCapture:
-                App.Current.RefreshQuickCaptureClipboardService();
-                break;
-            case WidgetKind.Todo:
-                App.Current.RefreshTodoReminderService();
-                break;
+            RaiseFeatureStateChanged(featureId, enabled);
+        }
+    }
+
+    private static FeatureId? TryGetFeatureId(WidgetKind kind) => kind switch
+    {
+        WidgetKind.Search => DeskBoxFeatureIds.Search,
+        WidgetKind.QuickCapture => DeskBoxFeatureIds.QuickCapture,
+        WidgetKind.Todo => DeskBoxFeatureIds.Todo,
+        WidgetKind.Music => DeskBoxFeatureIds.Music,
+        WidgetKind.Weather => DeskBoxFeatureIds.Weather,
+        WidgetKind.Glance => DeskBoxFeatureIds.Glance,
+        _ => null
+    };
+
+    private void RaiseFeatureStateChanged(FeatureId featureId, bool enabled)
+    {
+        if (FeatureStateChanged is null)
+        {
+            return;
+        }
+
+        var args = new FeatureStateChangedEventArgs(featureId, enabled);
+        foreach (Action<FeatureStateChangedEventArgs> handler in
+                 FeatureStateChanged.GetInvocationList())
+        {
+            try
+            {
+                handler(args);
+            }
+            catch (Exception ex)
+            {
+                App.Log(
+                    $"[WidgetManager] FeatureStateChanged subscriber failed for " +
+                    $"'{featureId.Value}': {ex.Message}");
+            }
         }
     }
 

--- a/src/DeskBox/Services/WidgetManager.cs
+++ b/src/DeskBox/Services/WidgetManager.cs
@@ -1,4 +1,5 @@
-﻿﻿using DeskBox.Models;
+﻿﻿using DeskBox.Contracts;
+using DeskBox.Models;
 using DeskBox.Helpers;
 using DeskBox.Controls.WidgetContents;
 using DeskBox.ViewModels;
@@ -13,11 +14,6 @@ public sealed record ManagedStorageMigrationResult(
     int AffectedWidgetCount,
     string OldRootPath,
     string NewRootPath);
-
-public sealed record QuickCaptureFileWidgetTarget(
-    string WidgetId,
-    string Name,
-    string FolderPath);
 
 public enum WidgetRemovalAction
 {
@@ -105,9 +101,16 @@ internal interface IDesktopWidgetWindow
 }
 
 /// <summary>
-/// Manages the lifecycle of all desktop organizer widgets.
+/// Manages the lifecycle of all desktop organizer widgets. Implements the
+/// stage 3b host-internal capability ports (pluginization roadmap stage 3)
+/// while their implementations still live here - callers depend on the
+/// Contracts interfaces, physical extraction is deferred until the
+/// dependency set is stable.
 /// </summary>
-public sealed partial class WidgetManager
+public sealed partial class WidgetManager :
+    ITodoReminderPresenter,
+    IFileWidgetImportTarget,
+    IFeatureStateEvents
 {
     private const string ManagedShortcutDescriptionPrefix = "DeskBox mapped widget shortcut:";
 

--- a/src/DeskBox/Views/QuickCaptureWidgetWindow.Menus.cs
+++ b/src/DeskBox/Views/QuickCaptureWidgetWindow.Menus.cs
@@ -430,7 +430,7 @@ public sealed partial class QuickCaptureWidgetWindow
             Icon = new FontIcon { Glyph = "\uE8B7" }
         };
 
-        var targets = App.Current.WidgetManager?.GetQuickCaptureFileWidgetTargets() ?? [];
+        var targets = App.Current.FileWidgetImport?.GetImportTargets() ?? [];
         if (targets.Count == 0)
         {
             subItem.Items.Add(new MenuFlyoutItem
@@ -460,7 +460,7 @@ public sealed partial class QuickCaptureWidgetWindow
 
     private MenuFlyoutItem? CreateSaveToLastFileWidgetItem(QuickCaptureItemViewModel item)
     {
-        var target = App.Current.WidgetManager?.GetLastQuickCaptureFileWidgetTarget();
+        var target = App.Current.FileWidgetImport?.GetLastImportTarget();
         if (target is null)
         {
             return null;
@@ -477,15 +477,31 @@ public sealed partial class QuickCaptureWidgetWindow
 
     private async Task SaveQuickCaptureItemToFileWidgetAsync(QuickCaptureItemViewModel item, string targetWidgetId)
     {
-        if (App.Current.WidgetManager is null)
+        // Stage 3b, cut point 2: the producer translates its own item into
+        // a file or text import (naming, .url format are QuickCapture
+        // knowledge) and hands it to the File-widget import port.
+        if (App.Current.FileWidgetImport is not { } import)
         {
             return;
         }
 
-        string? savedPath = await App.Current.WidgetManager.SaveQuickCaptureItemToFileWidgetAsync(
+        QuickCaptureFileImportPlan? plan = QuickCaptureService.BuildFileImportPlan(
             item.ToModel(),
-            targetWidgetId,
-            _localizationService.T("QuickCapture.ImageExportFileNamePrefix"));
+            _localizationService.T("QuickCapture.ImageExportFileNamePrefix"),
+            _localizationService.T("QuickCapture.TextFileNamePrefix"),
+            _localizationService.T("QuickCapture.LinkFileNamePrefix"));
+        string? savedPath = plan switch
+        {
+            { SourceFilePath: not null } => await import.TryImportFileAsync(
+                plan.SourceFilePath,
+                targetWidgetId,
+                plan.FileName),
+            { Text: not null } => await import.TryImportTextAsync(
+                plan.Text,
+                plan.FileName,
+                targetWidgetId),
+            _ => null
+        };
         ShowStatusToast(string.IsNullOrWhiteSpace(savedPath)
             ? _localizationService.T("QuickCapture.SaveToFileWidgetFailed")
             : _localizationService.T("QuickCapture.SavedToFileWidget"));

--- a/tests/DeskBox.Tests/HostCapabilityPortsContractTests.cs
+++ b/tests/DeskBox.Tests/HostCapabilityPortsContractTests.cs
@@ -99,4 +99,57 @@ public sealed class HostCapabilityPortsContractTests
         Assert.Contains("先接线", readme, StringComparison.Ordinal);
         Assert.Contains("零变化", readme, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void Stage3B_CallersDependOnPortsNotManagerInternals()
+    {
+        string app = File.ReadAllText(TestPaths.SourceFile("src/DeskBox/App.xaml.cs"));
+        string menus = File.ReadAllText(TestPaths.SourceFile(
+            "src/DeskBox/Views/QuickCaptureWidgetWindow.Menus.cs"));
+        string featureWidgets = File.ReadAllText(TestPaths.SourceFile(
+            "src/DeskBox/Services/WidgetManager.FeatureWidgets.cs"));
+        string manager = File.ReadAllText(TestPaths.SourceFile(
+            "src/DeskBox/Services/WidgetManager.cs"));
+        string quickCaptureService = File.ReadAllText(TestPaths.SourceFile(
+            "src/DeskBox/Services/QuickCaptureService.cs"));
+
+        // Cut 1 - Todo presenter: App goes through the port; the rich
+        // HWND/Visible/XamlRoot diagnostics log lives in the implementation.
+        Assert.DoesNotContain("ShowTodoReminderTargetAsync", app, StringComparison.Ordinal);
+        Assert.Contains("TodoReminderPresenter", app, StringComparison.Ordinal);
+        Assert.Contains("PresentReminderTargetAsync", app, StringComparison.Ordinal);
+        Assert.Contains("[Notification] Todo target presentation", featureWidgets, StringComparison.Ordinal);
+
+        // Cut 2 - file import: the import surface goes through the port (the
+        // menus keep other, unrelated manager uses). The pre-wiring manager
+        // method names must not come back; the producer-side item
+        // translation lives in QuickCaptureService, not in widget-manager
+        // internals.
+        Assert.DoesNotContain("GetQuickCaptureFileWidgetTargets", menus, StringComparison.Ordinal);
+        Assert.DoesNotContain("GetLastQuickCaptureFileWidgetTarget", menus, StringComparison.Ordinal);
+        Assert.Contains("App.Current.FileWidgetImport", menus, StringComparison.Ordinal);
+        Assert.Contains("TryImportFileAsync", menus, StringComparison.Ordinal);
+        Assert.Contains("TryImportTextAsync", menus, StringComparison.Ordinal);
+        Assert.Contains("BuildFileImportPlan", menus, StringComparison.Ordinal);
+        Assert.Contains("BuildQuickCaptureContentFileName", quickCaptureService, StringComparison.Ordinal);
+        Assert.DoesNotContain("BuildQuickCaptureContentFileName", featureWidgets, StringComparison.Ordinal);
+        Assert.Contains("TryResolveImportTarget", featureWidgets, StringComparison.Ordinal);
+
+        // Cut 3 - feature state events: the App.Current service switch is
+        // gone from the manager; the App subscribes through the port event
+        // and owns its three service refreshes.
+        Assert.DoesNotContain("App.Current.SetSearchFeatureEnabled", featureWidgets, StringComparison.Ordinal);
+        Assert.DoesNotContain("App.Current.RefreshQuickCaptureClipboardService", featureWidgets, StringComparison.Ordinal);
+        Assert.DoesNotContain("App.Current.RefreshTodoReminderService", featureWidgets, StringComparison.Ordinal);
+        Assert.Contains("RaiseFeatureStateChanged", featureWidgets, StringComparison.Ordinal);
+        Assert.Contains("FeatureStateChanged += OnFeatureStateChanged;", app, StringComparison.Ordinal);
+        Assert.Contains("private void OnFeatureStateChanged(FeatureStateChangedEventArgs e)", app, StringComparison.Ordinal);
+
+        // The manager declares all three ports; the import-target record is
+        // port vocabulary now.
+        Assert.Contains("ITodoReminderPresenter,", manager, StringComparison.Ordinal);
+        Assert.Contains("IFileWidgetImportTarget,", manager, StringComparison.Ordinal);
+        Assert.Contains("IFeatureStateEvents", manager, StringComparison.Ordinal);
+        Assert.DoesNotContain("QuickCaptureFileWidgetTarget", manager, StringComparison.Ordinal);
+    }
 }

--- a/tests/DeskBox.Tests/IdleRuntimeLifecycleContractTests.cs
+++ b/tests/DeskBox.Tests/IdleRuntimeLifecycleContractTests.cs
@@ -50,6 +50,13 @@ public sealed class IdleRuntimeLifecycleContractTests
             "internal TodoReminderService? RefreshTodoReminderService(bool checkNow = false)",
             "private void StartTodoReminderService()");
         string manager = Read("src/DeskBox/Services/WidgetManager.FeatureWidgets.cs");
+        // Stage 3b wiring: the manager raises the feature-state event; the
+        // App-side subscriber owns the service refreshes (same behavior as
+        // the old App.Current switch).
+        string stateHandler = Slice(
+            app,
+            "private void OnFeatureStateChanged(FeatureStateChangedEventArgs e)",
+            "internal void SetSearchFeatureEnabled");
 
         Assert.Contains("RefreshQuickCaptureClipboardService();", launch, StringComparison.Ordinal);
         Assert.Contains("RefreshTodoReminderService();", launch, StringComparison.Ordinal);
@@ -66,8 +73,10 @@ public sealed class IdleRuntimeLifecycleContractTests
         Assert.Contains("_todoReminderService.Dispose();", reminder, StringComparison.Ordinal);
         Assert.Contains("_todoReminderService = null;", reminder, StringComparison.Ordinal);
 
-        Assert.Contains("App.Current.RefreshQuickCaptureClipboardService();", manager, StringComparison.Ordinal);
-        Assert.Contains("App.Current.RefreshTodoReminderService();", manager, StringComparison.Ordinal);
+        Assert.Contains("RaiseFeatureStateChanged(featureId, enabled);", manager, StringComparison.Ordinal);
+        Assert.Contains("SetSearchFeatureEnabled(e.Enabled);", stateHandler, StringComparison.Ordinal);
+        Assert.Contains("RefreshQuickCaptureClipboardService();", stateHandler, StringComparison.Ordinal);
+        Assert.Contains("RefreshTodoReminderService();", stateHandler, StringComparison.Ordinal);
     }
 
     private static string Slice(string source, string startMarker, string endMarker)

--- a/tests/DeskBox.Tests/WidgetManagerStorageCleanupTests.cs
+++ b/tests/DeskBox.Tests/WidgetManagerStorageCleanupTests.cs
@@ -488,34 +488,46 @@ public sealed class WidgetManagerStorageCleanupTests : IDisposable
     }
 
     [Fact]
-    public async Task SaveQuickCaptureItemToFileWidgetAsync_WritesRealFiles()
+    public async Task FileImport_GoesThroughThePortAndWritesRealFiles()
     {
         string managedFolder = Directory.CreateDirectory(Path.Combine(_storageRoot, "Target")).FullName;
         var widget = CreateManagedWidget("Target", managedFolder);
         _settingsService.Settings.Widgets.Add(widget);
 
-        string? textPath = await _widgetManager.SaveQuickCaptureItemToFileWidgetAsync(
-            new QuickCaptureItem
-            {
-                Type = QuickCaptureItemType.Text,
-                Body = "hello world"
-            },
-            widget.Id,
-            "Capture");
+        // Stage 3b wiring: the producer-side translation (QuickCaptureService)
+        // plans the import; the IFileWidgetImportTarget implementation owns
+        // folders and writes. Same flow production uses.
+        var textPlan = QuickCaptureService.BuildFileImportPlan(
+            new QuickCaptureItem { Type = QuickCaptureItemType.Text, Body = "hello world" },
+            imageFileNamePrefix: "Capture",
+            textFileNamePrefix: "Capture",
+            linkFileNamePrefix: "Capture");
+        Assert.NotNull(textPlan);
+        Assert.Null(textPlan.SourceFilePath);
+        string? textPath = await _widgetManager.TryImportTextAsync(
+            textPlan.Text!,
+            textPlan.FileName,
+            widget.Id);
 
-        string? linkPath = await _widgetManager.SaveQuickCaptureItemToFileWidgetAsync(
+        var linkPlan = QuickCaptureService.BuildFileImportPlan(
             new QuickCaptureItem
             {
                 Type = QuickCaptureItemType.Link,
                 Body = "https://example.com/docs",
                 Url = "https://example.com/docs"
             },
-            widget.Id,
-            "Capture");
+            imageFileNamePrefix: "Capture",
+            textFileNamePrefix: "Capture",
+            linkFileNamePrefix: "Capture");
+        Assert.NotNull(linkPlan);
+        string? linkPath = await _widgetManager.TryImportTextAsync(
+            linkPlan.Text!,
+            linkPlan.FileName,
+            widget.Id);
 
         string sourceImagePath = Path.Combine(_tempRoot, "source.png");
         await File.WriteAllBytesAsync(sourceImagePath, [1, 2, 3, 4]);
-        string? imagePath = await _widgetManager.SaveQuickCaptureItemToFileWidgetAsync(
+        var imagePlan = QuickCaptureService.BuildFileImportPlan(
             new QuickCaptureItem
             {
                 Type = QuickCaptureItemType.Image,
@@ -523,8 +535,15 @@ public sealed class WidgetManagerStorageCleanupTests : IDisposable
                 ImagePath = sourceImagePath,
                 UpdatedAt = new DateTimeOffset(2026, 6, 21, 14, 32, 0, TimeSpan.Zero)
             },
+            imageFileNamePrefix: "Capture",
+            textFileNamePrefix: "Capture",
+            linkFileNamePrefix: "Capture");
+        Assert.NotNull(imagePlan);
+        Assert.Null(imagePlan.Text);
+        string? imagePath = await _widgetManager.TryImportFileAsync(
+            imagePlan.SourceFilePath!,
             widget.Id,
-            "Capture");
+            imagePlan.FileName);
 
         Assert.NotNull(textPath);
         Assert.Equal("hello world", await File.ReadAllTextAsync(textPath));
@@ -539,14 +558,47 @@ public sealed class WidgetManagerStorageCleanupTests : IDisposable
         Assert.StartsWith("Capture ", Path.GetFileName(imagePath), StringComparison.Ordinal);
         Assert.EndsWith(".png", imagePath, StringComparison.OrdinalIgnoreCase);
 
-        var target = Assert.Single(_widgetManager.GetQuickCaptureFileWidgetTargets());
+        var target = Assert.Single(_widgetManager.GetImportTargets());
         Assert.Equal(widget.Id, target.WidgetId);
         Assert.Equal(managedFolder, target.FolderPath);
         Assert.Equal(widget.Id, _settingsService.Settings.LastQuickCaptureFileWidgetId);
 
-        var lastTarget = _widgetManager.GetLastQuickCaptureFileWidgetTarget();
+        var lastTarget = _widgetManager.GetLastImportTarget();
         Assert.NotNull(lastTarget);
         Assert.Equal(widget.Id, lastTarget.WidgetId);
+    }
+
+    [Fact]
+    public void BuildFileImportPlan_ReturnsNullForNothingImportable()
+    {
+        // An image whose file vanished plans nothing (import returns null,
+        // matching the pre-wiring behavior).
+        Assert.Null(QuickCaptureService.BuildFileImportPlan(
+            new QuickCaptureItem
+            {
+                Type = QuickCaptureItemType.Image,
+                ImagePath = Path.Combine(_tempRoot, "missing.png")
+            },
+            imageFileNamePrefix: "Capture",
+            textFileNamePrefix: "Capture",
+            linkFileNamePrefix: "Capture"));
+
+        // Empty body text plans nothing.
+        Assert.Null(QuickCaptureService.BuildFileImportPlan(
+            new QuickCaptureItem { Type = QuickCaptureItemType.Text, Body = "   " },
+            imageFileNamePrefix: "Capture",
+            textFileNamePrefix: "Capture",
+            linkFileNamePrefix: "Capture"));
+
+        // A link whose URL is not absolute falls back to the text plan.
+        var fallbackPlan = QuickCaptureService.BuildFileImportPlan(
+            new QuickCaptureItem { Type = QuickCaptureItemType.Link, Body = "not a url" },
+            imageFileNamePrefix: "Capture",
+            textFileNamePrefix: "Capture",
+            linkFileNamePrefix: "Capture");
+        Assert.NotNull(fallbackPlan);
+        Assert.Equal("not a url", fallbackPlan.Text);
+        Assert.EndsWith(".txt", fallbackPlan.FileName, StringComparison.OrdinalIgnoreCase);
     }
 
     private static WidgetConfig CreateManagedWidget(string name, string folderPath)


### PR DESCRIPTION
feat: stage 3b dependency-inversion wiring across the three cut points

WidgetManager now implements the three host-internal capability ports and
every caller goes through them; physical extraction stays deferred until
the dependency set is stable (roadmap 16.9). Zero functional behavior
change - each cut re-homes code, it does not alter outcomes.

Cut 1 - ITodoReminderPresenter: PresentReminderTargetAsync wraps the
existing reminder flow, keeps the host-specific diagnostics (HWND,
visibility, XamlRoot commit) in the implementation's logging, and returns
the end-to-end TargetPresented signal. App's notification and search call
sites use the new TodoReminderPresenter port property.

Cut 2 - IFileWidgetImportTarget: the producer-side translation (item
naming, .url InternetShortcut format, content-derived names) moves to
QuickCaptureService.BuildFileImportPlan - QuickCapture knowledge on the
QuickCapture side. The File-widget internals (target validation, folder
resolution, the write, last-target memory, refresh + reveal) implement
TryImportFileAsync/TryImportTextAsync with a shared finalize core. The
image copy switches from File.Copy/Task.Run to a streaming
CopyToAsync(cancellationToken) so cancellation is honored mid-transfer
(round-5 requirement). QuickCaptureFileWidgetTarget becomes
FileWidgetImportTarget in Contracts; the QuickCapture menus go through
App.Current.FileWidgetImport.

Cut 3 - IFeatureStateEvents: SetFeatureWidgetEnabledState raises
FeatureStateChanged (per-subscriber exception isolation, UI thread)
instead of a hardcoded App.Current switch; App subscribes once at manager
creation and its OnFeatureStateChanged owns the three service refreshes.
WidgetKind-to-FeatureId mapping pins the enum-to-stable-id bridge.

Tests: the import behavior test now exercises the production flow
(producer plan + port write) and a new plan-boundary test covers the
nothing-importable and link-fallback-to-text cases; a stage-3b wiring
contract test pins that callers reference ports (not the manager's
method names) and the App.Current switch never returns; the idle
lifecycle pin follows the event wiring. 3412/3412 green x64. Canonical
Debug rebuilt and restarted (pid 27048).
