### PR TITLE
fix: round-10 - torsion-check bug, reparse-point traversal, IPv4-mapped bypass, canonical integer closure

### DIFF
--- a/docs/architecture/plugin-schema-v0-notes.md
+++ b/docs/architecture/plugin-schema-v0-notes.md
@@ -53,6 +53,11 @@
 | 签名输入 | `publisherSignature` 签 contentHash 的 raw 32 字节摘要，非 hex 字符串 |
 | contentHash 表示 | 小写 hex 存储；清单行 `<sha256 小写 hex>␣␣<path>`（摘要+两空格+路径），LF 行尾 ordinal 排序 |
 | **manifest 数字整数化（第九轮）** | **manifest 全部数字字段=integer**（v0.3 `defaultSize.width/height` 同改 integer）——Node `JSON.stringify` 会重排 `1.0`→`1` 而 C# 原样保留 token，跨平台漂移无解，禁浮点最便宜；C# 验证器结构期对全树拒绝 `./e/E` 数字 token，Node 工具链同步（v1 若真需要浮点再实现完整 RFC 8785 数字规范化） |
+| **safe-integer+去 -0（第十轮）** | 整数限定 **JSON 安全范围 ±(2^53-1)**（`9007199254740993` 在 Node IEEE-754 parse 下变 `...992`）；**`-0` 拒绝**（Node canonicalize 成 `0` 而 C# raw token 不同）；canonicalizer 不再透传 raw token，**parse 后重写十进制** |
+| **重复 JSON key 拒绝（第十轮）** | 任意 object 内重复属性名=invalid（解析器对 last/first-wins 各行其是；签名 manifest 零保留价值），C# 验证器全树扫描 |
+| **权限注册表（第十轮）** | v0 恰好两个权限 id：`network.fetch`/`shell.open`；未知 id install 期直接拒绝（不做"先入库后议"） |
+| **scope 去 deny（第十轮）** | v0.3 只有 exact-host allow list——`deny` 从 schema 删除（实现漂移：产品门从未实现 deny；等 files.read 类真需要 deny 语义再加） |
+| **Windows 路径文法（第十轮）** | 追加拒绝：DOS 保留设备名（CON/PRN/AUX/NUL/COM1-9/LPT1-9，含带扩展名形态）、段尾空格/句点、控制字符——integrity 字符串与文件系统对象必须同指 |
 
 ## v0 → v0.1 变更（第三轮外部评审吸收，roadmap 16.7）
 

--- a/docs/architecture/plugin-schema-v0.json
+++ b/docs/architecture/plugin-schema-v0.json
@@ -173,8 +173,7 @@
           "scope": {
             "type": "object",
             "properties": {
-              "allow": { "type": "array", "items": { "type": "string" }, "description": "e.g. directory globs (Downloads/**), URL filters (api.github.com), quotas (100/day)." },
-              "deny": { "type": "array", "items": { "type": "string" }, "description": "Deny always wins over allow; the host additionally maintains defensive default-denies (own config/credential dirs)." }
+              "allow": { "type": "array", "items": { "type": "string" }, "description": "e.g. directory globs (Downloads/**), URL hosts (api.github.com), quotas (100/day). v0.3: exact-host allow lists only." }
             },
             "additionalProperties": false
           }

--- a/docs/architecture/pluginization-roadmap.md
+++ b/docs/architecture/pluginization-roadmap.md
@@ -458,6 +458,21 @@ B1a 进入产品安全边界后标准升级；五项全部落地（本批）：
 
 **优先级调整（评审采纳）**：DNS 重绑定（hostname 解析到私网 IP）从 backlog **升格为 B2 blocker**——Declarative Executor 发出第一个产品网络请求前必须实现"解析后 IP 复检"；**installer 输入预算**归 B1b（manifest/integrity 体积上限、文件数、单文件大小、路径长度——恶意包不该能在验签失败前耗尽资源）。执行坑：手抄 base64 常量两次抄错——**测试向量一律 hex/程序生成，永不手抄**。
 
