### PR TITLE
fix: B1a hardening - weak-key forge fix, fail-closed verifier, integer-only manifests

### DIFF
--- a/docs/architecture/plugin-schema-v0-notes.md
+++ b/docs/architecture/plugin-schema-v0-notes.md
@@ -52,6 +52,7 @@
 | 指纹推导 | `sha256(raw 32 字节公钥)`，先 base64 解码再哈希，小写 hex——不是对 base64 文本哈希 |
 | 签名输入 | `publisherSignature` 签 contentHash 的 raw 32 字节摘要，非 hex 字符串 |
 | contentHash 表示 | 小写 hex 存储；清单行 `<sha256 小写 hex>␣␣<path>`（摘要+两空格+路径），LF 行尾 ordinal 排序 |
+| **manifest 数字整数化（第九轮）** | **manifest 全部数字字段=integer**（v0.3 `defaultSize.width/height` 同改 integer）——Node `JSON.stringify` 会重排 `1.0`→`1` 而 C# 原样保留 token，跨平台漂移无解，禁浮点最便宜；C# 验证器结构期对全树拒绝 `./e/E` 数字 token，Node 工具链同步（v1 若真需要浮点再实现完整 RFC 8785 数字规范化） |
 
 ## v0 → v0.1 变更（第三轮外部评审吸收，roadmap 16.7）
 

--- a/docs/architecture/plugin-schema-v0.json
+++ b/docs/architecture/plugin-schema-v0.json
@@ -42,7 +42,7 @@
         },
         "defaultSize": {
           "type": "object",
-          "properties": { "width": { "type": "number" }, "height": { "type": "number" } },
+          "properties": { "width": { "type": "integer" }, "height": { "type": "integer" } },
           "additionalProperties": false
         },
         "activationEvents": {

--- a/docs/architecture/pluginization-roadmap.md
+++ b/docs/architecture/pluginization-roadmap.md
@@ -446,6 +446,18 @@ WIT world 与 ndjson JSON-RPC 维持 **Spike World** 身份不冻结（widget-up
 
 **3.5 收官后路线（Simon 拍板 2026-09-08）**：AI 同题实验等未做功能后置；先做**"基础完整版"（Declarative-only 跑道）**——B1 C# 包安装/验证/授权存储 → B2 格子拆分（C# 声明式执行器+六模板渲染+贡献→真实格子 widget 生命周期+插件管理面）→ B3 商店基础功能（GitHub 索引+列表+安装流程权限授予+更新检查）→ B4 发布（store 规范 v0+1.4.3→新版直跳实测）。期间冻结 schema 于 v10。
 
+### 16.11 第九轮评审吸收（2026-09-08，B1a 硬化，"安全根标准"）
+
+B1a 进入产品安全边界后标准升级；五项全部落地（本批）：
+
+1. **Ed25519 弱公钥伪造（P0，实证成立后修复）**：identity 公钥（01 00…00）下 `S=1, R=B` 的伪造签名对任意消息通过——先写对抗测试在旧代码上实证攻击成立，再修：**TryDecodeStrict=A/R 双侧规范编码校验（重编码逐字节比对，顺带拒 y≥p）+8-torsion 拒绝（[8]P=identity ⟺ 小阶点）**；对抗向量（identity 伪造/0xff 全满/带符号位 y=0/小阶 R）+**RFC 8032 §7.1 官方向量四条（含 1023 字节消息）**全部通过——独立于 Node 生成向量的第二基准真值。长期：**trust root 迁移到 Rust `ed25519-dalek`（经 deskbox-native ABI 暴露 verify）列为 store GA 前置**（自研 BigInteger 仅作过渡，理由=常备曲线验证语义债不值得背）。
+2. **验证器 fail-closed 全函数（P0）**：任意字节输入 → 永远 Valid/Invalid+诊断、绝不抛未处理异常（顶层 catch 兜底+签名路径 base64/hex 全 try/catch）；**分阶段停机**（结构→integrity→签名，前阶段失败后阶段不跑——旧实现结构失败后继续跑验签是攻击面）。
+3. **类型严格化（P1）**：旧 helper"类型不对→静默跳过"=`schemaVersion:"zero"`/999 都漏检；现在每字段先查类型再查值（id/version/runtime/publisher/hostApi.min/max/permissions[].required/scope.allow 元素/dataSources map key），结构期还做**全树浮点拒绝**。
+4. **manifest 数字整数化（P1，选方案 B）**：Node 会把 `1.0` 重排成 `1` 而 C# 原样保留 token——跨平台哈希漂移无解，**schema v0.3 数字字段全 integer（defaultSize 同步）**，浮点留给 v1 配完整 RFC 8785 数字规范化。
+5. **VerificationPolicy（P1）**：`Verify(path)` 默认 **Store=签名必填**；unsigned 只在显式 `Development` 策略下有效——调用方"忘了查 UnsignedPackage"不再可能构成漏洞。B1b PackageManager 一律走 Store。
+
+**优先级调整（评审采纳）**：DNS 重绑定（hostname 解析到私网 IP）从 backlog **升格为 B2 blocker**——Declarative Executor 发出第一个产品网络请求前必须实现"解析后 IP 复检"；**installer 输入预算**归 B1b（manifest/integrity 体积上限、文件数、单文件大小、路径长度——恶意包不该能在验签失败前耗尽资源）。执行坑：手抄 base64 常量两次抄错——**测试向量一律 hex/程序生成，永不手抄**。
+
 ## 附录 A：关键证据文件索引
 
 | 主题 | 文件 |

--- a/src/DeskBox/Services/Plugins/PluginEd25519.cs
+++ b/src/DeskBox/Services/Plugins/PluginEd25519.cs
@@ -43,11 +43,16 @@ internal static class PluginEd25519
             return false;
         }
 
-        if (!TryDecompress(publicKey, out EdwardsPoint a))
+        // Strict decoding (round 9): non-canonical encodings and
+        // small-order points are rejected for BOTH the public key and R.
+        // Without this, a malicious publisherPublicKey (e.g. the identity
+        // point) makes h*A collapse, and forged signatures verify for any
+        // message with no private key at all.
+        if (!TryDecodeStrict(publicKey, out EdwardsPoint a))
         {
             return false;
         }
-        if (!TryDecompress(signature[..32], out EdwardsPoint r))
+        if (!TryDecodeStrict(signature[..32], out EdwardsPoint r))
         {
             return false;
         }
@@ -68,6 +73,34 @@ internal static class PluginEd25519
         left.Encode(leftEncoded);
         right.Encode(rightEncoded);
         return leftEncoded.SequenceEqual(rightEncoded);
