### PR TITLE
fix: round-7 - root-folder containment and no-clobber import rename

### DIFF
--- a/src/DeskBox/Services/WidgetManager.FeatureWidgets.cs
+++ b/src/DeskBox/Services/WidgetManager.FeatureWidgets.cs
@@ -714,15 +714,12 @@ public sealed partial class WidgetManager
         string? preferredFileName = null,
         CancellationToken cancellationToken = default)
     {
-        if (!TryResolveImportTarget(targetWidgetId, out string targetFolderPath))
-        {
-            return null;
-        }
-
-        if (!TryResolveImportDestination(
+        if (!TryResolveImportTarget(targetWidgetId, out string targetFolderPath) ||
+            !TryResolveImportDestination(
                 targetFolderPath,
                 preferredFileName ?? Path.GetFileName(sourceFilePath),
-                out string destinationPath))
+                out string destinationPath,
+                out string baseCandidatePath))
         {
             return null;
         }
@@ -739,7 +736,7 @@ public sealed partial class WidgetManager
                 await source.CopyToAsync(temp, cancellationToken);
             }
 
-            File.Move(tempPath, destinationPath, overwrite: true);
+            destinationPath = MoveImportIntoPlace(tempPath, baseCandidatePath, destinationPath);
         }
         catch
         {
@@ -750,8 +747,7 @@ public sealed partial class WidgetManager
         return await FinalizeImportAsync(targetWidgetId, destinationPath);
     }
 
-    public async Task<string?> TryImportTextAsync(
-        string text,
+    public async Task<string?> TryImportTextAsync(        string text,
         string fileName,
         string targetWidgetId,
         CancellationToken cancellationToken = default)
@@ -762,7 +758,11 @@ public sealed partial class WidgetManager
         }
 
         if (!TryResolveImportTarget(targetWidgetId, out string targetFolderPath) ||
-            !TryResolveImportDestination(targetFolderPath, fileName, out string destinationPath))
+            !TryResolveImportDestination(
+                targetFolderPath,
+                fileName,
+                out string destinationPath,
+                out string baseCandidatePath))
         {
             return null;
         }