+### 16.12 第十轮评审吸收（2026-09-08，B1a 硬化二）
+
+三 P0+四 P1 全核实全修（本批）；核心教训=**连续三轮（方程符号→identity 伪造→[4]P 冒充 [8]P）证明自研密码学实现会持续产出此类 bug**：
+
+1. **[8]P 实为 [4]P（P0）**：`Add(2P,2P)=4P`，真 order-8 点漏过——修正为 p2/p4/p8 三跳；补**真 order-8 向量**（`c7176a70…`，独立 BigInt 实现算 [L]generic-point 得到，恰为业界知名小阶向量）+order-2 向量。**Trust root 迁 Rust `ed25519-dalek` verify_strict 从"store GA 前"提前为 B1b/B2 期间执行**（C# BigInteger 降级为 transition/test oracle）。
+2. **reparse point 穿越拒绝（P0）**：`SearchOption.AllDirectories` 跟随 symlink/junction——恶意包可读包外文件或构造循环耗尽资源；显式 walk 树，**任何 reparse point=包 invalid**（不是跳过——link 也不该存在于 integrity 清单），符号链接行为测试（无开发者模式时降级源码钉扎）。
+3. **IPv4-mapped IPv6 绕过（P0）**：`[::ffff:127.0.0.1]` 走 v6 分支漏过私网拒绝——`IsIPv4MappedToIPv6→MapToIPv4` 解包后统一分类；顺带拒绝 unspecified(0.0.0.0/::)/multicast(≥224)——语义模型收敛为"**network.fetch 只允许 globally-routable 目的**，network.local 未来单独授权"。
+4. **DNS rebinding 半步补全**：roadmap 措辞从"resolve→check"升格为"**resolve→validate 全部候选 IP→连接 pin 到已验证 IP**（`SocketsHttpHandler.ConnectCallback`，TLS SNI 仍用原 hostname）"——否则 HttpClient 二次解析仍可被重绑。
+5. **safe-integer+去 -0（P1）**：`9007199254740993`（Node IEEE-754 变 ...992）与 `-0`（Node 变 0）都是跨平台 canonicalization 漂移——整数限 ±(2^53-1)、拒绝 -0、canonicalizer 改 **parse 后重写十进制**（不再透传 raw token）。
+6. **重复 JSON key 拒绝+类型洞补齐+权限注册表（P1）**：重复属性名全树拒绝；displayName/payload/bindings/dataSources 根/actions 根/permissions 根的类型洞补上；v0 权限注册表=恰好 `network.fetch`+`shell.open`，未知 id install 期拒绝；**长期方向（评审 P2 采纳）：结构校验从手写 if 迁往 schema 驱动+跨实现 conformance fixtures 同批喂三实现**（B1b 评估）。
+7. **scope 去 deny（P1）**：v0 只有 exact-host allow——deny 从 schema 删除（产品门从未实现它=语义漂移；真需要 files.read 类 deny 语义再加）。
+8. **Windows 路径文法（P1）**：DOS 保留设备名（CON/NUL/COM1-9…含带扩展名）/段尾空格句点/控制字符拒绝（C#+Node 双侧镜像）。
+
+**B1b 契约追加（评审建议直接入册）**：①Verifier 自带输入预算（`PluginVerificationLimits`：manifest/integrity 字节、文件数、总展开体积、单文件、树深、路径长）——不靠调用方记得检查；②大文件流式哈希（弃 `ReadAllBytes`）；③**验证后产出 typed `VerifiedInstalledPackage` 语义模型**（PackageId/Version/Publisher/Runtime/Permissions/Contributions/ContentHash/InstalledPath）——下游不再重复解析 raw manifest；④**更新 pin publisher**（同 packageId 的后续更新必须同 publisher 指纹）+**版本单调递增**（防 store index 被篡改后的降级/接管攻击）。**B1b 定性（评审结语采纳）：它不是"PackageManager+存授权"，是整个不可信包进入 DeskBox 的 quarantine/validation/immutable-commit 管线。**
+
 ## 附录 A：关键证据文件索引
 
 | 主题 | 文件 |

--- a/scripts/spike/package-ops.mjs
+++ b/scripts/spike/package-ops.mjs
@@ -10,13 +10,36 @@ import path from 'node:path';
 // Package path grammar (platform protocol, pinned early against zip-slip):
 // relative, forward slashes only, no . / .. segments, no drive prefix, no
 // colon (NTFS ADS), no empty segments.
+// Windows-safe path grammar (mirrors the C# verifier; round 10): relative
+// forward-slash paths only, no .. / . / empty / backslash / colon / control
+// chars, no trailing dot/space, no reserved DOS device names (incl. with
+// extensions) - the filesystem and the integrity strings must denote the
+// same object.
+const RESERVED_DEVICE_NAMES = new Set([
+  'CON', 'PRN', 'AUX', 'NUL',
+  'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
+  'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9'
+]);
+
 export function packagePathViolation(rel) {
   if (rel.startsWith('/') || rel.includes('\\') || rel.includes(':')) {
     return 'rooted path, backslash, or colon';
   }
   const segments = rel.split('/');
-  if (segments.some(seg => seg === '' || seg === '.' || seg === '..')) {
-    return 'empty, ".", or ".." segment';
+  for (const seg of segments) {
+    if (seg === '' || seg === '.' || seg === '..') {
+      return "empty, '.', or '..' segment";
+    }
+    if (/[ .]$/.test(seg)) {
+      return 'segment ending in space or dot';
+    }
+    if (/[\x00-\x1f]/.test(seg)) {
+      return 'control character in segment';
+    }
+    const base = seg.split('.')[0].toUpperCase();
+    if (RESERVED_DEVICE_NAMES.has(base)) {
+      return `reserved Windows device name '${base}'`;
+    }
   }
   return null;
 }

--- a/src/DeskBox/Services/Plugins/PluginCapabilityGate.cs
+++ b/src/DeskBox/Services/Plugins/PluginCapabilityGate.cs
@@ -80,24 +80,36 @@ public sealed class PluginCapabilityGate
             return false;
         }
 