+    }
+
+    /// <summary>
+    /// Strict point decoding: canonical encoding only (the re-encoded
+    /// point must be byte-identical, which also rejects y >= p and unused
+    /// high bits), and the point must NOT be in the 8-torsion subgroup
+    /// ([8]P = identity) - the small-order set used by weak-key forges.
+    /// </summary>
+    private static bool TryDecodeStrict(ReadOnlySpan<byte> encoded, out EdwardsPoint point)
+    {
+        if (!TryDecompress(encoded, out point))
+        {
+            return false;
+        }
+        Span<byte> canonical = stackalloc byte[32];
+        point.Encode(canonical);
+        if (!canonical.SequenceEqual(encoded))
+        {
+            return false;
+        }
+        EdwardsPoint times8 = Add(Add(point, point), Add(point, point));
+        return !IsIdentity(times8);
+    }
+
+    private static bool IsIdentity(EdwardsPoint point)
+    {
+        // Projective identity: X = 0, Y = Z (any Z != 0).
+        return point.X.IsZero && point.Y == point.Z;
     }
 
     private readonly struct EdwardsPoint(BigInteger x, BigInteger y, BigInteger z, BigInteger t)

--- a/src/DeskBox/Services/Plugins/PluginPackageVerifier.cs
+++ b/src/DeskBox/Services/Plugins/PluginPackageVerifier.cs
@@ -7,6 +7,20 @@ using System.Text.RegularExpressions;
 namespace DeskBox.Services.Plugins;
 
 /// <summary>
+/// Verification policy (round 9): the store path requires a publisher
+/// signature; unsigned packages verify only under an explicit Development
+/// policy so a caller can never "forget" the extra UnsignedPackage check.
+/// </summary>
+public enum PluginPackageVerificationPolicy
+{
+    /// <summary>Signature mandatory - the default for product install flows.</summary>
+    Store,
+
+    /// <summary>Unsigned packages allowed (dev tooling / local iteration only).</summary>
+    Development,
+}
+
+/// <summary>
 /// Verifies a plugin package directory against the manifest schema v0.3
 /// semantics: structural rules, the package path grammar, the
 /// package.integrity chain, and the Ed25519 publisher signature. This is
@@ -14,8 +28,14 @@ namespace DeskBox.Services.Plugins;
 /// and the install-time gate for the product plugin pipeline (roadmap
 /// 16.10); cross-implementation parity is enforced by tests that run this
 /// verifier over packages built and signed by the Node tooling.
-/// Uses JsonDocument (arbitrary plugin data, no reflection) so the frozen
-/// JsonSerializer baseline is untouched.
+///
+/// Security posture (round 9): the input is FULLY UNTRUSTED, so Verify is
+/// a fail-closed total function - any bytes yield Valid=false with
+/// diagnostics, never an unhandled exception - and phases stop on first
+/// failure (structure, then integrity, then signature). Manifest numbers
+/// must be integers (no float canonicalization ambiguity across
+/// platforms). Uses JsonDocument (arbitrary plugin data, no reflection)
+/// so the frozen JsonSerializer baseline is untouched.
 /// </summary>
 public static partial class PluginPackageVerifier
 {
@@ -55,7 +75,27 @@ public static partial class PluginPackageVerifier
     private static readonly string[] Templates =
         ["metric", "list", "status", "gallery", "action-list", "simple-form"];
 
-    public static VerificationResult Verify(string packageDirectory)
+    public static VerificationResult Verify(
+        string packageDirectory,
+        PluginPackageVerificationPolicy policy = PluginPackageVerificationPolicy.Store)
+    {
+        try
+        {
+            return VerifyCore(packageDirectory, policy);
+        }
+        catch (Exception error)
+        {
+            // Total function: package-controlled input must never surface
+            // as an unhandled exception to the host - always a result.
+            return new VerificationResult(
+                false,
+                [$"verifier internal error (treated as invalid): {error.GetType().Name}: {error.Message}"],
+                false,
+                null);
+        }
+    }
+
+    private static VerificationResult VerifyCore(string packageDirectory, PluginPackageVerificationPolicy policy)
     {
         var failures = new List<string>();
         string manifestPath = Path.Combine(packageDirectory, "manifest.json");
@@ -85,22 +125,45 @@ public static partial class PluginPackageVerifier
             bool unsigned = !root.TryGetProperty("signature", out JsonElement signature) ||
                             signature.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined;
 
-            ValidateStructure(root, failures);
-            VerifyIntegrityChain(packageDirectory, root, manifestJson, failures);
-
-            if (!unsigned)
+            // ---------- Phase B: strict structure (STOP on failure) ----------
+            ValidateStructure(root, packageDirectory, failures);
+            if (failures.Count > 0)
             {
-                VerifySignature(packageDirectory, signature, failures);
+                return Result(failures, unsigned, manifestJson);
             }
 
-            return new VerificationResult(failures.Count == 0, failures, unsigned, manifestJson);
+            // ---------- Phase C: integrity chain (STOP on failure) ----------
+            VerifyIntegrityChain(packageDirectory, root, manifestJson, failures);
+            if (failures.Count > 0)
+            {
+                return Result(failures, unsigned, manifestJson);
+            }
+
+            // ---------- Phase D: signature ----------
+            if (policy == PluginPackageVerificationPolicy.Store && unsigned)
+            {
+                failures.Add("signature required for store packages (unsigned is Development-policy only)");
+                return Result(failures, unsigned, manifestJson);
+            }
+            if (!unsigned)
+            {
+                VerifySignature(packageDirectory, root, signature, failures);
+            }
+
+            return Result(failures, unsigned, manifestJson);
         }
     }
 
+    private static VerificationResult Result(List<string> failures, bool unsigned, string manifestJson) =>
+        new(failures.Count == 0, failures, unsigned, manifestJson);
+
     // ---------- structural rules (schema v0.3, mirrors validate-lib.mjs) ----------
-    private static void ValidateStructure(JsonElement root, List<string> failures)
+    // Every check FAILS CLOSED on wrong types: "required property present"
+    // never silently substitutes for "property has the right type".
+    private static void ValidateStructure(JsonElement root, string packageDirectory, List<string> failures)
     {
         void Fail(string message) => failures.Add(message);
+
         foreach (string key in RootRequired)
         {
             if (!root.TryGetProperty(key, out _))
@@ -116,39 +179,52 @@ public static partial class PluginPackageVerifier
             }
         }
 
-        if (StringEquals(root, "schemaVersion", out string? schemaVersion) && schemaVersion != "0")
+        RequireInteger(root, "schemaVersion", value => value == 0, "schemaVersion must be the integer 0", Fail);
+        if (StringValue(root, "id") is null)
         {
-            Fail("schemaVersion must be 0");
+            Fail("id must be a string");
         }
-        if (StringEquals(root, "id", out string? id) && !PackageIdPattern().IsMatch(id))
+        else if (!PackageIdPattern().IsMatch(StringValue(root, "id")!))
         {
             Fail("id pattern");
         }
-        if (StringEquals(root, "version", out string? version) && !VersionPattern().IsMatch(version))
+        if (StringValue(root, "version") is null)
+        {
+            Fail("version must be a string");
+        }
+        else if (!VersionPattern().IsMatch(StringValue(root, "version")!))
         {
             Fail("version pattern");
         }
-        if (StringEquals(root, "runtime", out string? runtime) && runtime is not ("none" or "wasm" or "process"))
+        string? runtime = StringValue(root, "runtime");
+        if (runtime is null)
+        {
+            Fail("runtime must be a string");
+        }
+        else if (runtime is not ("none" or "wasm" or "process"))
         {
             Fail("runtime enum");
         }