@@ -772,7 +772,7 @@ public sealed partial class WidgetManager
         try
         {
             await File.WriteAllTextAsync(tempPath, text, cancellationToken);
-            File.Move(tempPath, destinationPath, overwrite: true);
+            destinationPath = MoveImportIntoPlace(tempPath, baseCandidatePath, destinationPath);
         }
         catch
         {
@@ -788,15 +788,18 @@ public sealed partial class WidgetManager
     /// with any path structure (separators, rooted segments, ..-traversal,
     /// absolute paths) is REJECTED as unusable input rather than silently
     /// reinterpreted - producers cannot be trusted to sanitize, and a
-    /// reduced name would mask the producer bug. The final destination is
-    /// additionally verified to sit inside the widget folder.
+    /// reduced name would mask the producer bug. Containment is checked via
+    /// GetRelativePath so drive-root and share-root mapped folders (where
+    /// folder + separator can never prefix-match a child) stay importable.
     /// </summary>
-    private static bool TryResolveImportDestination(
+    internal static bool TryResolveImportDestination(
         string targetFolderPath,
         string? fileName,
-        out string destinationPath)
+        out string destinationPath,
+        out string baseCandidatePath)
     {
         destinationPath = string.Empty;
+        baseCandidatePath = string.Empty;
         string? candidate = fileName?.Trim();
         if (string.IsNullOrWhiteSpace(candidate) ||
             candidate is "." or ".." ||
@@ -808,22 +811,54 @@ public sealed partial class WidgetManager
         try
         {
             string normalizedFolder = Path.GetFullPath(targetFolderPath);
-            string candidatePath = Path.GetFullPath(Path.Combine(normalizedFolder, candidate));
-            if (!candidatePath.StartsWith(
-                    normalizedFolder + Path.DirectorySeparatorChar,
-                    StringComparison.OrdinalIgnoreCase))
+            baseCandidatePath = Path.GetFullPath(Path.Combine(normalizedFolder, candidate));
+            string relative = Path.GetRelativePath(normalizedFolder, baseCandidatePath);
+            if (relative.Length == 0 ||
+                relative == ".." ||
+                relative.StartsWith($"..{Path.DirectorySeparatorChar}", StringComparison.Ordinal) ||
+                Path.IsPathRooted(relative))
             {
+                baseCandidatePath = string.Empty;
                 return false;
             }
 
-            destinationPath = FileService.GetAvailablePath(candidatePath);
+            destinationPath = FileService.GetAvailablePath(baseCandidatePath);
             return true;
         }
         catch (Exception)
         {
             // Pathologically malformed names (invalid chars, ADS-shaped)
             // are unusable input, not an I/O failure.
+            baseCandidatePath = string.Empty;
             return false;
+        }
+    }
+
+    /// <summary>
+    /// Moves the completed temp file into place WITHOUT ever overwriting:
+    /// an auto-generated import path must never clobber a file someone
+    /// else created between GetAvailablePath and the rename (a real race on
+    /// OneDrive/NAS/shared folders). On a destination collision the next
+    /// available name is computed from the base candidate and the rename
+    /// retried. Returns the path the file actually landed on (callers must
+    /// reveal/remember THIS path, not the initially proposed one).
+    /// </summary>
+    internal static string MoveImportIntoPlace(string tempPath, string baseCandidatePath, string destinationPath)
+    {
+        string finalPath = destinationPath;
+        for (int attempt = 0; ; attempt++)
+        {
+            try
+            {
+                File.Move(tempPath, finalPath);
+                return finalPath;
+            }
+            catch (IOException) when (attempt < 3 && File.Exists(finalPath))
+            {
+                // The destination was taken after GetAvailablePath picked
+                // it; take the next free variant instead of clobbering.
+                finalPath = FileService.GetAvailablePath(baseCandidatePath);
+            }
         }
     }
 

--- a/tests/DeskBox.Tests/WidgetManagerStorageCleanupTests.cs
+++ b/tests/DeskBox.Tests/WidgetManagerStorageCleanupTests.cs
@@ -642,6 +642,43 @@ public sealed class WidgetManagerStorageCleanupTests : IDisposable
         Assert.Empty(Directory.GetFiles(managedFolder, ".import-*.tmp"));
     }
 
+    [Fact]
+    public void ImportDestination_DriveRootMappedFolderStaysImportable()
+    {
+        // A File widget mapped to a drive root used to be wrongly rejected:
+        // folder + separator ("C:\" + "\") can never prefix-match a child
+        // ("C:\abc.txt"). GetRelativePath-based containment handles roots.
+        bool resolved = WidgetManager.TryResolveImportDestination(
+            @"C:\",
+            "abc.txt",
+            out string destinationPath,
+            out string baseCandidatePath);
+
+        Assert.True(resolved);
+        Assert.Equal(Path.GetFullPath(@"C:\abc.txt"), baseCandidatePath);
+        Assert.Equal(baseCandidatePath, destinationPath);
+    }
+
+    [Fact]
+    public void Import_NeverOverwritesAFileCreatedAfterPathResolution()
+    {
+        // The destination was taken between GetAvailablePath and the rename:
+        // the import must land on the next free variant, never clobber.
+        string folder = Directory.CreateDirectory(Path.Combine(_tempRoot, "NoClobber")).FullName;
+        string baseCandidate = Path.Combine(folder, "race.txt");
+        string occupied = Path.Combine(folder, "race.txt");
+        File.WriteAllText(occupied, "someone else");
+        string tempPath = Path.Combine(folder, ".import-test.tmp");
+        File.WriteAllText(tempPath, "mine");
+
+        string finalPath = WidgetManager.MoveImportIntoPlace(tempPath, baseCandidate, occupied);
+
+        Assert.NotEqual(occupied, finalPath);
+        Assert.Equal("someone else", File.ReadAllText(occupied));
+        Assert.Equal("mine", File.ReadAllText(finalPath));
+        Assert.StartsWith("race", Path.GetFileName(finalPath), StringComparison.Ordinal);
+    }
+
     private static WidgetConfig CreateManagedWidget(string name, string folderPath)
     {
         return new WidgetConfig


### PR DESCRIPTION
fix: round-7 - root-folder containment and no-clobber import rename

Seventh review round, two #253 follow-ups verified against the code:

- Drive-root containment bug: "C:\" + separator can never prefix-match
  "C:\abc.txt", so a File widget mapped to a drive root (or similar
  root-shaped path) would have every import rejected as an escape. The
  containment check now uses Path.GetRelativePath (empty/../rooted
  relative => reject), which handles drive and share roots correctly.
  Unit test pins the pure path computation.

- Overwrite race: File.Move(overwrite:true) could clobber a file someone
  else created between GetAvailablePath and the rename - a real race on
  OneDrive/NAS/shared mapped folders (and a regression vs the original
  File.Copy path, which threw on an existing destination). The rename is
  now MoveImportIntoPlace: plain Move, and on a destination collision the
  next free variant is computed from the base candidate and retried
  (bounded); it returns the actual landing path so reveal/last-target
  memory never point at someone else's file. DeskBox-generated import
  paths never overwrite existing user files. Unit test pins the
  no-clobber semantics.

3417/3417 green x64.