+        // IPv4-mapped IPv6 (::ffff:127.0.0.1 etc.) must be unwrapped and
+        // classified as the IPv4 it is - otherwise the v6 branch would
+        // wave loopback/private v4 through (round 10).
+        if (address.IsIPv4MappedToIPv6)
+        {
+            address = address.MapToIPv4();
+        }
+
         if (address.IsIPv6LinkLocal || address.IsIPv6SiteLocal)
         {
             return true;
         }
         if (address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6)
         {
-            // Unique-local fc00::/7 and loopback ::1.
             byte[] bytes = address.GetAddressBytes();
-            return bytes[0] == 0xfc || bytes[0] == 0xfd || address.Equals(IPAddress.IPv6Loopback);
+            // Unspecified (::), loopback (::1), unique-local fc00::/7.
+            return bytes.AsSpan()[..15].SequenceEqual(new byte[15]) ||
+                   bytes[0] == 0xfc || bytes[0] == 0xfd;
         }
 
-        // IPv4: loopback / private / link-local (169.254.169.254 metadata included).
+        // IPv4: unspecified, loopback, private, link-local (metadata
+        // included), multicast/broadcast-reserved.
         byte[] v4 = address.GetAddressBytes();
-        return v4[0] == 127 ||
+        return v4[0] == 0 ||
+               v4[0] == 127 ||
                v4[0] == 10 ||
                (v4[0] == 172 && v4[1] >= 16 && v4[1] <= 31) ||
                (v4[0] == 192 && v4[1] == 168) ||
-               (v4[0] == 169 && v4[1] == 254);
+               (v4[0] == 169 && v4[1] == 254) ||
+               v4[0] >= 224;
     }
 }
 

--- a/src/DeskBox/Services/Plugins/PluginEd25519.cs
+++ b/src/DeskBox/Services/Plugins/PluginEd25519.cs
@@ -93,8 +93,10 @@ internal static class PluginEd25519
         {
             return false;
         }
-        EdwardsPoint times8 = Add(Add(point, point), Add(point, point));
-        return !IsIdentity(times8);
+        EdwardsPoint p2 = Add(point, point);
+        EdwardsPoint p4 = Add(p2, p2);
+        EdwardsPoint p8 = Add(p4, p4);
+        return !IsIdentity(p8);
     }
 
     private static bool IsIdentity(EdwardsPoint point)

--- a/src/DeskBox/Services/Plugins/PluginPackageVerifier.cs
+++ b/src/DeskBox/Services/Plugins/PluginPackageVerifier.cs
@@ -271,11 +271,21 @@ public static partial class PluginPackageVerifier
             }
         }
 
-        // Manifest numbers are integer-only (round 9): floats are rejected
-        // before they can create cross-platform canonicalization drift
-        // (Node JSON.stringify re-formats numbers; raw tokens differ).
-        RejectNonIntegerNumbers(root, "manifest", Fail);
+        // Manifest numbers are integer-only within the JSON safe range and
+        // duplicate keys are rejected (round 10): both are parser-drift
+        // hazards between Node's IEEE-754/last-wins semantics and C#.
+        RejectAmbiguousNumbersAndKeys(root, "manifest", Fail);
 
+        if (root.TryGetProperty("dataSources", out JsonElement dataSourcesElement) &&
+            dataSourcesElement.ValueKind != JsonValueKind.Object)
+        {
+            Fail("dataSources must be an object map");
+        }
+        if (root.TryGetProperty("actions", out JsonElement actionsElement) &&
+            actionsElement.ValueKind != JsonValueKind.Object)
+        {
+            Fail("actions must be an object map");
+        }
         Dictionary<string, JsonElement> dataSources = MapOf(root, "dataSources");
         Dictionary<string, JsonElement> actions = MapOf(root, "actions");
         foreach (string key in dataSources.Keys.Concat(actions.Keys))
@@ -338,15 +348,20 @@ public static partial class PluginPackageVerifier
                     Fail("contribution ids must be unique within the package");
                 }
             }