+        if (StringValue(root, "publisher") is not { Length: > 0 })
+        {
+            Fail("publisher must be a non-empty string");
+        }
+        if (StringValue(root, "publisherPublicKey") is not { Length: > 0 })
+        {
+            Fail("publisherPublicKey must be a non-empty string");
+        }
 
         bool hasEntry = root.TryGetProperty("entry", out JsonElement entry) && entry.ValueKind == JsonValueKind.Object;
-        if (runtime == "none" && hasEntry)
+        if (runtime is "none" && hasEntry)
         {
             Fail("runtime:none packages must not declare an entry point");
         }
-        if (runtime != "none" && !hasEntry)
+        if (runtime is "wasm" or "process" && !hasEntry)
         {
             Fail($"runtime '{runtime}' requires an entry point");
         }
         if (hasEntry)
         {
-            string? entryMain = StringEquals(entry, "main", out string? main) ? main : null;
-            if (entryMain is null || entryMain.Length == 0)
-            {
-                Fail("entry.main must be a non-empty string");
-            }
             foreach (JsonProperty property in entry.EnumerateObject())
             {
                 if (property.Name != "main")
@@ -156,21 +232,49 @@ public static partial class PluginPackageVerifier
                     Fail($"entry: unknown property '{property.Name}'");
                 }
             }
-            // The manifest path is verified against the package later; the
-            // grammar itself is directory-independent so it runs here.
-            if (entryMain is not null && PackagePathViolation(entryMain) is { } entryViolation)
+            if (StringValue(entry, "main") is not { } entryMain || entryMain.Length == 0)
             {
-                Fail($"entry.main violates the package path grammar ({entryViolation})");
+                Fail("entry.main must be a non-empty string");
+            }
+            else
+            {
+                if (PackagePathViolation(entryMain) is { } entryViolation)
+                {
+                    Fail($"entry.main violates the package path grammar ({entryViolation})");
+                }
+                else if (!File.Exists(Path.Combine(packageDirectory, entryMain)))
+                {
+                    Fail($"entry.main file not found in package: {entryMain}");
+                }
             }
         }
 
-        if (!root.TryGetProperty("contributions", out JsonElement contributions) ||
-            contributions.ValueKind != JsonValueKind.Array ||
-            contributions.GetArrayLength() == 0)
+        if (!root.TryGetProperty("hostApi", out JsonElement hostApi) || hostApi.ValueKind != JsonValueKind.Object)
         {
-            Fail("contributions: minItems 1");
-            return;
+            Fail("hostApi must be an object with string min/max");
         }
+        else
+        {
+            foreach (string key in new[] { "min", "max" })
+            {
+                if (StringValue(hostApi, key) is not { Length: > 0 })
+                {
+                    Fail($"hostApi.{key} must be a non-empty string");
+                }
+            }
+            foreach (JsonProperty property in hostApi.EnumerateObject())
+            {
+                if (property.Name is not ("min" or "max"))
+                {
+                    Fail($"hostApi: unknown property '{property.Name}'");
+                }
+            }
+        }
+
+        // Manifest numbers are integer-only (round 9): floats are rejected
+        // before they can create cross-platform canonicalization drift
+        // (Node JSON.stringify re-formats numbers; raw tokens differ).
+        RejectNonIntegerNumbers(root, "manifest", Fail);
 
         Dictionary<string, JsonElement> dataSources = MapOf(root, "dataSources");
         Dictionary<string, JsonElement> actions = MapOf(root, "actions");
@@ -180,6 +284,14 @@ public static partial class PluginPackageVerifier
             {
                 Fail($"map key '{key}' must use the local id pattern (^[a-z0-9][a-z0-9-]*$)");
             }
+        }
+
+        if (!root.TryGetProperty("contributions", out JsonElement contributions) ||
+            contributions.ValueKind != JsonValueKind.Array ||
+            contributions.GetArrayLength() == 0)
+        {
+            Fail("contributions: minItems 1");
+            return;
         }
 
         var contributionIds = new HashSet<string>();
@@ -207,11 +319,15 @@ public static partial class PluginPackageVerifier
                     Fail($"{where}: unknown property '{property.Name}'");
                 }
             }
-            if (StringEquals(contribution, "type", out string? type) && type != "widget")
+            if (StringValue(contribution, "type") is not { } type || type != "widget")
             {
                 Fail($"{where}: unknown contribution type");
             }
-            if (StringEquals(contribution, "id", out string? contributionId))
+            if (StringValue(contribution, "id") is not { } contributionId)
+            {
+                Fail($"{where}: id must be a string");
+            }
+            else
             {
                 if (!LocalIdPattern().IsMatch(contributionId))
                 {
@@ -222,17 +338,20 @@ public static partial class PluginPackageVerifier
                     Fail("contribution ids must be unique within the package");
                 }
             }
-            if (StringEquals(contribution, "displayName", out string? displayName) && displayName.Length == 0)
+            if (StringValue(contribution, "displayName", out string? displayName) && displayName!.Length == 0)
             {
                 Fail($"{where}: displayName minLength 1");
             }
-            if (StringEquals(contribution, "template", out string? template) && !Templates.Contains(template))
+            if (StringValue(contribution, "template") is not { } template || !Templates.Contains(template))
             {
                 Fail($"{where}: template enum");
             }
 
-            if (contribution.TryGetProperty("payload", out JsonElement payload) &&
-                payload.ValueKind == JsonValueKind.Object)
+            JsonElement payload = contribution.TryGetProperty("payload", out JsonElement payloadElement) &&
+                                  payloadElement.ValueKind == JsonValueKind.Object
+                ? payloadElement
+                : default;
+            if (payload.ValueKind == JsonValueKind.Object)
             {
                 if (!payload.TryGetProperty("version", out JsonElement payloadVersion) ||
                     !payloadVersion.TryGetInt32(out int payloadVersionValue) ||
@@ -240,7 +359,8 @@ public static partial class PluginPackageVerifier
                 {
                     Fail($"{where}.payload.version >= 1 required");
                 }
-                if (StringEquals(payload, "primaryActionId", out string? primaryActionId))
+                if (StringValue(payload, "primaryActionId", out string? primaryActionId) &&
+                    primaryActionId!.Length > 0)
                 {
                     referencedActionIds.Add(primaryActionId);
                 }
@@ -265,21 +385,27 @@ public static partial class PluginPackageVerifier
                             Fail($"{bindingWhere}: unknown property '{property.Name}'");
                         }
                     }
-                    if (!StringEquals(binding, "source", out string? source) || source.Length == 0)
+                    if (StringValue(binding, "source", out string? source) && source!.Length > 0)
                     {
-                        Fail($"{bindingWhere}: 'source' required");
+                        if (!dataSources.ContainsKey(source))
+                        {
+                            Fail($"{bindingWhere}: unknown data source '{source}'");
+                        }
                     }
-                    else if (!dataSources.ContainsKey(source))
+                    else
                     {
-                        Fail($"{bindingWhere}: unknown data source '{source}'");
+                        Fail($"{bindingWhere}: 'source' must be a non-empty string");
                     }
