### PR TITLE
fix: round-8 spike finalization - scheme enforcement, real URL parsing, honest benchmarks

### DIFF
--- a/docs/architecture/pluginization-roadmap.md
+++ b/docs/architecture/pluginization-roadmap.md
@@ -433,6 +433,19 @@ P0：§6 重写为 Runtime 矩阵（删除 A→B→C 旧结论，与 §14 唯一
 
 **2026-09-07 3b 接线完工（同日）**：WidgetManager 声明实现三端口；切点 1=`PresentReminderTargetAsync` 包装现有流程+富诊断日志（HWND/Visible/XamlRoot）移入实现侧、App 两处调用改走 `TodoReminderPresenter` 端口属性；切点 2=QuickCapture 的 item→file 翻译（命名/.url 格式）归 `QuickCaptureService.BuildFileImportPlan`（生产者自有知识），File-widget 内部（目标校验/文件夹解析/写入+取消/刷新+Reveal）归 `TryImportFileAsync/TryImportTextAsync`（流式 CopyToAsync 真兑现取消），`QuickCaptureFileWidgetTarget`→`FileWidgetImportTarget` 移入 Contracts，Menus 三处改走 `App.Current.FileWidgetImport`；切点 3=`SetFeatureWidgetEnabledState` 的 App.Current switch 替换为 `FeatureStateChanged` 事件（按订阅者异常隔离 raise，UI 线程），App 侧 `OnFeatureStateChanged` 自持三个服务刷新。行为测试迁移至端口路径+新增接线契约测试与 plan 边界测试。
 
+### 16.10 第八轮评审吸收（2026-09-08，三腿合入后）
+
+四主张全核实为真并修复（B0 批次）：
+
+1. **Process=Full Trust 诚实化**：Node 子进程拥有 OS 用户全部权限、可完全绕过 broker——**声明式/WASM=真实技术强制；Process 的 Broker=推荐 API/UX/审计/兼容边界，非 OS 安全边界**。三方定位收敛入册：**声明式=安全默认（AI/普通用户）；WASM=沙箱代码第一候选（社区商店）；Process=Full Trust 扩展（专业/重型/原生集成）**——"WASM 是否默认代码 Runtime"等 AI 同题实验+公平基准再拍板。
+2. **能力门 scheme 强制（P0）**：门原先只比 host，`http://<granted-host>` 可过门。Node/Rust 两门已加 **https-only**（自测 mock 回环 http 走显式豁免，生产语义严格）；Rust 门弃手写 URL 拆分（`split("://")` 对 userinfo 形状会"门看 A 实连 B"）改 **`url` crate 唯一 canonicalization**。**永久纪律：network.fetch 的 URL canonicalization 全平台只有一个实现+一套共享 conformance 测试向量**（https allow/http deny/同 host 后缀 deny/userinfo 语义/端口/localhost deny——B1 C# 移植时建向量表三腿共跑）。
+3. **WASM 基准修正**：原"instantiate ~0ms"把 `Component::new` 编译排除在计时外。修正后真实冷启动=**compile 14ms + instantiate ~0ms + activate 1ms ≈ 15ms**（vs 进程腿 spawn 43+activate 50ms——结论方向不变但数字诚实了）；正式对比边界=Package validate/Compile-or-spawn/Activate/First state 四段三腿对齐，宿主 exe 体积≠内存数据。治理验证精度改口：**fuel=行为已验证；epoch/内存=机制已接入、行为场景待补**（正式 Runtime 批补 hostile memory growth 与 epoch-only 场景）。
+4. **Runtime 只消费已验证包（防 TOCTOU）设计入册**：`PackageManager`（install 期完整验证→**内容寻址不可变安装目录**）→ `RuntimeManager`（**只接受 InstalledPackageHandle，不接受任意文件夹路径**）。验证完成→文件被替换→运行时加载的窗口由不可变性关闭。Wasmtime 的安装期预编译+缓存序列化组件也归此架构（cold install / warm activation 分测）。
+
+WIT world 与 ndjson JSON-RPC 维持 **Spike World** 身份不冻结（widget-update 语义为 metric 量体裁衣；正式版走 Semantic Model→WIT Adapter，Process 正式协议倾向 LSP framing+stdout 纯协议/stderr 日志+违规不静默）。
+
+**3.5 收官后路线（Simon 拍板 2026-09-08）**：AI 同题实验等未做功能后置；先做**"基础完整版"（Declarative-only 跑道）**——B1 C# 包安装/验证/授权存储 → B2 格子拆分（C# 声明式执行器+六模板渲染+贡献→真实格子 widget 生命周期+插件管理面）→ B3 商店基础功能（GitHub 索引+列表+安装流程权限授予+更新检查）→ B4 发布（store 规范 v0+1.4.3→新版直跳实测）。期间冻结 schema 于 v10。
+
 ## 附录 A：关键证据文件索引
 
 | 主题 | 文件 |