-            if (StringValue(contribution, "displayName", out string? displayName) && displayName!.Length == 0)
+            if (StringValue(contribution, "displayName") is not { Length: > 0 })
             {
-                Fail($"{where}: displayName minLength 1");
+                Fail($"{where}: displayName must be a non-empty string");
             }
             if (StringValue(contribution, "template") is not { } template || !Templates.Contains(template))
             {
                 Fail($"{where}: template enum");
             }
 
+            if (contribution.TryGetProperty("payload", out JsonElement payloadProperty) &&
+                payloadProperty.ValueKind != JsonValueKind.Object)
+            {
+                Fail($"{where}: payload must be an object");
+            }
             JsonElement payload = contribution.TryGetProperty("payload", out JsonElement payloadElement) &&
                                   payloadElement.ValueKind == JsonValueKind.Object
                 ? payloadElement
@@ -366,9 +381,13 @@ public static partial class PluginPackageVerifier
                 }
             }
 
-            if (contribution.TryGetProperty("bindings", out JsonElement bindings) &&
-                bindings.ValueKind == JsonValueKind.Object)
+            if (contribution.TryGetProperty("bindings", out JsonElement bindings))
             {
+                if (bindings.ValueKind != JsonValueKind.Object)
+                {
+                    Fail($"{where}: bindings must be an object");
+                }
+                else
                 foreach (JsonProperty bindingProperty in bindings.EnumerateObject())
                 {
                     string bindingWhere = $"{where}.bindings['{bindingProperty.Name}']";
@@ -527,6 +546,11 @@ public static partial class PluginPackageVerifier
         }
 
         // Permissions: shape (fail-closed on types), unique ids, consumption rules.
+        if (root.TryGetProperty("permissions", out JsonElement permissionsProperty) &&
+            permissionsProperty.ValueKind != JsonValueKind.Array)
+        {
+            Fail("permissions must be an array");
+        }
         List<JsonElement> permissions = root.TryGetProperty("permissions", out JsonElement permissionsElement) &&
                                         permissionsElement.ValueKind == JsonValueKind.Array
             ? permissionsElement.EnumerateArray().ToList()
@@ -554,6 +578,10 @@ public static partial class PluginPackageVerifier
                 {
                     Fail($"{where}: id pattern");
                 }
+                else if (!KnownPermissionIds.Contains(permissionId))
+                {
+                    Fail($"{where}: unknown permission id '{permissionId}' (registry: {string.Join(", ", KnownPermissionIds)})");
+                }
                 else if (!permissionIds.Add(permissionId))
                 {
                     // Duplicate ids with different scopes would make grant/scope
@@ -580,7 +608,7 @@ public static partial class PluginPackageVerifier
                 {
                     foreach (JsonProperty scopeProperty in scope.EnumerateObject())
                     {
-                        if (scopeProperty.Name is not ("allow" or "deny"))
+                        if (scopeProperty.Name != "allow")
                         {
                             Fail($"{where}.scope: unknown property '{scopeProperty.Name}'");
                         }
@@ -639,22 +667,33 @@ public static partial class PluginPackageVerifier
         }
     }
 
-    /// <summary>Walks the tree and fails on any non-integer number token.</summary>
-    private static void RejectNonIntegerNumbers(JsonElement element, string where, Action<string> fail)
+    /// <summary>
+    /// Walks the tree and rejects duplicate JSON property names (parsers
+    /// disagree on last-vs-first-wins; a signed manifest has zero use for
+    /// them), non-integer numbers, values beyond the JSON safe-integer
+    /// range ±(2^53-1) (Node re-rounds them via IEEE-754), and "-0"
+    /// (Node canonicalizes to "0", C# raw tokens differ).
+    /// </summary>
+    private static void RejectAmbiguousNumbersAndKeys(JsonElement element, string where, Action<string> fail)
     {
         switch (element.ValueKind)
         {
             case JsonValueKind.Object:
+                var seen = new HashSet<string>(StringComparer.Ordinal);
                 foreach (JsonProperty property in element.EnumerateObject())
                 {
-                    RejectNonIntegerNumbers(property.Value, $"{where}.{property.Name}", fail);
+                    if (!seen.Add(property.Name))
+                    {
+                        fail($"{where}: duplicate property '{property.Name}' (parser-ambiguous, rejected)");
+                    }
+                    RejectAmbiguousNumbersAndKeys(property.Value, $"{where}.{property.Name}", fail);
                 }
                 break;
             case JsonValueKind.Array:
                 int index = 0;
                 foreach (JsonElement item in element.EnumerateArray())
                 {
-                    RejectNonIntegerNumbers(item, $"{where}[{index++}]", fail);
+                    RejectAmbiguousNumbersAndKeys(item, $"{where}[{index++}]", fail);
                 }
                 break;
             case JsonValueKind.Number:
@@ -662,6 +701,15 @@ public static partial class PluginPackageVerifier
                 if (raw.Contains('.') || raw.Contains('e') || raw.Contains('E'))
                 {
                     fail($"{where}: manifest numbers must be integers (floats are rejected to avoid cross-platform canonicalization drift)");
+                }
+                else if (raw == "-0")
+                {
+                    fail($"{where}: -0 is rejected (Node canonicalizes it to 0; raw tokens differ)");
+                }
+                else if (!element.TryGetInt64(out long value) ||
+                         value is > 9007199254740991 or < -9007199254740991)
+                {
+                    fail($"{where}: manifest integers must be within the JSON safe range ±(2^53-1) (Node re-rounds larger values via IEEE-754)");
                 }
                 break;
         }
@@ -755,6 +803,18 @@ public static partial class PluginPackageVerifier
         }
     }
 
+    // The v0 permission registry (round 10): exactly two capabilities
+    // exist; unknown ids are rejected at install time - "register it into
+    // the database and decide later" is not allowed.
+    private static readonly string[] KnownPermissionIds = ["network.fetch", "shell.open"];
+
+    // Windows-safe path grammar (round 10): besides the zip-slip rules,
+    // reject DOS device names (CON/NUL/COM1... incl. with extensions),
+    // trailing dots/spaces, and control characters - the filesystem and
+    // the integrity strings must denote the same object.
+    private static readonly string[] ReservedDeviceNames =
+        ["CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"];
+
     // ---------- package path grammar (zip-slip defense, shared with the Node tooling) ----------
     internal static string? PackagePathViolation(string relativePath)
     {
@@ -767,6 +827,20 @@ public static partial class PluginPackageVerifier
             if (segment is "" or "." or "..")
             {
                 return "empty, '.', or '..' segment";
+            }
+            if (segment.EndsWith(' ') || segment.EndsWith('.'))
+            {
+                return "segment ending in space or dot";
+            }
+            if (segment.Any(ch => char.IsControl(ch)))
+            {
+                return "control character in segment";
+            }
+            string baseName = segment.Split('.')[0];
+            if (ReservedDeviceNames.FirstOrDefault(name =>
+                    string.Equals(name, baseName, StringComparison.OrdinalIgnoreCase)) is { } reserved)
+            {
+                return $"reserved Windows device name '{reserved}'";
             }
         }
         return null;
@@ -833,10 +907,21 @@ public static partial class PluginPackageVerifier
             Fail("manifest.json integrity line does not match its canonicalization (signature=null)");
         }
 