-                    if (!StringEquals(binding, "path", out string? path) || path.Length == 0)
+                    if (StringValue(binding, "path", out string? path) && path!.Length > 0)
                     {
-                        Fail($"{bindingWhere}: 'path' required");
+                        if (!JsonPathPattern().IsMatch(path))
+                        {
+                            Fail($"{bindingWhere}: path must be a minimal JSON path like $.a.b[0].c");
+                        }
                     }
-                    else if (!JsonPathPattern().IsMatch(path))
+                    else
                     {
-                        Fail($"{bindingWhere}: path must be a minimal JSON path like $.a.b[0].c");
+                        Fail($"{bindingWhere}: 'path' must be a non-empty string");
                     }
                     if (payload.ValueKind == JsonValueKind.Object && !payload.TryGetProperty(bindingProperty.Name, out _))
                     {
@@ -294,6 +420,11 @@ public static partial class PluginPackageVerifier
         {
             string where = $"dataSources['{pair.Key}']";
             JsonElement source = pair.Value;
+            if (source.ValueKind != JsonValueKind.Object)
+            {
+                Fail($"{where}: must be an object");
+                continue;
+            }
             foreach (string key in new[] { "type", "url", "refreshSeconds" })
             {
                 if (!source.TryGetProperty(key, out _))
@@ -308,13 +439,20 @@ public static partial class PluginPackageVerifier
                     Fail($"{where}: unknown property '{property.Name}'");
                 }
             }
-            if (StringEquals(source, "type", out string? sourceType) && sourceType != "http-json")
+            if (StringValue(source, "type") is not { } sourceType || sourceType != "http-json")
             {
                 Fail($"{where}: v0.3 supports type http-json only");
             }
-            if (StringEquals(source, "url", out string? url) && !url.StartsWith("https://", StringComparison.Ordinal))
+            if (StringValue(source, "url", out string? url) && url!.Length > 0)
             {
-                Fail($"{where}: url must be HTTPS");
+                if (!url.StartsWith("https://", StringComparison.Ordinal))
+                {
+                    Fail($"{where}: url must be HTTPS");
+                }
+            }
+            else
+            {
+                Fail($"{where}: url must be a non-empty string");
             }
             if (source.TryGetProperty("refreshSeconds", out JsonElement refresh) &&
                 (!refresh.TryGetInt32(out int refreshValue) || refreshValue < 10))
@@ -328,6 +466,11 @@ public static partial class PluginPackageVerifier
         {
             string where = $"actions['{pair.Key}']";
             JsonElement action = pair.Value;
+            if (action.ValueKind != JsonValueKind.Object)
+            {
+                Fail($"{where}: must be an object");
+                continue;
+            }
             foreach (string key in new[] { "type", "url" })
             {
                 if (!action.TryGetProperty(key, out _))
@@ -342,13 +485,20 @@ public static partial class PluginPackageVerifier
                     Fail($"{where}: unknown property '{property.Name}'");
                 }
             }
-            if (StringEquals(action, "type", out string? actionType) && actionType != "open-url")
+            if (StringValue(action, "type") is not { } actionType || actionType != "open-url")
             {
                 Fail($"{where}: v0.3 supports type open-url only");
             }
-            if (StringEquals(action, "url", out string? actionUrl) && !actionUrl.StartsWith("https://", StringComparison.Ordinal))
+            if (StringValue(action, "url", out string? actionUrl) && actionUrl!.Length > 0)
             {
-                Fail($"{where}: url must be HTTPS");
+                if (!actionUrl.StartsWith("https://", StringComparison.Ordinal))
+                {
+                    Fail($"{where}: url must be HTTPS");
+                }
+            }
+            else
+            {
+                Fail($"{where}: url must be a non-empty string");
             }
         }
         if (actions.Count > 0)
@@ -357,12 +507,12 @@ public static partial class PluginPackageVerifier
             // primaryActionId references were collected above.
             foreach (JsonElement contribution in contributions.EnumerateArray())
             {
-                if (!contribution.TryGetProperty("payload", out JsonElement payload) ||
-                    payload.ValueKind != JsonValueKind.Object)
+                if (!contribution.TryGetProperty("payload", out JsonElement payloadElement) ||
+                    payloadElement.ValueKind != JsonValueKind.Object)
                 {
                     continue;
                 }
-                foreach (JsonProperty property in payload.EnumerateObject())
+                foreach (JsonProperty property in payloadElement.EnumerateObject())
                 {
                     CollectActionId(property.Value, referencedActionIds);
                 }
@@ -376,7 +526,7 @@ public static partial class PluginPackageVerifier
             }
         }
 
-        // Permissions: shape, unique ids, then consumption rules.
+        // Permissions: shape (fail-closed on types), unique ids, consumption rules.
         List<JsonElement> permissions = root.TryGetProperty("permissions", out JsonElement permissionsElement) &&
                                         permissionsElement.ValueKind == JsonValueKind.Array
             ? permissionsElement.EnumerateArray().ToList()