--- a/native/deskbox-wasm-spike/Cargo.lock
+++ b/native/deskbox-wasm-spike/Cargo.lock
@@ -402,6 +402,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ureq",
+ "url",
  "wasmtime",
  "wasmtime-wasi",
 ]

--- a/native/deskbox-wasm-spike/host/Cargo.toml
+++ b/native/deskbox-wasm-spike/host/Cargo.toml
@@ -8,5 +8,6 @@ anyhow = "1.0.104"
 serde = "1.0.229"
 serde_json = "1.0.151"
 ureq = { version = "2", default-features = false, features = ["tls"] }
+url = "2.5.8"
 wasmtime = { version = "48", features = ["component-model", "cranelift"] }
 wasmtime-wasi = "48.0.1"

--- a/native/deskbox-wasm-spike/host/src/main.rs
+++ b/native/deskbox-wasm-spike/host/src/main.rs
@@ -42,11 +42,18 @@ struct HostState {
 }
 
 impl HostState {
-    fn hostname_of(url: &str) -> Option<String> {
-        url.split("://").nth(1)?
-            .split(['/', ':'])
-            .next()
-            .map(|h| h.to_ascii_lowercase())
+    /// Canonical URL check for the capability gate: a REAL parser (never a
+    /// hand-rolled split - userinfo/IPv6/encoded forms parse differently
+    /// and a bypass is "gate sees host A, HTTP client connects to B").
+    /// Production policy is HTTPS-only; the loopback exemption exists
+    /// solely for the self-test mock server.
+    fn canonical_host(url: &str) -> Result<(String, bool), String> {
+        let parsed = url::Url::parse(url).map_err(|e| format!("unparseable url '{url}': {e}"))?;
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| format!("url '{url}' has no host"))?
+            .to_ascii_lowercase();
+        Ok((host, parsed.scheme() == "https"))
     }
 
     fn gate(&self, url: &str, permission: &str) -> Result<(), String> {
@@ -62,8 +69,15 @@ impl HostState {
         if !declared {
             return Err(format!("capability '{permission}' is not declared by the package"));
         }
-        let host = Self::hostname_of(url)
-            .ok_or_else(|| format!("unparseable url '{url}'"))?;
+        let (host, is_https) = Self::canonical_host(url)?;
+        let loopback_mock = self.mock_url.is_some()
+            && !is_https
+            && (host == "127.0.0.1" || host == "localhost" || host == "[::1]");
+        if !is_https && !loopback_mock {
+            return Err(format!(
+                "url '{url}' must use https (scheme enforcement; http requests are refused)"
+            ));
+        }
         let in_scope = permissions
             .iter()
             .find(|p| p.get("id").and_then(|i| i.as_str()) == Some(permission))
@@ -293,7 +307,9 @@ fn run() -> anyhow::Result<()> {
     });
 
     let component_bytes = std::fs::read(std::path::Path::new(&pkg_dir).join(entry))?;
+    let compile_start = Instant::now();
     let component = wasmtime::component::Component::new(&engine, &component_bytes)?;
+    let compile_ms = compile_start.elapsed().as_millis();
 
     let mut store = Store::new(&engine, state);
     store.set_fuel(FUEL_LIMIT)?;
@@ -360,6 +376,10 @@ fn run() -> anyhow::Result<()> {
     }
     if measure {
         output["measurements"] = serde_json::json!({
+            // Cold start = compile + instantiate + activate. The earlier
+            // "instantiate ~0ms" claim excluded compilation (round-8 fix);
+            // instantiateMs alone is a warm-cache-style number.
+            "compileMs": compile_ms,
             "instantiateMs": instantiate_ms,
             "activateMs": activate_ms,
             "fuelRemaining": store.get_fuel().ok(),

--- a/scripts/spike/host-capabilities.mjs
+++ b/scripts/spike/host-capabilities.mjs
@@ -11,7 +11,11 @@ export const MAX_RESPONSE_BYTES = 2 * 1024 * 1024; // host hard limit, packages 
 // permissions: the manifest's REQUESTED permission list (mutated by
 // self-test modes to scope the mock host). grants: host-side grant
 // strings like "network.fetch=api.github.com".
-export function createCapabilityGate(permissions, grants) {
+// options.allowInsecureLoopback: harness-only escape hatch for the local
+// mock server (http://127.0.0.1) in --self-test modes. Production policy
+// is HTTPS-only - a guest asking for http://<granted-host> must refuse.
+export function createCapabilityGate(permissions, grants, options = {}) {
+  const allowInsecureLoopback = options.allowInsecureLoopback === true;
   const permissionIds = new Set(permissions.map(p => p.id));
   const allows = id => permissions.find(p => p.id === id)?.scope?.allow ?? [];
   const grantedHosts = id =>
@@ -22,7 +26,15 @@ export function createCapabilityGate(permissions, grants) {
       if (!permissionIds.has(permissionId)) {
         throw new PolicyRefused(`capability '${permissionId}' is not declared by the package`);
       }
-      const host = new URL(url).hostname.toLowerCase();
+      const parsed = new URL(url);
+      const host = parsed.hostname.toLowerCase();
+      const loopbackMock = allowInsecureLoopback &&
+        parsed.protocol === 'http:' &&
+        (host === '127.0.0.1' || host === 'localhost' || host === '[::1]' || host === '::1');
+      if (parsed.protocol !== 'https:' && !loopbackMock) {
+        throw new PolicyRefused(
+          `url '${url}' must use https (scheme enforcement; http requests are refused)`);
+      }
       if (!allows(permissionId).some(entry => entry.toLowerCase() === host)) {
         throw new PolicyRefused(`url '${url}' is outside the declared ${permissionId} scope`);
       }

--- a/scripts/spike/run-declarative.mjs
+++ b/scripts/spike/run-declarative.mjs
@@ -86,9 +86,13 @@ async function run() {
   // ---------- host policy gate ----------
   // Requested (manifest) vs granted (host). A capability needs all three:
   // declared permission + URL host inside the declared scope + a grant.
-  // Shared with the process leg so both enforce identical semantics.
+  // Shared with the process leg so both enforce identical semantics. The
+  // loopback exemption exists only for the self-test mock server.
   const permissions = manifest.permissions ?? [];
-  const gate = createCapabilityGate(permissions, grants);
+  const selfTestUsesMock = ['ok', 'redirect', 'server-error', 'huge', 'out-of-scope'].includes(selfTest);
+  const gate = createCapabilityGate(permissions, grants, {
+    allowInsecureLoopback: selfTestUsesMock
+  });
   const hostAllowed = (url, permissionId) => gate.requireAllowed(url, permissionId);
 
   const dataSources = manifest.dataSources ?? {};

--- a/scripts/spike/run-process.mjs
+++ b/scripts/spike/run-process.mjs
@@ -79,7 +79,10 @@ async function run() {
   }
 
   const permissions = manifest.permissions ?? [];
-  const gate = createCapabilityGate(permissions, grants);
+  const selfTestUsesMock = ['ok', 'redirect', 'server-error'].includes(selfTest);
+  const gate = createCapabilityGate(permissions, grants, {
+    allowInsecureLoopback: selfTestUsesMock
+  });
 
   if (selfTest === 'ok' || selfTest === 'redirect' || selfTest === 'server-error') {
     const server = await startMockServer(selfTest);
@@ -209,6 +212,10 @@ async function handlePluginMessage(child, message, session, gate, activateStart)
           url = mockFetchUrl;
         } else if (selfTest === 'evil-ask') {
           url = 'https://evil.example/secret';
+        } else if (selfTest === 'downgrade') {
+          // Same host, wrong scheme: the gate must refuse http even when
+          // the host is in scope AND granted (round-8 scheme enforcement).
+          url = url.replace('https://', 'http://');
         }
         gate.requireAllowed(url, 'network.fetch');
         const result = await fetchHttpJson(url);

--- a/spikes/README.md
+++ b/spikes/README.md
@@ -53,7 +53,7 @@
 
 | 维度 | ① 声明式 | ② TS 进程 | ③ WASM |
 |---|---|---|---|
-| 冷启动（包校验+首帧状态） | validate 3ms + bind 0ms | spawn 43ms + activate→首状态 50ms（mock） | **instantiate ~0ms + activate 1-2ms（mock，含完整 fetch+绑定+guest 逻辑）** |
+| 冷启动（包校验+首帧状态） | validate 3ms + bind 0ms | spawn 43ms + activate→首状态 50ms（mock） | **compile 14ms + instantiate ~0ms + activate 1ms ≈ 真实冷启动 15ms**（此前"instantiate 0ms"是排除 `Component::new` 编译的暖启动读数，第八轮修正计时边界；真实产品可用安装期预编译+缓存序列化组件把冷启动压回 deserialize+instantiate） |
 | 稳态内存增量 | 峰值堆 ~9.0MB（含 Node 运行时本身；宿主内嵌渲染器将远低于此——此数是 harness 上界，非插件成本） | 宿主 ~9.2MB + 子进程 Node 运行时（子进程 RSS 待正式测量轮统一采） | 插件本体 37.9KB 组件 + store 按需（内存 64MB 硬顶）；宿主 exe 12.7MB（含 Wasmtime） |
 | 数据源刷新→绑定延迟（p50） | 32ms（mock；真实 GitHub 数百 ms，网络主导） | 50ms（mock，含 stdio 往返；真实 GitHub 700ms 网络主导） | 1-2ms（mock，含能力往返+guest 解析；真实 GitHub 641ms 网络主导） |
 | 开发代码量（行） | harness ~350 行（权限门+绑定求值器+mock） | 插件 ~120 行 + harness ~290 行（共享能力库两腿复用） | WIT ~25 行 + guest ~95 行 + host ~400 行（三腿唯一需要 WIT 的） |
@@ -62,9 +62,11 @@
 | AI 一次生成成功率 | 待三腿同题测试 | 待三腿同题测试 | 待三腿同题测试 |
 | 升级兼容 | payload per-element fallback + 绑定失败回退=设计内置 | 协议版本化待定（ndjson JSON-RPC 为 spike 选择） | 组件模型版本化+WIT world 版本化（`deskbox:plugin@0.1.0`） |
 | 权限强制点 | 请求∧scope∧授予三层门先于 fetch；redirect 拒绝；2MB 上限（五场景测试钉死） | **同一共享库同一语义**（未授予/敌意越界/redirect 调用级拒绝+回退，测试钉死） | **同一语义 Rust 实现**（七场景手动验证+源码钉扎） |
-| Crash 恢复 | 无第三方代码可崩（模型固有优势） | 进程崩溃→宿主检出（退出码传播，首状态后崩溃不吞成功） | **最强：trap 隔离（fuel 耗尽/epoch 超时→宿主存活报错）+内存 64MB 硬顶+确定性 fuel 计数** |
+| Crash 恢复 | 无第三方代码可崩（模型固有优势） | 进程崩溃→宿主检出（退出码传播，首状态后崩溃不吞成功） | **最强：trap 隔离（fuel 耗尽/epoch 超时→宿主存活报错）+内存 64MB 硬顶+确定性 fuel 计数**（验证精度：**fuel=行为已验证**；epoch/内存=机制已接入、行为场景待补——见第八轮注） |
 
-**三腿初步读数（正式对比仍按下方方法学，等最小 C# 宿主执行器再定论）**：WASM 腿在本机读数上全面占优（激活 1-2ms vs 进程 50ms vs 声明式 3ms+绑定；崩溃隔离最强制；唯一代价=37.9KB 组件产物+Rust 宿主工具链+WIT 学习面）。AI 可生成性与真实集成成本待三腿同题实测——这正是拍板"代码插件默认 Runtime"前最后的坑。
+**三方安全定位（第八轮钉死）**：**声明式/WASM=真实技术强制**（声明式一切经宿主；WASM 无 WASI 导入、网络/文件/Shell 天然不可见）；**Process=Full Trust**——子进程拥有 OS 用户全部权限，可以完全绕过 broker，Capability Broker 对它只是**推荐 API/UX/审计/兼容边界，不是 OS 安全边界**（schema 的 `process = full-trust executable` 一直是这么写的；商店走 L1 人工审核+Windows 代码签名通道）。据此的定位收敛：声明式=安全默认/AI 与普通用户；WASM=沙箱代码第一候选（社区商店）；Process=Full Trust 扩展（专业/重型/原生集成）——"WASM 是否默认代码 Runtime"仍等 AI 同题实验+公平基准再拍板。
+
+**三腿初步读数（正式对比仍按下方方法学，等最小 C# 宿主执行器再定论）**：WASM 修正后仍占优（真实冷启动 ~15ms vs 进程 spawn+激活 ~93ms；崩溃隔离最强制；代价=37.9KB 产物+Rust 宿主工具链+WIT 面）。AI 可生成性与真实集成成本待三腿同题实测——这是拍板前最后的坑。宿主 exe 12.7MB 是**磁盘体积不是内存数据**，不能与 Node RSS 比较。
 
 测量方法学（第七轮修订）：**上表腿①数字是 scaffolding observation（Node 脚手架观察值），不能与腿②③直接横向定胜负**——产品形态下声明式执行器内嵌在 DeskBox C# 宿主里，Node 堆/启动数与产品无对应关系。正式对比拆两层：**Runtime intrinsic**（activation/协议/绑定延迟、增量内存，排除网络）与 **E2E**（从"宿主要求激活"到"首个绑定状态就绪"，统一包含 process spawn / WASM instantiate / declarative parse，三腿测量边界完全一致）。腿①正式数等最小 C# 宿主执行器就绪后再填。
 

--- a/tests/DeskBox.Tests/DeclarativePackageSpikeTests.cs
+++ b/tests/DeskBox.Tests/DeclarativePackageSpikeTests.cs
@@ -287,6 +287,25 @@ public sealed class DeclarativePackageSpikeTests : IDisposable
     }
 
     [Fact]
+    public void ProcessPackage_DowngradedHttpSchemeIsRefused()
+    {
+        // Round 8: the gate must enforce https even when the host is in
+        // scope AND granted - http://<granted-host> is a scheme downgrade,
+        // not an allowed request.
+        ProcessResult result = RunProcessHarness(
+            TestPaths.FromRepository("spikes/github-stats-process"),
+            "--self-test=downgrade",
+            "--grant=network.fetch=api.github.com");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("\"value\": \"…\"", result.StandardOutput, StringComparison.Ordinal);
+        Assert.Contains(
+            "must use https (scheme enforcement; http requests are refused)",
+            result.StandardOutput,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ProcessPackage_PluginCrashIsSurfacedByProcessGovernance()
     {
         // A crashed plugin must never be swallowed as success.
@@ -353,6 +372,12 @@ public sealed class DeclarativePackageSpikeTests : IDisposable
         Assert.Contains("outside the declared", host, StringComparison.Ordinal);
         Assert.Contains("redirects are refused in v0.3", host, StringComparison.Ordinal);
         Assert.Contains("MAX_RESPONSE_BYTES", host, StringComparison.Ordinal);
+
+        // Round 8: https scheme enforcement and a real URL parser - never a
+        // hand-rolled split in a security boundary.
+        Assert.Contains("must use https (scheme enforcement", host, StringComparison.Ordinal);
+        Assert.Contains("url::Url::parse", host, StringComparison.Ordinal);
+        Assert.DoesNotContain("split(\"://\")", host, StringComparison.Ordinal);
 
         // Governance: deterministic fuel budget, epoch deadline, memory cap.
         Assert.Contains("consume_fuel(true)", host, StringComparison.Ordinal);


### PR DESCRIPTION
fix: round-8 spike finalization - scheme enforcement, real URL parsing, honest benchmarks

Eighth review round; all four claims verified against the code and fixed.
This closes the spike so the "basic complete version" (Declarative-only
product lane, roadmap 16.10) can start from a clean, honest baseline.

- Scheme enforcement (P0): both Node gates checked only the hostname, so
  http://<granted-host> passed. The gate now requires https everywhere;
  the only exemption is the http://127.0.0.1 self-test mock (an explicit,
  documented harness-only escape hatch - production semantics stay
  strict). New process-leg scenario --self-test=downgrade proves the
  refusal: same host, in scope, granted, wrong scheme -> refused and the
  plugin degrades to fallback.
- Real URL parsing (P0): the Rust host's hand-rolled split("://") could
  be bypassed with userinfo shapes (https://api.github.com:xxx@evil.example
  - gate sees api.github.com, HTTP client connects to evil.example). The
  gate now parses with the url crate and matches on the canonical host;
  the hand parser is gone (test-pinned). Permanent discipline recorded in
  the roadmap: one URL canonicalization implementation across platforms
  plus a shared conformance vector set (B1 ports the vectors to C#).
- Honest WASM benchmarks: Component::new (compilation) was outside the
  timer, so "instantiate ~0ms" was a warm-style number. The host now
  reports compileMs separately: compile 14ms + instantiate ~0ms +
  activate 1ms = true cold start ~15ms (direction unchanged vs the
  process leg's ~93ms, but the numbers are honest now). Governance
  verification precision fixed: fuel behavior-verified; epoch/memory
  mechanism-wired with behavioral scenarios deferred to the product
  runtime batch.
- Positioning honesty: Process runtime is Full Trust - the child can
  bypass the broker entirely, so the broker is a recommended
  API/UX/audit/compatibility boundary, NOT an OS security boundary.
  The three-tier positioning (Declarative=safe default, WASM=sandboxed
  code first candidate, Process=full trust) is now pinned in the README
  and roadmap 16.10; "WASM as default code runtime" still awaits the AI
  same-prompt experiment and the fair benchmark. Also recorded in 16.10:
  the VerifiedInstalledPackage design (PackageManager verifies into a
  content-addressed immutable directory; RuntimeManager accepts only
  InstalledPackageHandle - never an arbitrary folder path - closing the
  TOCTOU window), WIT/ndjson stay Spike World (not frozen), and the
  agreed next-phase plan (basic complete version on the Declarative-only
  lane, schema frozen at v10).

Tests: +1 (http downgrade refused + fallback), Rust host pins extended
(url::Url::parse present, hand parser absent, scheme message). 3439/3439
green x64. The wasm host binary was rebuilt locally (cargo) - no CI
impact (the Rust build is not a CI prerequisite).