-        // Step 2: every payload file hashes to its line and is listed.
-        foreach (string file in EnumeratePayloadFiles(packageDirectory))
+        // Step 2: every payload file hashes to its line and is listed. The
+        // walk never follows reparse points; any reparse point in the tree
+        // is itself a failure (round 10).
+        (List<string> payloadFiles, List<string> walkFailures) = WalkPackageTree(packageDirectory);
+        foreach (string walkFailure in walkFailures)
+        {
+            Fail(walkFailure);
+        }
+        foreach (string file in payloadFiles)
         {
             string relative = Path.GetRelativePath(packageDirectory, file).Replace('\\', '/');
+            if (relative == "package.integrity")
+            {
+                continue;
+            }
             if (PackagePathViolation(relative) is { } violation)
             {
                 Fail($"payload file violates the package path grammar ({violation}): {relative}");
@@ -944,14 +1029,43 @@ public static partial class PluginPackageVerifier
         }
     }
 
-    internal static IEnumerable<string> EnumeratePayloadFiles(string packageDirectory)
+    /// <summary>
+    /// Explicit tree walk that NEVER follows reparse points (round 10):
+    /// SearchOption.AllDirectories follows symlinks/junctions, letting a
+    /// hostile package read outside its directory or loop forever. Any
+    /// reparse point in the package tree is a FAILURE, not an invisible
+    /// skip - a symlink would also be absent from the integrity inventory.
+    /// </summary>
+    internal static (List<string> Files, List<string> Failures) WalkPackageTree(string packageDirectory)
     {
-        return Directory.EnumerateFiles(packageDirectory, "*", SearchOption.AllDirectories)
-            .Where(path =>
+        var files = new List<string>();
+        var failures = new List<string>();
+        var queue = new Queue<string>();
+        queue.Enqueue(packageDirectory);
+        while (queue.Count > 0)
+        {
+            string directory = queue.Dequeue();
+            foreach (string entry in Directory.EnumerateFileSystemEntries(directory))
             {
-                string relative = Path.GetRelativePath(packageDirectory, path).Replace('\\', '/');
-                return relative != "package.integrity";
-            });
+                FileAttributes attributes = File.GetAttributes(entry);
+                if ((attributes & FileAttributes.ReparsePoint) != 0)
+                {
+                    failures.Add(
+                        $"package tree contains a reparse point (symlink/junction/mount): " +
+                        Path.GetRelativePath(packageDirectory, entry).Replace('\\', '/'));
+                    continue;
+                }
+                if ((attributes & FileAttributes.Directory) != 0)
+                {
+                    queue.Enqueue(entry);
+                }
+                else
+                {
+                    files.Add(entry);
+                }
+            }
+        }
+        return (files, failures);
     }
 
     /// <summary>
