### PR TITLE
fix: round-6 hardening - migration tail gap, import sink discipline, port hygiene

### DIFF
--- a/src/DeskBox/Contracts/IFileWidgetImportTarget.cs
+++ b/src/DeskBox/Contracts/IFileWidgetImportTarget.cs
@@ -23,6 +23,10 @@ public interface IFileWidgetImportTarget
     /// <summary>
     /// Lists the file widgets that are valid import targets right now
     /// (enabled, not deleted, with a resolvable writable backing folder).
+    /// The record deliberately carries no raw folder path: a producer that
+    /// learned the backing folder could bypass this port and write there
+    /// directly. UI that needs to show a location gets display text, not a
+    /// usable path capability.
     /// </summary>
     IReadOnlyList<FileWidgetImportTarget> GetImportTargets();
 
@@ -35,9 +39,14 @@ public interface IFileWidgetImportTarget
     /// <summary>
     /// Imports a file already materialized on disk into the target file
     /// widget's backing folder. Returns the destination path, or null when
-    /// the target is invalid, disabled, or the folder is not accessible.
-    /// Implementations honor cancellation for large transfers (streaming
-    /// copy, not a start-only token check).
+    /// the target widget is invalid or the input is unusable - which
+    /// includes file names with path structure (separators, rooted
+    /// segments, ..-traversal), which are rejected rather than
+    /// reinterpreted. I/O failures (access denied, disk full) and
+    /// cancellation propagate as exceptions. The sink confines every write
+    /// inside the widget folder, writes through a temp file, and leaves no
+    /// partial destination on failure. Cancellation is honored mid-transfer
+    /// (streaming copy, not a start-only token check).
     /// </summary>
     Task<string?> TryImportFileAsync(
         string sourceFilePath,
@@ -47,7 +56,11 @@ public interface IFileWidgetImportTarget
 
     /// <summary>
     /// Imports inline text content as a file into the target file widget's
-    /// backing folder. Returns the destination path or null on failure.
+    /// backing folder. Returns the destination path, or null when the
+    /// target widget is invalid or the input is unusable; I/O failures and
+    /// cancellation propagate as exceptions. Same sink discipline as
+    /// <see cref="TryImportFileAsync"/>: the file name is confined to the
+    /// widget folder and the write is atomic.
     /// </summary>
     Task<string?> TryImportTextAsync(
         string text,
@@ -56,8 +69,7 @@ public interface IFileWidgetImportTarget
         CancellationToken cancellationToken = default);
 }
 
-/// <summary>An importable file widget: id, display name, backing folder.</summary>
+/// <summary>An importable file widget: id and display name (no raw paths).</summary>
 public sealed record FileWidgetImportTarget(
     string WidgetId,
-    string Name,
-    string FolderPath);
+    string Name);

--- a/src/DeskBox/Services/SettingsMigrationService.cs
+++ b/src/DeskBox/Services/SettingsMigrationService.cs
@@ -119,6 +119,21 @@ public sealed class SettingsMigrationPipeline
             App.Log($"[SettingsMigration] Applied migration from version {migration.FromVersion} to {version}");
         }
 
+        // Tail gap: the registry ran out of steps before reaching Current.
+        // Stamping the current version anyway would mark migrations that
+        // were never registered as applied (the mirror image of the mid-
+        // registry gap caught above). Keep the version at the last
+        // successful step so the misconfiguration is visible in the log.
+        if (version != CurrentSchemaVersion)
+        {
+            App.Log(
+                $"[SettingsMigration] Migration registry TAIL GAP: reached version {version} " +
+                $"but the current schema version is {CurrentSchemaVersion}. " +
+                "Stopping so unregistered steps are never marked as applied.");
+            settings.SchemaVersion = version;
+            return anyApplied;
+        }
+
         settings.SchemaVersion = CurrentSchemaVersion;
         return anyApplied;
     }

--- a/src/DeskBox/Services/WidgetManager.FeatureWidgets.cs
+++ b/src/DeskBox/Services/WidgetManager.FeatureWidgets.cs
@@ -677,11 +677,7 @@ public sealed partial class WidgetManager
                              !widget.IsDisabled &&
                              !IsDeleted(widget.Id) &&
                              TryGetFileWidgetFolderPath(widget, out _))