@@ -385,35 +535,88 @@ public static partial class PluginPackageVerifier
         for (int i = 0; i < permissions.Count; i++)
         {
             JsonElement permission = permissions[i];
-            if (!StringEquals(permission, "id", out string? permissionId) || !PermissionIdPattern().IsMatch(permissionId))
+            string where = $"permissions[{i}]";
+            if (permission.ValueKind != JsonValueKind.Object)
             {
-                Fail($"permissions[{i}]: id pattern");
-            }
-            else if (!permissionIds.Add(permissionId))
-            {
-                // Duplicate ids with different scopes would make grant/scope
-                // lookup implementation-defined across runtimes.
-                Fail($"permissions: duplicate id '{permissionId}' (use one entry with multiple scope.allow hosts)");
+                Fail($"{where}: must be an object");
+                continue;
             }
             foreach (JsonProperty property in permission.EnumerateObject())
             {
                 if (property.Name is not ("id" or "required" or "scope"))
                 {
-                    Fail($"permissions[{i}]: unknown property '{property.Name}'");
+                    Fail($"{where}: unknown property '{property.Name}'");
+                }
+            }
+            if (StringValue(permission, "id", out string? permissionId) && permissionId!.Length > 0)
+            {
+                if (!PermissionIdPattern().IsMatch(permissionId))
+                {
+                    Fail($"{where}: id pattern");
+                }
+                else if (!permissionIds.Add(permissionId))
+                {
+                    // Duplicate ids with different scopes would make grant/scope
+                    // lookup implementation-defined across runtimes.
+                    Fail($"permissions: duplicate id '{permissionId}' (use one entry with multiple scope.allow hosts)");
+                }
+            }
+            else
+            {
+                Fail($"{where}: id must be a non-empty string");
+            }
+            if (permission.TryGetProperty("required", out JsonElement required) &&
+                required.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
+            {
+                Fail($"{where}: required must be a boolean");
+            }
+            if (permission.TryGetProperty("scope", out JsonElement scope))
+            {
+                if (scope.ValueKind != JsonValueKind.Object)
+                {
+                    Fail($"{where}: scope must be an object");
+                }
+                else
+                {
+                    foreach (JsonProperty scopeProperty in scope.EnumerateObject())
+                    {
+                        if (scopeProperty.Name is not ("allow" or "deny"))
+                        {
+                            Fail($"{where}.scope: unknown property '{scopeProperty.Name}'");
+                        }
+                    }
+                    if (scope.TryGetProperty("allow", out JsonElement allow))
+                    {
+                        if (allow.ValueKind != JsonValueKind.Array)
+                        {
+                            Fail($"{where}.scope.allow must be an array");
+                        }
+                        else
+                        {
+                            foreach (JsonElement allowEntry in allow.EnumerateArray())
+                            {
+                                if (allowEntry.ValueKind != JsonValueKind.String)
+                                {
+                                    Fail($"{where}.scope.allow entries must be strings");
+                                    break;
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
 
         foreach (KeyValuePair<string, JsonElement> pair in dataSources)
         {
-            if (StringEquals(pair.Value, "type", out string? type) && type == "http-json")
+            if (StringValue(pair.Value, "type", out string? type) && type == "http-json")
             {
                 if (!permissionIds.Contains("network.fetch"))
                 {
                     Fail($"dataSources['{pair.Key}']: http-json requires the network.fetch permission");
                 }
-                else if (StringEquals(pair.Value, "url", out string? url) &&
-                         !HostInScope(url, permissions, "network.fetch"))
+                else if (StringValue(pair.Value, "url", out string? url) &&
+                         !HostInScope(url!, permissions, "network.fetch"))
                 {
                     Fail($"dataSources['{pair.Key}']: url host is outside the declared network.fetch scope");
                 }
@@ -421,18 +624,46 @@ public static partial class PluginPackageVerifier
         }
         foreach (KeyValuePair<string, JsonElement> pair in actions)
         {
-            if (StringEquals(pair.Value, "type", out string? type) && type == "open-url")
+            if (StringValue(pair.Value, "type", out string? type) && type == "open-url")
             {
                 if (!permissionIds.Contains("shell.open"))
                 {
                     Fail($"actions['{pair.Key}']: open-url requires the shell.open permission");
                 }
-                else if (StringEquals(pair.Value, "url", out string? url) &&
-                         !HostInScope(url, permissions, "shell.open"))
+                else if (StringValue(pair.Value, "url", out string? url) &&
+                         !HostInScope(url!, permissions, "shell.open"))
                 {
                     Fail($"actions['{pair.Key}']: url host is outside the declared shell.open scope");
                 }
             }
+        }
+    }
+
+    /// <summary>Walks the tree and fails on any non-integer number token.</summary>
+    private static void RejectNonIntegerNumbers(JsonElement element, string where, Action<string> fail)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (JsonProperty property in element.EnumerateObject())
+                {
+                    RejectNonIntegerNumbers(property.Value, $"{where}.{property.Name}", fail);
+                }
+                break;
+            case JsonValueKind.Array:
+                int index = 0;
+                foreach (JsonElement item in element.EnumerateArray())
+                {
+                    RejectNonIntegerNumbers(item, $"{where}[{index++}]", fail);
+                }
+                break;
+            case JsonValueKind.Number:
+                string raw = element.GetRawText();
+                if (raw.Contains('.') || raw.Contains('e') || raw.Contains('E'))
+                {
+                    fail($"{where}: manifest numbers must be integers (floats are rejected to avoid cross-platform canonicalization drift)");
+                }
+                break;
         }
     }
 
@@ -459,7 +690,7 @@ public static partial class PluginPackageVerifier
         {
             string host = new Uri(url).Host.ToLowerInvariant();
             return permissions
-                .Where(p => StringEquals(p, "id", out string? id) && id == permissionId)
+                .Where(p => StringValue(p, "id", out string? id) && id == permissionId)
                 .SelectMany(p => p.TryGetProperty("scope", out JsonElement scope) &&
                                  scope.TryGetProperty("allow", out JsonElement allow) &&
                                  allow.ValueKind == JsonValueKind.Array
@@ -487,17 +718,41 @@ public static partial class PluginPackageVerifier
         return result;
     }
 
-    private static bool StringEquals(JsonElement element, string property, out string? value)
+    /// <summary>The string value when the property exists and is a string; null otherwise.</summary>
+    private static string? StringValue(JsonElement element, string property)
     {
-        value = null;
-        if (element.ValueKind == JsonValueKind.Object &&
-            element.TryGetProperty(property, out JsonElement node) &&
-            node.ValueKind == JsonValueKind.String)
+        return element.ValueKind == JsonValueKind.Object &&
+               element.TryGetProperty(property, out JsonElement node) &&
+               node.ValueKind == JsonValueKind.String
+            ? node.GetString()
+            : null;
+    }
+
+    private static bool StringValue(JsonElement element, string property, out string? value)
+    {
+        value = StringValue(element, property);
+        return value is not null;
+    }
+
+    private static void RequireInteger(
+        JsonElement element,
+        string property,
+        Func<int, bool> predicate,
+        string message,
+        Action<string> fail)
+    {
+        if (!element.TryGetProperty(property, out JsonElement node))
         {
-            value = node.GetString();
-            return true;
+            return; // missing already reported by the required scan
         }
-        return false;
+        if (node.ValueKind != JsonValueKind.Number || !node.TryGetInt32(out int value))
+        {
+            fail($"{property} must be an integer");
+        }
+        else if (!predicate(value))
+        {
+            fail(message);
+        }
     }
 
     // ---------- package path grammar (zip-slip defense, shared with the Node tooling) ----------
@@ -562,7 +817,16 @@ public static partial class PluginPackageVerifier
 
         // Step 1: the manifest's canonical form (signature = null) must match
         // its integrity line - catches a manifest edited after the build.
-        string canonicalManifestHash = Sha256Hex(CanonicalizeManifest(root));
+        string canonicalManifestHash;
+        try
+        {
+            canonicalManifestHash = Sha256Hex(CanonicalizeManifest(root));
+        }
+        catch (Exception error)
+        {
+            Fail($"manifest canonicalization failed: {error.Message}");
+            return;
+        }
         if (!listed.TryGetValue("manifest.json", out string? manifestLine) ||
             !string.Equals(manifestLine, canonicalManifestHash, StringComparison.Ordinal))
         {
@@ -599,15 +863,17 @@ public static partial class PluginPackageVerifier
         }
     }
 
-    private static void VerifySignature(string packageDirectory, JsonElement signature, List<string> failures)
+    private static void VerifySignature(string packageDirectory, JsonElement root, JsonElement signature, List<string> failures)
     {
         void Fail(string message) => failures.Add(message);
+        if (signature.ValueKind != JsonValueKind.Object)
+        {
+            Fail("signature must be an object when present");
+            return;
+        }
         foreach (string key in new[] { "contentHash", "publisherSignature" })
         {
-            if (signature.ValueKind != JsonValueKind.Object ||
-                !signature.TryGetProperty(key, out JsonElement node) ||
-                node.ValueKind != JsonValueKind.String ||
-                node.GetString()!.Length == 0)
+            if (!StringValue(signature, key, out string? value) || value!.Length == 0)
             {
                 Fail($"signature: '{key}' required when the block is present");
                 return;
@@ -620,10 +886,6 @@ public static partial class PluginPackageVerifier
                 Fail($"signature: unknown property '{property.Name}'");
             }
         }
-
-        string manifestJson = File.ReadAllText(Path.Combine(packageDirectory, "manifest.json"));
-        using JsonDocument document = JsonDocument.Parse(manifestJson);
-        JsonElement root = document.RootElement;
 
         string integrityPath = Path.Combine(packageDirectory, "package.integrity");
         if (!File.Exists(integrityPath))
@@ -640,17 +902,43 @@ public static partial class PluginPackageVerifier
         }
 
         // Step 5 first (cheap): publisher == sha256(raw key bytes).
-        byte[] publicKey = Convert.FromBase64String(root.GetProperty("publisherPublicKey").GetString()!);
+        if (StringValue(root, "publisherPublicKey") is not { } publicKeyText)
+        {
+            return; // already failed structurally
+        }
+        byte[] publicKey;
+        try
+        {
+            publicKey = Convert.FromBase64String(publicKeyText);
+        }
+        catch (FormatException)
+        {
+            Fail("publisherPublicKey is not valid base64");
+            return;
+        }
+        if (publicKey.Length != 32)
+        {
+            Fail($"publisherPublicKey must decode to 32 raw bytes, got {publicKey.Length}");
+            return;
+        }
         string fingerprint = Sha256Hex(publicKey);
-        if (!string.Equals(root.GetProperty("publisher").GetString(), fingerprint, StringComparison.Ordinal))
+        if (!string.Equals(StringValue(root, "publisher"), fingerprint, StringComparison.Ordinal))
         {
             Fail("publisher does not equal sha256(raw publisherPublicKey bytes)");
         }
 
         // Step 4: Ed25519 over the RAW 32-byte digest.
-        byte[] signatureBytes = Convert.FromBase64String(signature.GetProperty("publisherSignature").GetString()!);
-        byte[] digest = Convert.FromHexString(contentHash);
-        if (!PluginEd25519.Verify(signatureBytes, digest, publicKey))
+        byte[] signatureBytes;
+        try
+        {
+            signatureBytes = Convert.FromBase64String(signature.GetProperty("publisherSignature").GetString()!);
+        }
+        catch (FormatException)
+        {
+            Fail("publisherSignature is not valid base64");
+            return;
+        }
+        if (!PluginEd25519.Verify(signatureBytes, Convert.FromHexString(contentHash), publicKey))
         {
             Fail("publisherSignature verification failed");
         }
@@ -670,10 +958,11 @@ public static partial class PluginPackageVerifier
     /// JCS-subset canonicalization (parity with the Node tooling): object
     /// keys ordinal-sorted (UTF-16 code units, same as JS default sort), no
     /// whitespace, minimal string escaping, number tokens preserved verbatim
-    /// (spike manifests are integer-only). The signature property is forced
-    /// to null (written as an explicit null at its sorted position, exactly
-    /// like the Node tooling's {...manifest, signature: null}) so the hash
-    /// domain is self-reference free and byte-identical across platforms.
+    /// - valid because manifests are integer-only (enforced structurally).
+    /// The signature property is forced to null (written as an explicit null
+    /// at its sorted position, exactly like the Node tooling's
+    /// {...manifest, signature: null}) so the hash domain is self-reference
+    /// free and byte-identical across platforms.
     /// </summary>
     internal static byte[] CanonicalizeManifest(JsonElement root)
     {
@@ -729,8 +1018,8 @@ public static partial class PluginPackageVerifier
                 writer.WriteStringValue(element.GetString());
                 break;
             case JsonValueKind.Number:
-                // RawValue preserves the original token text (no float
-                // reformatting; the manifests are integer-only).
+                // RawValue preserves the original token text (integer-only,
+                // enforced by the structural pass).
                 writer.WriteRawValue(element.GetRawText(), skipInputValidation: true);
                 break;
             case JsonValueKind.True:

--- a/tests/DeskBox.Tests/PluginEd25519Tests.cs
+++ b/tests/DeskBox.Tests/PluginEd25519Tests.cs
@@ -76,4 +76,104 @@ public sealed class PluginEd25519Tests
 
         Assert.False(PluginEd25519.Verify(signature, "deskbox"u8.ToArray(), publicKey));
     }
+
+    // ----- adversarial public keys / signatures (round 9) -----
+
+    // The base point encoding = [1]B; with S = 1 (little-endian) this is
+    // the classic small-order-public-key forge: right = R + h*A collapses
+    // to R when A is the identity, so the "signature" verifies for ANY
+    // message without any private key.
+    private static byte[] ForgedSignature() => Convert.FromHexString(
+        "5866666666666666666666666666666666666666666666666666666666666666" + // R = base point
+        "0100000000000000000000000000000000000000000000000000000000000000"); // S = 1
+
+    [Fact]
+    public void Verify_RejectsIdentityPublicKeyForge()
+    {
+        byte[] signature = ForgedSignature();
+        byte[] identityKey = Convert.FromHexString(
+            "0100000000000000000000000000000000000000000000000000000000000000");
+
+        Assert.False(PluginEd25519.Verify(signature, "any message"u8.ToArray(), identityKey));
+        Assert.False(PluginEd25519.Verify(signature, "other message"u8.ToArray(), identityKey));
+        Assert.False(PluginEd25519.Verify(signature, [], identityKey));
+    }
+
+    public static TheoryData<string> SmallOrderPublicKeyHex => new()
+    {
+        // identity (order 1)
+        "0100000000000000000000000000000000000000000000000000000000000000",
+        // 0xff * 32: non-canonical y >= p
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        // y = 0 with the sign bit set: non-canonical
+        "0000000000000000000000000000000000000000000000000000000000000080"
+    };
+
+    [Theory]
+    [MemberData(nameof(SmallOrderPublicKeyHex))]
+    public void Verify_RejectsSmallOrderOrNonCanonicalPublicKeys(string publicKeyHex)
+    {
+        byte[] signature = ForgedSignature();
+
+        Assert.False(PluginEd25519.Verify(
+            signature,
+            "any"u8.ToArray(),
+            Convert.FromHexString(publicKeyHex)));
+    }
+
+    [Fact]
+    public void Verify_RejectsSmallOrderRWithLegitimateKey()
+    {
+        // R = identity (01 00 ...), S = 1, real key: strict verification
+        // rejects small-order R outright.
+        byte[] signature = new byte[64];
+        signature[0] = 0x01; // R = identity encoding
+        signature[32] = 0x01; // S = 1
+
+        Assert.False(PluginEd25519.Verify(
+            signature,
+            "deskbox"u8.ToArray(),
+            Convert.FromBase64String(PublicKeyBase64)));
+    }
+
+    // ----- RFC 8032 §7.1 official vectors (independent ground truth from
+    // the Node-generated dev-key vectors) -----
+
+    public static TheoryData<string, string, string> Rfc8032Vectors => new()
+    {
+        // TEST 1: empty message
+        {
+            "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+            "",
+            "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b"
+        },
+        // TEST 2: one byte 0x72
+        {
+            "3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c",
+            "72",
+            "92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00"
+        },
+        // TEST 3: two bytes af82
+        {
+            "fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025",
+            "af82",
+            "6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a"
+        },
+        // TEST 1024: 1023-byte message
+        {
+            "278117fc144c72340f67d0f2316e8386ceffbf2b2428c9c51fef7c597f1d426e",
+            "08b8b2b733424243760fe426a4b54908632110a66c2f6591eabd3345e3e4eb98fa6e264bf09efe12ee50f8f54e9f77b1e355f6c50544e23fb1433ddf73be84d879de7c0046dc4996d9e773f4bc9efe5738829adb26c81b37c93a1b270b20329d658675fc6ea534e0810a4432826bf58c941efb65d57a338bbd2e26640f89ffbc1a858efcb8550ee3a5e1998bd177e93a7363c344fe6b199ee5d02e82d522c4feba15452f80288a821a579116ec6dad2b3b310da903401aa62100ab5d1a36553e06203b33890cc9b832f79ef80560ccb9a39ce767967ed628c6ad573cb116dbefefd75499da96bd68a8a97b928a8bbc103b6621fcde2beca1231d206be6cd9ec7aff6f6c94fcd7204ed3455c68c83f4a41da4af2b74ef5c53f1d8ac70bdcb7ed185ce81bd84359d44254d95629e9855a94a7c1958d1f8ada5d0532ed8a5aa3fb2d17ba70eb6248e594e1a2297acbbb39d502f1a8c6eb6f1ce22b3de1a1f40cc24554119a831a9aad6079cad88425de6bde1a9187ebb6092cf67bf2b13fd65f27088d78b7e883c8759d2c4f5c65adb7553878ad575f9fad878e80a0c9ba63bcbcc2732e69485bbc9c90bfbd62481d9089beccf80cfe2df16a2cf65bd92dd597b0707e0917af48bbb75fed413d238f5555a7a569d80c3414a8d0859dc65a46128bab27af87a71314f318c782b23ebfe808b82b0ce26401d2e22f04d83d1255dc51addd3b75a2b1ae0784504df543af8969be3ea7082ff7fc9888c144da2af58429ec96031dbcad3dad9af0dcbaaaf268cb8fcffead94f3c7ca495e056a9b47acdb751fb73e666c6c655ade8297297d07ad1ba5e43f1bca32301651339e22904cc8c42f58c30c04aafdb038dda0847dd988dcda6f3bfd15c4b4c4525004aa06eeff8ca61783aacec57fb3d1f92b0fe2fd1a85f6724517b65e614ad6808d6f6ee34dff7310fdc82aebfd904b01e1dc54b2927094b2db68d6f903b68401adebf5a7e08d78ff4ef5d63653a65040cf9bfd4aca7984a74d37145986780fc0b16ac451649de6188a7dbdf191f64b5fc5e2ab47b57f7f7276cd419c17a3ca8e1b939ae49e488acba6b965610b5480109c8b17b80e1b7b750dfc7598d5d5011fd2dcc5600a32ef5b52a1ecc820e308aa342721aac0943bf6686b64b2579376504ccc493d97e6aed3fb0f9cd71a43dd497f01f17c0e2cb3797aa2a2f256656168e6c496afc5fb93246f6b1116398a346f1a641f3b041e989f7914f90cc2c7fff357876e506b50d334ba77c225bc307ba537152f3f1610e4eafe595f6d9d90d11faa933a15ef1369546868a7f3a45a96768d40fd9d03412c091c6315cf4fde7cb68606937380db2eaaa707b4c4185c32eddcdd306705e4dc1ffc872eeee475a64dfac86aba41c0618983f8741c5ef68d3a101e8a3b8cac60c905c15fc910840b94c00a0b9d0",
+            "0aab4c900501b3e24d7cdf4663326a3a87df5e4843b2cbdb67cbf6e460fec350aa5371b1508f9f4528ecea23c436d94b5e8fcd4f681e30a6ac00a9704a188a03"
+        }
+    };
+
+    [Theory]
+    [MemberData(nameof(Rfc8032Vectors))]
+    public void Verify_AcceptsRfc8032OfficialVectors(string publicKeyHex, string messageHex, string signatureHex)
+    {
+        Assert.True(PluginEd25519.Verify(
+            Convert.FromHexString(signatureHex),
+            Convert.FromHexString(messageHex),
+            Convert.FromHexString(publicKeyHex)));
+    }
 }

--- a/tests/DeskBox.Tests/PluginPackageVerifierTests.cs
+++ b/tests/DeskBox.Tests/PluginPackageVerifierTests.cs
@@ -131,10 +131,133 @@ public sealed class PluginPackageVerifierTests : IDisposable
             Path.Combine(package, "package.integrity"),
             $"{digest}  manifest.json\n");
 
+        PluginPackageVerifier.VerificationResult devResult = PluginPackageVerifier.Verify(
+            package, PluginPackageVerificationPolicy.Development);
+
+        Assert.True(devResult.IsValid, string.Join("; ", devResult.Failures));
+        Assert.True(devResult.UnsignedPackage);
+
+        PluginPackageVerifier.VerificationResult storeResult = PluginPackageVerifier.Verify(
+            package, PluginPackageVerificationPolicy.Store);
+
+        Assert.False(storeResult.IsValid);
+        Assert.Contains(storeResult.Failures, f =>
+            f.Contains("signature required for store packages", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void MalformedPackage_NeverThrows_AllFailuresAreResults()
+    {
+        // Fail-closed total function (round 9): wrong types, invalid
+        // base64, garbage - every byte input yields a result, never an
+        // unhandled exception, and structural failures stop the phases.
+        string package = Path.Combine(_tempRoot, "malformed-pkg");
+        Directory.CreateDirectory(package);
+        File.WriteAllText(
+            Path.Combine(package, "manifest.json"),
+            """
+            {
+              "schemaVersion": "zero",
+              "id": [],
+              "version": 1.5,
+              "publisher": {},
+              "publisherPublicKey": "!!!!not-base64!!!!",
+              "runtime": 7,
+              "hostApi": { "min": 3 },
+              "contributions": "nope",
+              "permissions": [ { "id": "bad", "required": "yes", "scope": { "allow": [ 42 ] } } ],
+              "dataSources": { "UPPER": { "type": "http-json", "url": "http://x/", "refreshSeconds": 1.5 } },
+              "entry": { "main": 5 }
+            }
+            """);
+        File.WriteAllText(Path.Combine(package, "package.integrity"), "garbage\n");
+
         PluginPackageVerifier.VerificationResult result = PluginPackageVerifier.Verify(package);
 
-        Assert.True(result.IsValid, string.Join("; ", result.Failures));
-        Assert.True(result.UnsignedPackage);
+        Assert.False(result.IsValid);
+        Assert.NotEmpty(result.Failures);
+        // Structural phase must report the type violations it is designed
+        // to catch (wrong types now FAIL instead of silently skipping).
+        Assert.Contains(result.Failures, f => f.Contains("schemaVersion must be an integer", StringComparison.Ordinal));
+        Assert.Contains(result.Failures, f => f.Contains("id must be a string", StringComparison.Ordinal));
+        Assert.Contains(result.Failures, f => f.Contains("runtime must be a string", StringComparison.Ordinal));
+        Assert.Contains(result.Failures, f => f.Contains("hostApi.min must be a non-empty string", StringComparison.Ordinal));
+        Assert.Contains(result.Failures, f => f.Contains("manifest numbers must be integers", StringComparison.Ordinal));
+        Assert.Contains(result.Failures, f => f.Contains("map key 'UPPER' must use the local id pattern", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FloatNumbers_AreRejectedInSignedPackagesToo()
+    {
+        // Floats would break cross-platform canonicalization: even a
+        // structurally-plausible float must fail (integer-only manifests).
+        string copy = CopyPackage("spikes/github-stats");
+        string manifestPath = Path.Combine(copy, "manifest.json");
+        File.WriteAllText(
+            manifestPath,
+            File.ReadAllText(manifestPath).Replace("\"version\": 1", "\"version\": 1", StringComparison.Ordinal));
+
+        // Inject a float into a payload field (payload allows extra fields).
+        File.WriteAllText(
+            manifestPath,
+            File.ReadAllText(manifestPath).Replace("\"value\": \"1284\"", "\"value\": \"1284\", \"rating\": 4.5"));
+
+        PluginPackageVerifier.VerificationResult result = PluginPackageVerifier.Verify(
+            copy, PluginPackageVerificationPolicy.Development);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, f => f.Contains("manifest numbers must be integers", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ValidBase64ButWrongLengthKey_IsRejectedWithoutThrowing()
+    {
+        string package = Path.Combine(_tempRoot, "badkey-pkg");
+        Directory.CreateDirectory(package);
+        string manifest = """
+        {
+          "schemaVersion": 0,
+          "id": "com.example.bad",
+          "version": "0.1.0",
+          "publisher": "PUB",
+          "publisherPublicKey": "QUJD",
+          "runtime": "none",
+          "hostApi": { "min": "1.0.0", "max": "1.0.0" },
+          "contributions": [
+            { "type": "widget", "id": "x", "displayName": "X", "template": "metric", "payload": { "version": 1 } }
+          ],
+          "signature": { "contentHash": "PLACEHOLDER", "publisherSignature": "!!!" }
+        }
+        """
+        .Replace("\"publisher\": \"PUB\"", "\"publisher\": \"" + new string('a', 64) + "\"");
+        string manifestPath = Path.Combine(package, "manifest.json");
+        File.WriteAllText(manifestPath, manifest);
+
+        // Integrity line covers the manifest's canonical form (signature
+        // forced null, so the placeholder contentHash is excluded); the
+        // real contentHash is then back-filled into the manifest without
+        // changing the canonical hash.
+        using (JsonDocument document = JsonDocument.Parse(manifest))
+        {
+            string digest = Convert.ToHexString(
+                System.Security.Cryptography.SHA256.HashData(PluginPackageVerifier.CanonicalizeManifest(document.RootElement)))
+                .ToLowerInvariant();
+            File.WriteAllText(
+                Path.Combine(package, "package.integrity"),
+                $"{digest}  manifest.json\n");
+        }
+        string integrityHash = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(
+            File.ReadAllBytes(Path.Combine(package, "package.integrity")))).ToLowerInvariant();
+        File.WriteAllText(manifestPath, manifest.Replace("\"PLACEHOLDER\"", $"\"{integrityHash}\""));
+
+        PluginPackageVerifier.VerificationResult result = PluginPackageVerifier.Verify(package);
+
+        Assert.False(result.IsValid);
+        // Short key ("QUJB" = 3 bytes) / invalid signature base64 are
+        // reported as failures, never thrown.
+        Assert.Contains(result.Failures, f =>
+            f.Contains("must decode to 32 raw bytes", StringComparison.Ordinal) ||
+            f.Contains("not valid base64", StringComparison.Ordinal));
     }
 
     private string CopyPackage(string relativePackagePath)


### PR DESCRIPTION
fix: B1a hardening - weak-key forge fix, fail-closed verifier, integer-only manifests

Ninth review round: B1a became the product trust boundary, so the bar
went up. Both P0s were verified real before fixing (the weak-key forge
was proven against the shipped code by a test that failed exactly as the
review predicted), and the three P1s landed with it.

- Ed25519 weak-public-key forgery (P0): an identity-encoded public key
  (01 00 ... 00) made h*A collapse, so the forged signature R=B, S=1
  verified for ANY message with no private key - once a user trusted
  that publisher fingerprint, anyone could forge its updates. Fixed with
  strict decoding for BOTH the public key and R: canonical-encoding
  check (re-encode and byte-compare, which also rejects y >= p and
  unused bits) plus 8-torsion rejection ([8]P = identity). Ground truth
  now has two independent sources: the Node-generated dev-key vectors
  AND the four RFC 8032 7.1 official vectors (including the 1023-byte
  message). Adversarial vectors pin the identity forge, 0xff-filled and
  sign-bit y=0 encodings, and small-order R. Long term (roadmap 16.11):
  the trust root migrates to Rust ed25519-dalek via the deskbox-native
  ABI before the store GA - the BigInteger implementation is a
  transition, not the destination.
- Fail-closed total function (P0): Verify() on fully untrusted bytes
  never throws - a top-level catch converts internal errors into
  Invalid+diagnostics, and the signature path wraps base64/hex decoding
  (publisherPublicKey "!!!!" used to escape as FormatException). Phases
  now STOP on first failure (structure, then integrity, then
  signature); the old flow kept verifying signatures on packages that
  had already failed structurally.
- Strict type validation (P1): the old helpers silently skipped checks
  when a property had the wrong JSON type, so "schemaVersion": "zero"
  and 999 both slipped past. Every field now fails on wrong type first:
  schemaVersion integer==0, id/version/runtime/publisher strings with
  patterns, hostApi object with string min/max (previously not mirrored
  from the Node validator at all), permissions entries (required
  boolean, scope object with string-array allow), map keys.
- Integer-only manifests (P1, option B): Node JSON.stringify re-formats
  1.0 to 1 while the C# canonicalizer preserves raw tokens -
  cross-platform hash drift with no cheap fix. Schema v0.3 numeric
  fields are now integer (defaultSize included), the C# verifier
  rejects any ./e/E number token anywhere in the manifest, and the
  float question is deferred until a real need pays for full RFC 8785
  number canonicalization.
- VerificationPolicy (P1): Verify(path) now defaults to Store =
  signature mandatory; unsigned packages verify only under an explicit
  Development policy. B1b's PackageManager will call Store, so "forgot
  to check UnsignedPackage" can never become a vulnerability.
- Roadmap 16.11 also records: DNS rebinding promoted from backlog to a
  B2 BLOCKER (resolve-then-check-IPs before the first product network
  request), installer input budgets assigned to B1b (manifest/integrity
  size caps, file count, single-file size, path length), and the
  process note that test vectors are hex/program-generated - never
  hand-copied base64 (two transcription errors were caught this round).

Tests: +11 (identity forge triple, small-order/non-canonical encodings,
small-order R, RFC 8032 x4, malformed-package never-throws with type
assertions, float rejection, wrong-length key without throwing, Store
vs Development policy). 3482/3482 green x64. Canonical Debug rebuilt
and restarted (pid 25468).