@@ -1018,9 +1132,11 @@ public static partial class PluginPackageVerifier
                 writer.WriteStringValue(element.GetString());
                 break;
             case JsonValueKind.Number:
-                // RawValue preserves the original token text (integer-only,
-                // enforced by the structural pass).
-                writer.WriteRawValue(element.GetRawText(), skipInputValidation: true);
+                // Parsed-and-rewritten decimal (round 10), NOT the raw
+                // token: integers are safe-range only (enforced by the
+                // structural pass), so the rewrite is byte-stable with the
+                // Node canonicalization.
+                writer.WriteNumberValue(element.GetInt64());
                 break;
             case JsonValueKind.True:
                 writer.WriteBooleanValue(true);

--- a/tests/DeskBox.Tests/PluginCapabilityGateConformanceTests.cs
+++ b/tests/DeskBox.Tests/PluginCapabilityGateConformanceTests.cs
@@ -101,10 +101,21 @@ public sealed class PluginCapabilityGateConformanceTests
     [InlineData("https://192.168.1.1/x")]
     [InlineData("https://169.254.169.254/latest/meta-data")]
     [InlineData("https://[fd12::1]/x")]
+    // Round 10: IPv4-mapped IPv6 must classify as the IPv4 it is.
+    [InlineData("https://[::ffff:127.0.0.1]/x")]
+    [InlineData("https://[::ffff:10.1.2.3]/x")]
+    [InlineData("https://[::ffff:192.168.1.1]/x")]
+    // Round 10: unspecified and multicast are not globally routable.
+    [InlineData("https://0.0.0.0/x")]
+    [InlineData("https://[::]/x")]
+    [InlineData("https://224.0.0.1/x")]
     public void LocalNetwork_IsRefusedByDefault(string url)
     {
-        string refusal = Refusal(url, ["127.0.0.1", "localhost", "::1", "10.1.2.3", "169.254.169.254", "fd12::1"],
-            ["127.0.0.1", "localhost", "::1", "10.1.2.3", "169.254.169.254", "fd12::1"]);
+        string refusal = Refusal(url,
+            ["127.0.0.1", "localhost", "::1", "10.1.2.3", "169.254.169.254", "fd12::1",
+             "::ffff:127.0.0.1", "::ffff:10.1.2.3", "::ffff:192.168.1.1", "0.0.0.0", "224.0.0.1"],
+            ["127.0.0.1", "localhost", "::1", "10.1.2.3", "169.254.169.254", "fd12::1",
+             "::ffff:127.0.0.1", "::ffff:10.1.2.3", "::ffff:192.168.1.1", "0.0.0.0", "224.0.0.1"]);
 
         Assert.Contains("local-network", refusal, StringComparison.Ordinal);
     }

--- a/tests/DeskBox.Tests/PluginEd25519Tests.cs
+++ b/tests/DeskBox.Tests/PluginEd25519Tests.cs
@@ -103,6 +103,12 @@ public sealed class PluginEd25519Tests
     {
         // identity (order 1)
         "0100000000000000000000000000000000000000000000000000000000000000",
+        // genuine order-8 point (independently computed as [L] of a generic
+        // curve point; also the well-known small-order vector) - this is
+        // the case the [4]P-vs-[8]P bug let through (round 10)
+        "c7176a703d4dd84fba3c0b760d10670f2a2053fa2c39ccc64ec7fd7792ac037a",
+        // order-2 point: y = p-1, x = 0
+        "ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
         // 0xff * 32: non-canonical y >= p
         "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
         // y = 0 with the sign bit set: non-canonical

--- a/tests/DeskBox.Tests/PluginPackageVerifierTests.cs
+++ b/tests/DeskBox.Tests/PluginPackageVerifierTests.cs
@@ -187,6 +187,147 @@ public sealed class PluginPackageVerifierTests : IDisposable
     }
 
     [Fact]