-            .Select(widget =>
-            {
-                TryGetFileWidgetFolderPath(widget, out string folderPath);
-                return new FileWidgetImportTarget(widget.Id, widget.Name, folderPath);
-            })
+            .Select(widget => new FileWidgetImportTarget(widget.Id, widget.Name))
             .ToList();
     }
 
@@ -704,6 +700,13 @@ public sealed partial class WidgetManager
     /// producer side (QuickCaptureService.BuildFileImportPlan); this side
     /// owns the File-widget internals: target validation, folder
     /// resolution, the write itself, and the post-import refresh/reveal.
+    /// Sink discipline: a producer may pass an arbitrary file name, so the
+    /// sink itself confines writes - the name is reduced to its final path
+    /// segment and the destination is verified to sit inside the widget's
+    /// backing folder. Writes go through a temp file moved into place so a
+    /// cancellation or I/O failure never leaves a partial destination.
+    /// Returns null only for an invalid target or unusable input; I/O
+    /// failures and cancellation propagate as exceptions.
     /// </summary>
     public async Task<string?> TryImportFileAsync(
         string sourceFilePath,
@@ -716,17 +719,32 @@ public sealed partial class WidgetManager
             return null;
         }
 
-        Directory.CreateDirectory(targetFolderPath);
-        string fileName = string.IsNullOrWhiteSpace(preferredFileName)
-            ? Path.GetFileName(sourceFilePath)
-            : preferredFileName;
-        string destinationPath = FileService.GetAvailablePath(Path.Combine(targetFolderPath, fileName));
-        await using (FileStream source = File.OpenRead(sourceFilePath))
-        await using (FileStream destination = File.Create(destinationPath))
+        if (!TryResolveImportDestination(
+                targetFolderPath,
+                preferredFileName ?? Path.GetFileName(sourceFilePath),
+                out string destinationPath))
         {
-            // Streaming copy so cancellation is honored mid-transfer, unlike
-            // File.Copy/Task.Run (round-5 review requirement).
-            await source.CopyToAsync(destination, cancellationToken);
+            return null;
+        }
+
+        Directory.CreateDirectory(targetFolderPath);
+        string tempPath = Path.Combine(targetFolderPath, $".import-{Guid.NewGuid():N}.tmp");
+        try
+        {
+            await using (FileStream source = File.OpenRead(sourceFilePath))
+            await using (FileStream temp = File.Create(tempPath))
+            {
+                // Streaming copy so cancellation is honored mid-transfer,
+                // unlike File.Copy/Task.Run (round-5 review requirement).
+                await source.CopyToAsync(temp, cancellationToken);
+            }
+
+            File.Move(tempPath, destinationPath, overwrite: true);
+        }
+        catch
+        {
+            TryDeleteFile(tempPath);
+            throw;
         }
 
         return await FinalizeImportAsync(targetWidgetId, destinationPath);
@@ -743,15 +761,84 @@ public sealed partial class WidgetManager
             return null;
         }
 
-        if (!TryResolveImportTarget(targetWidgetId, out string targetFolderPath))
+        if (!TryResolveImportTarget(targetWidgetId, out string targetFolderPath) ||
+            !TryResolveImportDestination(targetFolderPath, fileName, out string destinationPath))
         {
             return null;
         }
 
         Directory.CreateDirectory(targetFolderPath);
-        string destinationPath = FileService.GetAvailablePath(Path.Combine(targetFolderPath, fileName));
-        await File.WriteAllTextAsync(destinationPath, text, cancellationToken);
+        string tempPath = Path.Combine(targetFolderPath, $".import-{Guid.NewGuid():N}.tmp");
+        try
+        {
+            await File.WriteAllTextAsync(tempPath, text, cancellationToken);
+            File.Move(tempPath, destinationPath, overwrite: true);
+        }
+        catch
+        {
+            TryDeleteFile(tempPath);
+            throw;
+        }
+
         return await FinalizeImportAsync(targetWidgetId, destinationPath);