+    public void DuplicateJsonKeys_AreRejected()
+    {
+        // Round 10: parsers disagree on last-vs-first-wins for duplicate
+        // members; signed manifests have zero use for them.
+        string package = Path.Combine(_tempRoot, "dup-key-pkg");
+        Directory.CreateDirectory(package);
+        string manifest = """
+        {
+          "schemaVersion": 0,
+          "schemaVersion": 0,
+          "id": "com.example.dup",
+          "version": "0.1.0",
+          "publisher": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "publisherPublicKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+          "runtime": "none",
+          "hostApi": { "min": "1.0.0", "max": "1.0.0" },
+          "contributions": [
+            { "type": "widget", "id": "x", "displayName": "X", "template": "metric", "payload": { "version": 1 } }
+          ],
+          "signature": null
+        }
+        """;
+        File.WriteAllText(Path.Combine(package, "manifest.json"), manifest);
+
+        PluginPackageVerifier.VerificationResult result = PluginPackageVerifier.Verify(
+            package, PluginPackageVerificationPolicy.Development);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, f =>
+            f.Contains("duplicate property 'schemaVersion'", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void UnsafeIntegersAndNegativeZero_AreRejected()
+    {
+        // Round 10: integers beyond ±(2^53-1) re-round in Node's IEEE-754
+        // parse; "-0" canonicalizes to "0" in Node but not in C# raw text.
+        string package = Path.Combine(_tempRoot, "unsafe-int-pkg");
+        Directory.CreateDirectory(package);
+        string manifest = """
+        {
+          "schemaVersion": 0,
+          "id": "com.example.unsafe",
+          "version": "0.1.0",
+          "publisher": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "publisherPublicKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+          "runtime": "none",
+          "hostApi": { "min": "1.0.0", "max": "1.0.0" },
+          "contributions": [
+            { "type": "widget", "id": "x", "displayName": "X", "template": "metric",
+              "payload": { "version": 1, "big": 9007199254740993, "neg": -0 } }
+          ],
+          "signature": null
+        }
+        """;
+        File.WriteAllText(Path.Combine(package, "manifest.json"), manifest);
+
+        PluginPackageVerifier.VerificationResult result = PluginPackageVerifier.Verify(
+            package, PluginPackageVerificationPolicy.Development);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, f => f.Contains("JSON safe range", StringComparison.Ordinal));
+        Assert.Contains(result.Failures, f => f.Contains("-0 is rejected", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void UnknownPermissionIds_AreRejected()
+    {
+        // Round 10: the v0 registry has exactly network.fetch and
+        // shell.open; "evil.super-admin" must not pass a format check.
+        string copy = CopyPackage("spikes/github-stats");
+        string manifestPath = Path.Combine(copy, "manifest.json");
+        File.WriteAllText(
+            manifestPath,
+            File.ReadAllText(manifestPath).Replace(
+                "\"id\": \"network.fetch\"",
+                "\"id\": \"evil.super-admin\""));
+
+        PluginPackageVerifier.VerificationResult result = PluginPackageVerifier.Verify(
+            copy, PluginPackageVerificationPolicy.Development);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, f =>
+            f.Contains("unknown permission id 'evil.super-admin'", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void WindowsReservedNamesInPaths_AreRejected()
+    {
+        // Round 10: CON/NUL/COM1... (also with extensions), trailing dots
+        // and spaces are filesystem-level aliases the integrity grammar
+        // must not allow.
+        Assert.Equal(
+            "reserved Windows device name 'NUL'",
+            PluginPackageVerifier.PackagePathViolation("files/NUL.txt"));
+        Assert.Equal(
+            "reserved Windows device name 'CON'",
+            PluginPackageVerifier.PackagePathViolation("con"));
+        Assert.Equal(
+            "segment ending in space or dot",
+            PluginPackageVerifier.PackagePathViolation("files/foo."));
+        Assert.Equal(
+            "segment ending in space or dot",
+            PluginPackageVerifier.PackagePathViolation("files/bar "));
+        Assert.Null(PluginPackageVerifier.PackagePathViolation("files/normal.txt"));
+    }
+
+    [Fact]
+    public void ReparsePointsInPackageTree_AreRejected()
+    {
+        // Round 10: a symlink inside the package would let the verifier
+        // read outside the package (SearchOption.AllDirectories follows
+        // reparse points) or loop forever. The walk must FAIL the package.
+        string copy = CopyPackage("spikes/github-stats");
+        string linkPath = Path.Combine(copy, "files", "escape-link");
+        string outsideDirectory = Directory.CreateDirectory(Path.Combine(_tempRoot, "outside-target")).FullName;
+        try
+        {
+            Directory.CreateSymbolicLink(linkPath, outsideDirectory);
+        }
+        catch (Exception)
+        {
+            // Symbolic link creation needs developer mode/admin - when
+            // unavailable (some CI/local configurations), the behavioral
+            // test degrades to the source pin below.
+            string verifierSource = File.ReadAllText(TestPaths.SourceFile(
+                "src/DeskBox/Services/Plugins/PluginPackageVerifier.cs"));
+            Assert.Contains("WalkPackageTree", verifierSource, StringComparison.Ordinal);
+            Assert.Contains("FileAttributes.ReparsePoint", verifierSource, StringComparison.Ordinal);
+            return;
+        }
+
+        PluginPackageVerifier.VerificationResult result = PluginPackageVerifier.Verify(
+            copy, PluginPackageVerificationPolicy.Development);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, f =>
+            f.Contains("reparse point", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void FloatNumbers_AreRejectedInSignedPackagesToo()
     {
         // Floats would break cross-platform canonicalization: even a


### PR DESCRIPTION
fix: round-10 - torsion-check bug, reparse-point traversal, IPv4-mapped bypass, canonical integer closure

Tenth review round: three P0s and four P1s, all verified against the
code and all fixed here. The running lesson (three crypto bugs in three
rounds: equation sign, identity forge, [4]P-as-[8]P) is recorded in the
roadmap - the Rust ed25519-dalek trust-root migration moves UP from
"before store GA" to "during B1b/B2", with the BigInteger verifier
demoted to a transition/test oracle.

- Torsion check computed [4]P not [8]P (P0): Add(2P, 2P) is 4P, so
  genuine order-8 points slipped through the small-order rejection. The
  check now does the p2/p4/p8 chain, and the adversarial vectors gain a
  REAL order-8 point (c7176a70..., independently computed as [L] of a
  generic curve point - note the dev key lies in the prime-order
  subgroup, so [L]Q of it is identity; also the well-known small-order
  test vector) plus the order-2 point (y = p-1).
- Reparse-point traversal (P0): SearchOption.AllDirectories follows
  symlinks/junctions, letting a hostile package read files outside
  itself or loop a junction ring forever. The verifier now walks the
  tree explicitly and ANY reparse point is a package FAILURE (not a
  skip - a symlink could hide outside the integrity inventory).
  Behavioral test creates a real directory symlink (degrading to a
  source pin where developer mode is unavailable).
- IPv4-mapped IPv6 bypass (P0): [::ffff:127.0.0.1] took the v6 branch
  and waved loopback through. Now unwrapped via IsIPv4MappedToIPv6/
  MapToIPv4 and classified as the IPv4 it is; unspecified (0.0.0.0, ::)
  and multicast (>=224) are also denied. The gate's semantic model is
  now "globally-routable destinations only; network.local is a future
  separate grant."
- Canonical integer closure (P1): integers were still raw tokens, so
  9007199254740993 (Node's IEEE-754 parse re-rounds it to ...992) and
  -0 (Node canonicalizes to 0) drifted between platforms. Integers are
  now bounded to the JSON safe range ±(2^53-1), -0 is rejected, and the
  canonicalizer PARSES and rewrites the decimal instead of passing the
  raw token through.
- Duplicate JSON property names are rejected tree-wide (P1): parsers
  disagree on last-vs-first-wins; a signed manifest has zero use for
  them. Plus the remaining type holes (displayName/payload/bindings/
  dataSources root/actions root/permissions root) now fail on wrong
  types instead of silently skipping.
- Permission registry (P1): v0 knows exactly network.fetch and
  shell.open; "evil.super-admin" passing a format check is over - the
  C# verifier rejects unknown ids at install time.
- scope.deny removed from the schema (P1): the product gate never
  implemented it and v0 is exact-host allow lists only - protocol/
  product drift removed by deletion; deny comes back when files.read-
  style semantics actually need it.
- Windows path grammar (P1): DOS reserved device names (CON/NUL/COM1-9
  ... including with extensions), trailing dots/spaces, and control
  characters are rejected (C# and Node tooling both) so the integrity
  strings and the filesystem denote the same objects.
- Roadmap 16.12 also records: DNS rebinding upgraded to
  resolve-validate-CONNECT-TO-THE-VALIDATED-IP (ConnectCallback with
  SNI kept - a plain resolve-then-check still races HttpClient's second
  lookup), and the B1b contract gains verifier-owned input budgets,
  streaming hashes, the typed VerifiedInstalledPackage model (no more
  raw-manifest reparsing downstream), publisher pinning + version
  monotonicity for updates, and the framing that B1b is the full
  untrusted-package quarantine/validation/immutable-commit pipeline.

Tests: +13 (order-8 + order-2 vectors; three IPv4-mapped vectors,
unspecified, multicast; duplicate key; safe-integer + -0; unknown
permission id; reserved names; reparse-point package). 3495/3495 green
x64; all four committed packages re-verify under the mirrored Node
grammar. Canonical Debug rebuilt and restarted (pid 36464).