+    }
+
+    /// <summary>
+    /// Confines a producer-supplied file name to the widget folder: a name
+    /// with any path structure (separators, rooted segments, ..-traversal,
+    /// absolute paths) is REJECTED as unusable input rather than silently
+    /// reinterpreted - producers cannot be trusted to sanitize, and a
+    /// reduced name would mask the producer bug. The final destination is
+    /// additionally verified to sit inside the widget folder.
+    /// </summary>
+    private static bool TryResolveImportDestination(
+        string targetFolderPath,
+        string? fileName,
+        out string destinationPath)
+    {
+        destinationPath = string.Empty;
+        string? candidate = fileName?.Trim();
+        if (string.IsNullOrWhiteSpace(candidate) ||
+            candidate is "." or ".." ||
+            !string.Equals(candidate, Path.GetFileName(candidate), StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        try
+        {
+            string normalizedFolder = Path.GetFullPath(targetFolderPath);
+            string candidatePath = Path.GetFullPath(Path.Combine(normalizedFolder, candidate));
+            if (!candidatePath.StartsWith(
+                    normalizedFolder + Path.DirectorySeparatorChar,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            destinationPath = FileService.GetAvailablePath(candidatePath);
+            return true;
+        }
+        catch (Exception)
+        {
+            // Pathologically malformed names (invalid chars, ADS-shaped)
+            // are unusable input, not an I/O failure.
+            return false;
+        }
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+        }
     }
 
     private bool TryResolveImportTarget(string targetWidgetId, out string targetFolderPath)
@@ -1348,6 +1435,19 @@ public sealed partial class WidgetManager
 
     private void RaiseFeatureStateChanged(FeatureId featureId, bool enabled)
     {
+        // The port contract promises UI-thread delivery. Current call sites
+        // are UI-thread, but a future background caller must not silently
+        // break the contract - marshal instead.
+        if (!HasUiThreadAccess())
+        {
+            _ = RunOnUiThreadAsync(() =>
+            {
+                RaiseFeatureStateChanged(featureId, enabled);
+                return Task.CompletedTask;
+            });
+            return;
+        }
+
         if (FeatureStateChanged is null)
         {
             return;

--- a/tests/DeskBox.Tests/MusicSettingsStoreTests.cs
+++ b/tests/DeskBox.Tests/MusicSettingsStoreTests.cs
@@ -232,6 +232,23 @@ public sealed class MusicSettingsStoreTests : IDisposable
     }
 
     [Fact]
+    public void Pipeline_StopsWhenTrailingMigrationIsMissing()
+    {
+        // Registry simply ends before reaching the current version: the
+        // loop previously stamped CurrentSchemaVersion anyway, marking
+        // steps that were never registered as applied.
+        var settings = new AppSettings { SchemaVersion = 8 };
+
+        bool applied = new SettingsMigrationPipeline(
+        [
+            new FakeMigration(8, succeeded: true)
+        ]).RunMigrations(settings);
+
+        Assert.True(applied);
+        Assert.Equal(9, settings.SchemaVersion);
+    }
+
+    [Fact]
     public void Pipeline_NeverRunsStepsBeyondTheCurrentVersion()
     {
         // A step registered for a future schema version must never execute.

--- a/tests/DeskBox.Tests/WidgetManagerStorageCleanupTests.cs
+++ b/tests/DeskBox.Tests/WidgetManagerStorageCleanupTests.cs
@@ -560,7 +560,7 @@ public sealed class WidgetManagerStorageCleanupTests : IDisposable
 
         var target = Assert.Single(_widgetManager.GetImportTargets());
         Assert.Equal(widget.Id, target.WidgetId);
-        Assert.Equal(managedFolder, target.FolderPath);
+        Assert.Equal(widget.Name, target.Name);
         Assert.Equal(widget.Id, _settingsService.Settings.LastQuickCaptureFileWidgetId);
 
         var lastTarget = _widgetManager.GetLastImportTarget();
@@ -599,6 +599,47 @@ public sealed class WidgetManagerStorageCleanupTests : IDisposable
         Assert.NotNull(fallbackPlan);
         Assert.Equal("not a url", fallbackPlan.Text);
         Assert.EndsWith(".txt", fallbackPlan.FileName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ImportSink_ConfinesProducerSuppliedFileNamesToTheWidgetFolder()
+    {
+        // Producers cannot be trusted to sanitize: traversal, rooted and
+        // absolute-path names must be reduced to a harmless in-folder name
+        // (or rejected), never escape the sink.
+        string managedFolder = Directory.CreateDirectory(Path.Combine(_storageRoot, "Confined")).FullName;
+        var widget = CreateManagedWidget("Confined", managedFolder);
+        _settingsService.Settings.Widgets.Add(widget);
+
+        Assert.Null(await _widgetManager.TryImportTextAsync(
+            "escape", "..\\..\\escaped.txt", widget.Id));
+        Assert.Null(await _widgetManager.TryImportTextAsync(
+            "escape", "../escaped.txt", widget.Id));
+        Assert.Null(await _widgetManager.TryImportTextAsync(
+            "escape", Path.Combine(_tempRoot, "absolute-escape.txt"), widget.Id));
+
+        Assert.False(File.Exists(Path.Combine(_storageRoot, "escaped.txt")));
+        Assert.False(File.Exists(Path.Combine(_tempRoot, "absolute-escape.txt")));
+        Assert.Empty(Directory.GetFiles(managedFolder));
+    }
+
+    [Fact]
+    public async Task ImportSink_LeavesNoPartialFileWhenCancelledOrFailed()
+    {
+        string managedFolder = Directory.CreateDirectory(Path.Combine(_storageRoot, "Atomic")).FullName;
+        var widget = CreateManagedWidget("Atomic", managedFolder);
+        _settingsService.Settings.Widgets.Add(widget);
+
+        string sourcePath = Path.Combine(_tempRoot, "cancel-source.bin");
+        await File.WriteAllBytesAsync(sourcePath, new byte[64 * 1024]);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            _widgetManager.TryImportFileAsync(sourcePath, widget.Id, "partial.bin", cts.Token));
+
+        Assert.False(File.Exists(Path.Combine(managedFolder, "partial.bin")));
+        Assert.Empty(Directory.GetFiles(managedFolder, ".import-*.tmp"));
     }
 
     private static WidgetConfig CreateManagedWidget(string name, string folderPath)


### PR DESCRIPTION
fix: round-6 hardening - migration tail gap, import sink discipline, port hygiene

Sixth review round (#250/#251/#252); every code-level claim verified
against the actual sources and confirmed. The host-side fixes land here;
the spike-tooling fixes go onto PR #252 itself.

- Migration tail gap (#250): a registry that simply ends before reaching
  CurrentSchemaVersion was still stamped with the current version after
  the loop - marking steps that were never registered as applied (the
  mirror image of the mid-registry gap). The pipeline now stops at the
  last successful step and logs a TAIL GAP.
- Import sink discipline (#251): TryImportFileAsync/TryImportTextAsync
  now (1) reject producer-supplied file names with any path structure
  (separators, rooted segments, ..-traversal, absolute paths) as unusable
  input instead of reinterpreting them, and containment-verify the final
  destination inside the widget folder - producers cannot be trusted to
  sanitize, which matters once AI/automation producers exist;
  (2) write through a temp file moved into place, so cancellation or an
  I/O failure mid-transfer can no longer leave a partial destination (the
  reviewer's 27MB-of-100MB scenario). Streaming CopyToAsync(token) from
  round 5 is retained.
- Port hygiene (#251): FileWidgetImportTarget loses its raw FolderPath -
  production callers only use WidgetId+Name (the folder was consumed by
  exactly one test assertion); exposing the backing folder through the
  port invited future File.WriteAllText(target.FolderPath, ...) bypasses.
  The interface docs now state the real null/exception split (null =
  invalid target or unusable input; I/O failures and cancellation throw)
  instead of overpromising null for inaccessible folders.
- Event contract as code (#251): RaiseFeatureStateChanged marshals to the
  UI thread when called off it, turning the documented "raised on the UI
  thread" guarantee from an assumption about current call sites into an
  enforced property.

Tests: +3 (tail gap; traversal/rooted/absolute names rejected with no
escape artifacts; pre-cancelled import leaves no partial file or temp).
FolderPath assertion replaced with Name. 3415/3415 green x64. Canonical
Debug rebuilt and restarted (pid 17956).
