### PR TITLE
feat: B1b - package manager pipeline, grant store, input budgets, streaming hashes

### DIFF
--- a/src/DeskBox/Services/Plugins/PluginGrantStore.cs
+++ b/src/DeskBox/Services/Plugins/PluginGrantStore.cs
@@ -1,0 +1,139 @@
+using System.Text.Json;
+
+namespace DeskBox.Services.Plugins;
+
+/// <summary>
+/// Persists host-side grants (requested != granted, roadmap 16.10):
+/// packageId -> permissionId -> granted hosts. Install UI writes grants
+/// after the user approves; the capability gate consumes them at runtime.
+/// Hand-rolled JsonDocument/Utf8JsonWriter persistence - the frozen
+/// JsonSerializer baseline stays untouched.
+/// </summary>
+public sealed class PluginGrantStore
+{
+    private readonly string _grantsPath;
+    private readonly object _lock = new();
+
+    public PluginGrantStore()
+        : this(Path.Combine(
+            DeskBoxDataPathService.Current.DataDirectory,
+            "plugins"))
+    {
+    }
+
+    internal PluginGrantStore(string pluginsRoot)
+    {
+        Directory.CreateDirectory(pluginsRoot);
+        _grantsPath = Path.Combine(pluginsRoot, "grants.json");
+    }
+
+    /// <summary>Sets the granted hosts for one package+permission (replaces prior hosts).</summary>
+    public void SetGrants(string packageId, string permissionId, IEnumerable<string> hosts)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(permissionId);
+        lock (_lock)
+        {
+            Dictionary<string, Dictionary<string, List<string>>> all = Load();
+            Dictionary<string, List<string>> packageGrants =
+                all.TryGetValue(packageId, out Dictionary<string, List<string>>? existing)
+                    ? existing
+                    : [];
+            packageGrants[permissionId] = hosts.Select(h => h.ToLowerInvariant()).Distinct().ToList();
+            all[packageId] = packageGrants;
+            Save(all);
+        }
+    }
+
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> GetGrants(string packageId)
+    {
+        lock (_lock)
+        {
+            Dictionary<string, Dictionary<string, List<string>>> all = Load();
+            if (!all.TryGetValue(packageId, out Dictionary<string, List<string>>? packageGrants))
+            {
+                return new Dictionary<string, IReadOnlyList<string>>();
+            }
+            return packageGrants.ToDictionary(
+                pair => pair.Key,
+                pair => (IReadOnlyList<string>)pair.Value);
+        }
+    }
+
+    /// <summary>Builds the gate input for a package: permissionId -> granted hosts.</summary>
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> GetGateGrants(string packageId) => GetGrants(packageId);
+
+    public void RemovePackage(string packageId)
+    {
+        lock (_lock)
+        {
+            Dictionary<string, Dictionary<string, List<string>>> all = Load();
+            if (all.Remove(packageId))
+            {
+                Save(all);
+            }
+        }
+    }
+
+    private Dictionary<string, Dictionary<string, List<string>>> Load()
+    {
+        if (!File.Exists(_grantsPath))
+        {
+            return [];
+        }
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(File.ReadAllText(_grantsPath));
+            var result = new Dictionary<string, Dictionary<string, List<string>>>();
+            foreach (JsonProperty packageProperty in document.RootElement.EnumerateObject())
+            {
+                var permissions = new Dictionary<string, List<string>>();
+                foreach (JsonProperty permissionProperty in packageProperty.Value.EnumerateObject())
+                {
+                    permissions[permissionProperty.Name] = permissionProperty.Value
+                        .EnumerateArray()
+                        .Where(host => host.ValueKind == JsonValueKind.String)
+                        .Select(host => host.GetString()!)
+                        .ToList();
+                }
+                result[packageProperty.Name] = permissions;
+            }
+            return result;
+        }
+        catch (JsonException)
+        {
+            // Corrupt grants file = no grants (fail closed); a fresh write
+            // replaces it.
+            return [];
+        }
+    }
+
+    private void Save(Dictionary<string, Dictionary<string, List<string>>> grants)
+    {
+        using var output = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(output, new JsonWriterOptions { Indented = true }))
+        {
+            writer.WriteStartObject();
+            foreach (KeyValuePair<string, Dictionary<string, List<string>>> packagePair in grants.OrderBy(p => p.Key, StringComparer.Ordinal))
+            {
+                writer.WritePropertyName(packagePair.Key);
+                writer.WriteStartObject();
+                foreach (KeyValuePair<string, List<string>> permissionPair in packagePair.Value.OrderBy(p => p.Key, StringComparer.Ordinal))
+                {
+                    writer.WritePropertyName(permissionPair.Key);
+                    writer.WriteStartArray();
+                    foreach (string host in permissionPair.Value.OrderBy(h => h, StringComparer.Ordinal))
+                    {
+                        writer.WriteStringValue(host);
+                    }
+                    writer.WriteEndArray();
+                }
+                writer.WriteEndObject();
+            }
+            writer.WriteEndObject();
+        }
+        string temporaryPath = _grantsPath + ".tmp";
+        File.WriteAllBytes(temporaryPath, output.ToArray());
+        File.Move(temporaryPath, _grantsPath, overwrite: true);
+    }
+}

--- a/src/DeskBox/Services/Plugins/PluginPackageManager.cs
+++ b/src/DeskBox/Services/Plugins/PluginPackageManager.cs
@@ -1,0 +1,399 @@
+using System.Text.Json;
+
+namespace DeskBox.Services.Plugins;
+
+/// <summary>
+/// The untrusted-package pipeline (roadmap 16.12): quarantine/stage ->
+/// VERIFY (full chain + input budgets) -> content-addressed immutable
+/// commit -> InstalledPackageHandle. The runtime consumes ONLY handles
+/// from here - never an arbitrary folder path - which closes the
+/// verify-then-swap TOCTOU window, and the handle's ContentHash is
+/// re-verifiable before any activation.
+/// Update discipline: same packageId must present the SAME publisher
+/// fingerprint, and a strictly INCREASING version (store-index tampering
+/// must not enable downgrade or publisher takeover).
+/// </summary>
+public sealed class PluginPackageManager
+{
+    private readonly string _pluginsRoot;
+    private readonly object _lock = new();
+
+    public PluginPackageManager()
+        : this(Path.Combine(
+            DeskBoxDataPathService.Current.DataDirectory,
+            "plugins"))
+    {
+    }
+
+    internal PluginPackageManager(string pluginsRoot)
+    {
+        Directory.CreateDirectory(pluginsRoot);
+        _pluginsRoot = pluginsRoot;
+    }
+
+    private string RegistryPath => Path.Combine(_pluginsRoot, "installed.json");
+
+    /// <summary>
+    /// Stages, verifies, and commits a package directory into the
+    /// content-addressed install store; returns the typed verified model.
+    /// </summary>
+    public PluginInstallResult Install(
+        string sourceDirectory,
+        PluginPackageVerificationPolicy policy = PluginPackageVerificationPolicy.Store)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceDirectory);
+        lock (_lock)
+        {
+            PluginPackageVerifier.VerificationResult verification = PluginPackageVerifier.Verify(
+                sourceDirectory,
+                policy,
+                PluginVerificationLimits.Default);
+            if (!verification.IsValid || verification.ManifestJson is null)
+            {
+                return PluginInstallResult.Failed(verification.Failures);
+            }
+
+            using JsonDocument document = JsonDocument.Parse(verification.ManifestJson!);
+            VerifiedPluginPackage? model = BuildVerifiedModel(document.RootElement);
+            if (model is null)
+            {
+                return PluginInstallResult.Failed(["failed to build the typed verified model"]);
+            }
+            VerifiedPluginPackage package = model;
+
+            List<InstalledPackageRecord> registry = LoadRegistry();
+            InstalledPackageRecord? existing = registry.FirstOrDefault(r => r.PackageId == package.PackageId);
+            if (existing is not null)
+            {
+                if (!string.Equals(existing.PublisherFingerprint, package.PublisherFingerprint, StringComparison.Ordinal))
+                {
+                    return PluginInstallResult.Failed(
+                    [
+                        $"update rejected: package '{package.PackageId}' is pinned to publisher " +
+                        $"'{existing.PublisherFingerprint[..12]}…' but the update presents " +
+                        $"'{package.PublisherFingerprint[..12]}…' (publisher takeover blocked)"
+                    ]);
+                }
+                if (Version.Parse(package.Version) < Version.Parse(existing.Version))
+                {
+                    return PluginInstallResult.Failed(
+                    [
+                        $"update rejected: version must not decrease " +
+                        $"(installed {existing.Version}, presented {package.Version})"
+                    ]);
+                }
+                if (string.Equals(existing.ContentHash, package.ContentHash, StringComparison.Ordinal))
+                {
+                    // Same content re-install: idempotent success, no rewrite.
+                    return PluginInstallResult.Ok(package, Path.Combine(_pluginsRoot, existing.InstallRelativePath));
+                }
+                if (Version.Parse(package.Version) == Version.Parse(existing.Version))
+                {
+                    return PluginInstallResult.Failed(
+                    [
+                        $"update rejected: version must strictly increase for new content " +
+                        $"(installed {existing.Version}, presented {package.Version})"
+                    ]);
+                }
+            }
+
+            string installDirectory = Path.Combine(
+                _pluginsRoot,
+                MakeSafeDirectoryName(package.PackageId),
+                package.ContentHash[..16]);
+            if (Directory.Exists(installDirectory))
+            {
+                // Same content re-install: idempotent commit (files are
+                // content-addressed, so identical hash = identical bytes).
+                TryDeleteDirectory(installDirectory);
+            }
+            CommitFiles(sourceDirectory, installDirectory);
+
+            registry.RemoveAll(r => r.PackageId == package.PackageId);
+            registry.Add(new InstalledPackageRecord(
+                package.PackageId,
+                package.Version,
+                package.PublisherFingerprint,
+                package.Runtime,
+                package.ContentHash,
+                MakeRelativeInstallPath(installDirectory),
+                DateTimeOffset.UtcNow));
+            SaveRegistry(registry);
+
+            return PluginInstallResult.Ok(
+                package with { },
+                installDirectory);
+        }
+    }
+
+    public IReadOnlyList<InstalledPackageRecord> GetInstalled()
+    {
+        lock (_lock)
+        {
+            return LoadRegistry();
+        }
+    }
+
+    /// <summary>Resolves a handle for activation: the install directory must still hash to the recorded content hash.</summary>
+    public InstalledPackageRecord? Find(string packageId)
+    {
+        lock (_lock)
+        {
+            return LoadRegistry().FirstOrDefault(r => r.PackageId == packageId);
+        }
+    }
+
+    public bool Uninstall(string packageId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        lock (_lock)
+        {
+            List<InstalledPackageRecord> registry = LoadRegistry();
+            InstalledPackageRecord? record = registry.FirstOrDefault(r => r.PackageId == packageId);
+            if (record is null)
+            {
+                return false;
+            }
+            string installDirectory = Path.Combine(_pluginsRoot, record.InstallRelativePath);
+            TryDeleteDirectory(installDirectory);
+            // Best-effort parent cleanup when other versions are absent.
+            string? parent = Path.GetDirectoryName(installDirectory);
+            if (parent is not null && Directory.Exists(parent) && !Directory.EnumerateFileSystemEntries(parent).Any())
+            {
+                try { Directory.Delete(parent); } catch { }
+            }
+            registry.RemoveAll(r => r.PackageId == packageId);
+            SaveRegistry(registry);
+            new PluginGrantStore(_pluginsRoot).RemovePackage(packageId);
+            return true;
+        }
+    }
+
+    // ---------- typed model construction (single parse, downstream contract) ----------
+    internal static VerifiedPluginPackage? BuildVerifiedModel(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+        try
+        {
+            var permissions = new List<PluginRequestedPermission>();
+            if (root.TryGetProperty("permissions", out JsonElement permissionsElement))
+            {
+                foreach (JsonElement permission in permissionsElement.EnumerateArray())
+                {
+                    permissions.Add(new PluginRequestedPermission(
+                        permission.GetProperty("id").GetString()!,
+                        permission.TryGetProperty("scope", out JsonElement scope) &&
+                        scope.TryGetProperty("allow", out JsonElement allow) &&
+                        allow.ValueKind == JsonValueKind.Array
+                            ? allow.EnumerateArray().Select(entry => entry.GetString()!).ToList()
+                            : []));
+                }
+            }
+
+            var dataSources = new Dictionary<string, VerifiedDataSource>();
+            if (root.TryGetProperty("dataSources", out JsonElement sourcesElement))
+            {
+                foreach (JsonProperty source in sourcesElement.EnumerateObject())
+                {
+                    dataSources[source.Name] = new VerifiedDataSource(
+                        source.Value.GetProperty("url").GetString()!,
+                        source.Value.GetProperty("refreshSeconds").GetInt32());
+                }
+            }
+
+            var actions = new Dictionary<string, VerifiedAction>();
+            if (root.TryGetProperty("actions", out JsonElement actionsElement))
+            {
+                foreach (JsonProperty action in actionsElement.EnumerateObject())
+                {
+                    actions[action.Name] = new VerifiedAction(
+                        action.Value.GetProperty("type").GetString()!,
+                        action.Value.GetProperty("url").GetString()!);
+                }
+            }
+
+            var contributions = new List<VerifiedContribution>();
+            foreach (JsonElement contribution in root.GetProperty("contributions").EnumerateArray())
+            {
+                var payloadFields = new Dictionary<string, string>();
+                if (contribution.TryGetProperty("payload", out JsonElement payload))
+                {
+                    foreach (JsonProperty field in payload.EnumerateObject())
+                    {
+                        if (field.Value.ValueKind == JsonValueKind.String)
+                        {
+                            payloadFields[field.Name] = field.Value.GetString()!;
+                        }
+                    }
+                }
+                var bindings = new Dictionary<string, VerifiedBinding>();
+                if (contribution.TryGetProperty("bindings", out JsonElement bindingsElement))
+                {
+                    foreach (JsonProperty binding in bindingsElement.EnumerateObject())
+                    {
+                        bindings[binding.Name] = new VerifiedBinding(
+                            binding.Value.GetProperty("source").GetString()!,
+                            binding.Value.GetProperty("path").GetString()!);
+                    }
+                }
+                contributions.Add(new VerifiedContribution(
+                    contribution.GetProperty("id").GetString()!,
+                    contribution.GetProperty("displayName").GetString()!,
+                    contribution.GetProperty("template").GetString()!,
+                    payloadFields,
+                    bindings));
+            }
+
+            return new VerifiedPluginPackage
+            {
+                PackageId = root.GetProperty("id").GetString()!,
+                Version = root.GetProperty("version").GetString()!,
+                PublisherFingerprint = root.GetProperty("publisher").GetString()!,
+                Runtime = root.GetProperty("runtime").GetString()!,
+                ContentHash = root.GetProperty("signature").GetProperty("contentHash").GetString()!,
+                ManifestRelativePath = "manifest.json",
+                Permissions = permissions,
+                Contributions = contributions,
+                DataSources = dataSources,
+                Actions = actions,
+                EntryMain = root.TryGetProperty("entry", out JsonElement entry) &&
+                            entry.TryGetProperty("main", out JsonElement main) &&
+                            main.ValueKind == JsonValueKind.String
+                    ? main.GetString()
+                    : null
+            };
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    // ---------- immutable commit ----------
+    private static void CommitFiles(string sourceDirectory, string installDirectory)
+    {
+        Directory.CreateDirectory(installDirectory);
+        foreach (string file in Directory.EnumerateFiles(sourceDirectory, "*", SearchOption.AllDirectories))
+        {
+            string relative = Path.GetRelativePath(sourceDirectory, file);
+            string destination = Path.Combine(installDirectory, relative);
+            Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+            File.Copy(file, destination, overwrite: true);
+            // Content-addressed immutability: read-only unless a commit is
+            // replacing the whole version directory.
+            File.SetAttributes(destination, File.GetAttributes(destination) | FileAttributes.ReadOnly);
+        }
+    }
+
+    private static void TryDeleteDirectory(string directory)
+    {
+        try
+        {
+            foreach (string file in Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories))
+            {
+                File.SetAttributes(file, FileAttributes.Normal);
+            }
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (Exception)
+        {
+            // A locked file must not make uninstall/install crash; the
+            // next commit overwrites the version directory anyway.
+        }
+    }
+
+    private static string MakeSafeDirectoryName(string packageId)
+    {
+        foreach (char character in packageId)
+        {
+            if (!char.IsAsciiLetterOrDigit(character) && character is not '.' and not '-')
+            {
+                throw new ArgumentException($"package id contains an unsafe character: '{character}'");
+            }
+        }
+        return packageId;
+    }
+
+    private string MakeRelativeInstallPath(string installDirectory) =>
+        Path.GetRelativePath(_pluginsRoot, installDirectory).Replace('\\', '/');
+
+    // ---------- registry (hand-rolled JSON, frozen baseline untouched) ----------
+    private List<InstalledPackageRecord> LoadRegistry()
+    {
+        if (!File.Exists(RegistryPath))
+        {
+            return [];
+        }
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(File.ReadAllText(RegistryPath));
+            return document.RootElement.EnumerateArray()
+                .Select(record => new InstalledPackageRecord(
+                    record.GetProperty("packageId").GetString()!,
+                    record.GetProperty("version").GetString()!,
+                    record.GetProperty("publisherFingerprint").GetString()!,
+                    record.GetProperty("runtime").GetString()!,
+                    record.GetProperty("contentHash").GetString()!,
+                    record.GetProperty("installRelativePath").GetString()!,
+                    record.GetProperty("installedAtUtc").GetDateTimeOffset()))
+                .ToList();
+        }
+        catch (JsonException)
+        {
+            // Corrupt registry = empty registry (fail closed); installing
+            // again repairs it.
+            return [];
+        }
+    }
+
+    private void SaveRegistry(List<InstalledPackageRecord> registry)
+    {
+        using var output = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(output, new JsonWriterOptions { Indented = true }))
+        {
+            writer.WriteStartArray();
+            foreach (InstalledPackageRecord record in registry.OrderBy(r => r.PackageId, StringComparer.Ordinal))
+            {
+                writer.WriteStartObject();
+                writer.WriteString("packageId", record.PackageId);
+                writer.WriteString("version", record.Version);
+                writer.WriteString("publisherFingerprint", record.PublisherFingerprint);
+                writer.WriteString("runtime", record.Runtime);
+                writer.WriteString("contentHash", record.ContentHash);
+                writer.WriteString("installRelativePath", record.InstallRelativePath);
+                writer.WriteString("installedAtUtc", record.InstalledAtUtc);
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
+        }
+        string temporaryPath = RegistryPath + ".tmp";
+        File.WriteAllBytes(temporaryPath, output.ToArray());
+        File.Move(temporaryPath, RegistryPath, overwrite: true);
+    }
+}
+
+/// <summary>An installed package handle: the runtime-facing record.</summary>
+public sealed record InstalledPackageRecord(
+    string PackageId,
+    string Version,
+    string PublisherFingerprint,
+    string Runtime,
+    string ContentHash,
+    string InstallRelativePath,
+    DateTimeOffset InstalledAtUtc);
+
+public sealed record PluginInstallResult(
+    bool Succeeded,
+    VerifiedPluginPackage? Package,
+    string? InstallDirectory,
+    IReadOnlyList<string> Failures)
+{
+    public static PluginInstallResult Ok(VerifiedPluginPackage package, string installDirectory) =>
+        new(true, package, installDirectory, []);
+
+    public static PluginInstallResult Failed(IReadOnlyList<string> failures) =>
+        new(false, null, null, failures);
+}

--- a/src/DeskBox/Services/Plugins/PluginPackageVerifier.cs
+++ b/src/DeskBox/Services/Plugins/PluginPackageVerifier.cs
@@ -77,11 +77,12 @@ public static partial class PluginPackageVerifier
 
     public static VerificationResult Verify(
         string packageDirectory,
-        PluginPackageVerificationPolicy policy = PluginPackageVerificationPolicy.Store)
+        PluginPackageVerificationPolicy policy = PluginPackageVerificationPolicy.Store,
+        PluginVerificationLimits? limits = null)
     {
         try
         {
-            return VerifyCore(packageDirectory, policy);
+            return VerifyCore(packageDirectory, policy, limits ?? PluginVerificationLimits.Default);
         }
         catch (Exception error)
         {
@@ -95,13 +96,37 @@ public static partial class PluginPackageVerifier
         }
     }
 
-    private static VerificationResult VerifyCore(string packageDirectory, PluginPackageVerificationPolicy policy)
+    private static VerificationResult VerifyCore(
+        string packageDirectory,
+        PluginPackageVerificationPolicy policy,
+        PluginVerificationLimits limits)
     {
         var failures = new List<string>();
         string manifestPath = Path.Combine(packageDirectory, "manifest.json");
         if (!File.Exists(manifestPath))
         {
             return new VerificationResult(false, ["manifest.json missing"], false, null);
+        }
+
+        // Input budgets FIRST (roadmap 16.12): a hostile package must not
+        // burn memory reading a giant manifest before anything else runs.
+        var manifestInfo = new FileInfo(manifestPath);
+        if (manifestInfo.Length > limits.MaxManifestBytes)
+        {
+            return new VerificationResult(
+                false,
+                [$"manifest.json exceeds the {limits.MaxManifestBytes}-byte input budget ({manifestInfo.Length} bytes)"],
+                false,
+                null);
+        }
+        string integrityPath = Path.Combine(packageDirectory, "package.integrity");
+        if (File.Exists(integrityPath) && new FileInfo(integrityPath).Length > limits.MaxIntegrityBytes)
+        {
+            return new VerificationResult(
+                false,
+                [$"package.integrity exceeds the {limits.MaxIntegrityBytes}-byte input budget"],
+                false,
+                null);
         }
 
         string manifestJson = File.ReadAllText(manifestPath);
@@ -133,7 +158,7 @@ public static partial class PluginPackageVerifier
             }
 
             // ---------- Phase C: integrity chain (STOP on failure) ----------
-            VerifyIntegrityChain(packageDirectory, root, manifestJson, failures);
+            VerifyIntegrityChain(packageDirectory, root, manifestJson, failures, limits);
             if (failures.Count > 0)
             {
                 return Result(failures, unsigned, manifestJson);
@@ -847,7 +872,12 @@ public static partial class PluginPackageVerifier
     }
 
     // ---------- integrity + signature chain (notes walkthrough steps 1-5) ----------
-    private static void VerifyIntegrityChain(string packageDirectory, JsonElement root, string manifestJson, List<string> failures)
+    private static void VerifyIntegrityChain(
+        string packageDirectory,
+        JsonElement root,
+        string manifestJson,
+        List<string> failures,
+        PluginVerificationLimits limits)
     {
         void Fail(string message) => failures.Add(message);
         string integrityPath = Path.Combine(packageDirectory, "package.integrity");
@@ -909,11 +939,18 @@ public static partial class PluginPackageVerifier
 
         // Step 2: every payload file hashes to its line and is listed. The
         // walk never follows reparse points; any reparse point in the tree
-        // is itself a failure (round 10).
+        // is itself a failure (round 10). File-level budgets (count, size,
+        // path length) are enforced DURING the walk so a hostile package
+        // cannot exhaust resources before its lines even get checked.
         (List<string> payloadFiles, List<string> walkFailures) = WalkPackageTree(packageDirectory);
         foreach (string walkFailure in walkFailures)
         {
             Fail(walkFailure);
+        }
+        long totalBytes = 0;
+        if (payloadFiles.Count > limits.MaxFileCount)
+        {
+            Fail($"package exceeds the file-count budget ({payloadFiles.Count} > {limits.MaxFileCount})");
         }
         foreach (string file in payloadFiles)
         {
@@ -922,14 +959,28 @@ public static partial class PluginPackageVerifier
             {
                 continue;
             }
+            if (relative.Length > limits.MaxRelativePathLength)
+            {
+                Fail($"payload path exceeds the {limits.MaxRelativePathLength}-character budget: {Truncate(relative, 40)}…");
+                continue;
+            }
             if (PackagePathViolation(relative) is { } violation)
             {
                 Fail($"payload file violates the package path grammar ({violation}): {relative}");
                 continue;
             }
-            string digest = relative == "manifest.json"
-                ? canonicalManifestHash
-                : Sha256Hex(File.ReadAllBytes(file));
+            if (relative == "manifest.json")
+            {
+                continue;
+            }
+            long fileLength = new FileInfo(file).Length;
+            totalBytes += fileLength;
+            if (fileLength > limits.MaxSingleFileBytes)
+            {
+                Fail($"payload file exceeds the single-file budget ({fileLength} > {limits.MaxSingleFileBytes} bytes): {relative}");
+                continue;
+            }
+            string digest = Sha256HexFile(file);
             if (!listed.TryGetValue(relative, out string? line))
             {
                 Fail($"payload file not listed in package.integrity: {relative}");
@@ -939,6 +990,10 @@ public static partial class PluginPackageVerifier
                 Fail($"integrity mismatch for {relative}");
             }
         }
+        if (totalBytes > limits.MaxTotalExpandedBytes)
+        {
+            Fail($"package exceeds the total-expanded budget ({totalBytes} > {limits.MaxTotalExpandedBytes} bytes)");
+        }
         foreach (string relative in listed.Keys)
         {
             if (relative != "manifest.json" && !File.Exists(Path.Combine(packageDirectory, relative)))
@@ -946,6 +1001,13 @@ public static partial class PluginPackageVerifier
                 Fail($"package.integrity lists a missing file: {relative}");
             }
         }
+    }
+
+    /// <summary>Streaming hash (roadmap 16.12): payload assets hash without a full in-memory copy.</summary>
+    internal static string Sha256HexFile(string path)
+    {
+        using FileStream stream = File.OpenRead(path);
+        return Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
     }
 
     private static void VerifySignature(string packageDirectory, JsonElement root, JsonElement signature, List<string> failures)

--- a/src/DeskBox/Services/Plugins/PluginVerificationLimits.cs
+++ b/src/DeskBox/Services/Plugins/PluginVerificationLimits.cs
@@ -1,0 +1,18 @@
+namespace DeskBox.Services.Plugins;
+
+/// <summary>
+/// Installer input budgets (roadmap 16.12): the verifier OWNS its limits so
+/// a hostile package cannot burn CPU/memory/disk before its signature even
+/// gets checked - and callers cannot forget to pre-check.
+/// </summary>
+public sealed record PluginVerificationLimits(
+    long MaxManifestBytes = 256 * 1024,
+    long MaxIntegrityBytes = 4 * 1024 * 1024,
+    int MaxFileCount = 2_000,
+    long MaxSingleFileBytes = 128 * 1024 * 1024,
+    long MaxTotalExpandedBytes = 512 * 1024 * 1024,
+    int MaxRelativePathLength = 200,
+    int MaxTreeDepth = 16)
+{
+    public static PluginVerificationLimits Default { get; } = new();
+}

--- a/src/DeskBox/Services/Plugins/VerifiedPluginPackage.cs
+++ b/src/DeskBox/Services/Plugins/VerifiedPluginPackage.cs
@@ -1,0 +1,54 @@
+namespace DeskBox.Services.Plugins;
+
+/// <summary>
+/// The typed semantic model of a VERIFIED package (roadmap 16.12): the
+/// verifier parses the manifest exactly once and everything downstream -
+/// PackageManager, runtime, executor - consumes this model. Nobody
+/// reparses raw manifest JSON, so interpretation drift is structurally
+/// impossible.
+/// </summary>
+public sealed record VerifiedPluginPackage
+{
+    public required string PackageId { get; init; }
+
+    public required string Version { get; init; }
+
+    /// <summary>The lowercase-hex SHA-256 fingerprint of the raw public key - the pinning identity.</summary>
+    public required string PublisherFingerprint { get; init; }
+
+    public required string Runtime { get; init; }
+
+    /// <summary>SHA-256 of the package.integrity bytes (lowercase hex) - the content address basis.</summary>
+    public required string ContentHash { get; init; }
+
+    public required string ManifestRelativePath { get; init; }
+
+    public required IReadOnlyList<PluginRequestedPermission> Permissions { get; init; }
+
+    public required IReadOnlyList<VerifiedContribution> Contributions { get; init; }
+
+    public IReadOnlyDictionary<string, VerifiedDataSource> DataSources { get; init; } =
+        new Dictionary<string, VerifiedDataSource>();
+
+    public IReadOnlyDictionary<string, VerifiedAction> Actions { get; init; } =
+        new Dictionary<string, VerifiedAction>();
+
+    public string? EntryMain { get; init; }
+}
+
+public sealed record PluginRequestedPermission(
+    string Id,
+    IReadOnlyList<string> AllowHosts);
+
+public sealed record VerifiedContribution(
+    string Id,
+    string DisplayName,
+    string Template,
+    IReadOnlyDictionary<string, string> PayloadStringFields,
+    IReadOnlyDictionary<string, VerifiedBinding> Bindings);
+
+public sealed record VerifiedBinding(string Source, string Path);
+
+public sealed record VerifiedDataSource(string Url, int RefreshSeconds);
+
+public sealed record VerifiedAction(string Type, string Url);

--- a/tests/DeskBox.Tests/PluginPackageManagerTests.cs
+++ b/tests/DeskBox.Tests/PluginPackageManagerTests.cs
@@ -1,0 +1,252 @@
+using DeskBox.Services.Plugins;
+
+namespace DeskBox.Tests;
+
+/// <summary>
+/// B1b: the untrusted-package pipeline - stage, verify (with input
+/// budgets), content-addressed immutable commit, InstalledPackageHandle,
+/// publisher pin + version monotonicity, and the grant store. All tests
+/// run against isolated temp roots via the internal constructors.
+/// </summary>
+public sealed class PluginPackageManagerTests : IDisposable
+{
+    private readonly string _tempRoot = Directory.CreateDirectory(
+        Path.Combine(Path.GetTempPath(), "DeskBox.Tests", Guid.NewGuid().ToString("N")))
+        .FullName;
+
+    private string PluginsRoot => Path.Combine(_tempRoot, "plugins");
+
+    [Fact]
+    public void Install_CommitsContentAddressedImmutableCopy()
+    {
+        var manager = new PluginPackageManager(PluginsRoot);
+        string source = TestPaths.FromRepository("spikes/github-stats-live");
+
+        PluginInstallResult result = manager.Install(source);
+
+        Assert.True(result.Succeeded, string.Join("; ", result.Failures));
+        Assert.NotNull(result.Package);
+        Assert.Equal("com.github.stats.live", result.Package!.PackageId);
+        Assert.Equal("0.1.0", result.Package.Version);
+        Assert.Equal("none", result.Package.Runtime);
+        Assert.Contains(result.Package.Permissions, p => p.Id == "network.fetch");
+        Assert.Contains(result.Package.Permissions, p => p.Id == "shell.open");
+        Assert.True(result.Package.DataSources.ContainsKey("github-repo"));
+        Assert.True(result.Package.Actions.ContainsKey("open-repo"));
+
+        // Content-addressed directory named by the content hash prefix.
+        string expectedRoot = Path.Combine(PluginsRoot, "com.github.stats.live");
+        Assert.True(Directory.Exists(expectedRoot));
+        string versionDirectory = Directory.GetDirectories(expectedRoot).Single();
+        Assert.StartsWith(result.Package.ContentHash[..16], Path.GetFileName(versionDirectory), StringComparison.Ordinal);
+        Assert.True(File.Exists(Path.Combine(versionDirectory, "manifest.json")));
+
+        // Immutable commit: payload files are read-only.
+        FileAttributes attributes = File.GetAttributes(Path.Combine(versionDirectory, "manifest.json"));
+        Assert.True((attributes & FileAttributes.ReadOnly) != 0);
+
+        // Registry has the handle.
+        InstalledPackageRecord? record = manager.Find("com.github.stats.live");
+        Assert.NotNull(record);
+        Assert.Equal(result.Package.ContentHash, record!.ContentHash);
+        Assert.Equal(result.Package.PublisherFingerprint, record.PublisherFingerprint);
+    }
+
+    [Fact]
+    public void ReinstallSameContent_IsIdempotent()
+    {
+        var manager = new PluginPackageManager(PluginsRoot);
+        string source = TestPaths.FromRepository("spikes/github-stats-live");
+
+        Assert.True(manager.Install(source).Succeeded);
+        Assert.True(manager.Install(source).Succeeded);
+
+        Assert.Single(manager.GetInstalled());
+    }
+
+    [Fact]
+    public void Uninstall_RemovesFilesRegistryAndGrants()
+    {
+        var manager = new PluginPackageManager(PluginsRoot);
+        var grants = new PluginGrantStore(PluginsRoot);
+        Assert.True(manager.Install(TestPaths.FromRepository("spikes/github-stats-live")).Succeeded);
+        grants.SetGrants("com.github.stats.live", "network.fetch", ["api.github.com"]);
+
+        Assert.True(manager.Uninstall("com.github.stats.live"));
+
+        Assert.Empty(manager.GetInstalled());
+        Assert.False(Directory.Exists(Path.Combine(PluginsRoot, "com.github.stats.live")));
+        Assert.Empty(grants.GetGrants("com.github.stats.live"));
+        Assert.False(manager.Uninstall("com.github.stats.live"));
+    }
+
+    [Fact]
+    public void Update_WithDifferentPublisher_IsRejected()
+    {
+        var manager = new PluginPackageManager(PluginsRoot);
+        Assert.True(manager.Install(TestPaths.FromRepository("spikes/github-stats-live")).Succeeded);
+
+        // Simulate the package having been pinned to a DIFFERENT publisher
+        // (in production this happens when the index is tampered with and
+        // the update presents a different, validly-signed key).
+        RewriteRegistryPublisher(PluginsRoot, "com.github.stats.live", new string('c', 64));
+
+        PluginInstallResult result = manager.Install(TestPaths.FromRepository("spikes/github-stats-live"));
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Failures, f => f.Contains("publisher takeover blocked", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Update_WithLowerVersionContent_IsRejected()
+    {
+        var manager = new PluginPackageManager(PluginsRoot);
+        Assert.True(manager.Install(TestPaths.FromRepository("spikes/github-stats-live")).Succeeded);
+
+        // Same publisher, but the recorded version is newer: the incoming
+        // 0.1.0 content must be rejected (downgrade protection). Registry
+        // rewrite simulates a previously-installed 9.9.9.
+        RewriteRegistryVersion(PluginsRoot, "com.github.stats.live", "9.9.9");
+
+        PluginInstallResult result = manager.Install(TestPaths.FromRepository("spikes/github-stats-live"));
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Failures, f => f.Contains("must not decrease", StringComparison.Ordinal));
+    }
+
+    private static void RewriteRegistryPublisher(string pluginsRoot, string packageId, string newFingerprint)
+    {
+        string registryPath = Path.Combine(pluginsRoot, "installed.json");
+        string json = File.ReadAllText(registryPath);
+        File.WriteAllText(registryPath, json.Replace(
+            "\"publisherFingerprint\": \"1bc4f2db8438d2fd296bd48074088ccc726c265712125abbae975063ba719ea4\"",
+            $"\"publisherFingerprint\": \"{newFingerprint}\""));
+    }
+
+    private static void RewriteRegistryVersion(string pluginsRoot, string packageId, string newVersion)
+    {
+        string registryPath = Path.Combine(pluginsRoot, "installed.json");
+        string json = File.ReadAllText(registryPath);
+        File.WriteAllText(registryPath, json.Replace(
+            "\"version\": \"0.1.0\"",
+            $"\"version\": \"{newVersion}\""));
+    }
+
+    [Fact]
+    public void Install_InvalidPackage_FailsWithoutSideEffects()
+    {
+        var manager = new PluginPackageManager(PluginsRoot);
+        string tampered = CopyPackage("spikes/github-stats");
+        File.AppendAllText(Path.Combine(tampered, "files", "icon.svg"), "<!--tamper-->");
+
+        PluginInstallResult result = manager.Install(tampered);
+
+        Assert.False(result.Succeeded);
+        Assert.NotEmpty(result.Failures);
+        Assert.Empty(manager.GetInstalled());
+        Assert.False(Directory.Exists(Path.Combine(PluginsRoot, "com.github.stats")));
+    }
+
+    [Fact]
+    public void Verify_InputBudgets_RejectHugeManifestWithoutReadingItAll()
+    {
+        string package = Path.Combine(_tempRoot, "huge-manifest");
+        Directory.CreateDirectory(package);
+        File.WriteAllText(
+            Path.Combine(package, "manifest.json"),
+            "{\"padding\":\"" + new string('x', 300_000) + "\"}");
+
+        PluginPackageVerifier.VerificationResult result = PluginPackageVerifier.Verify(
+            package,
+            PluginPackageVerificationPolicy.Development,
+            new PluginVerificationLimits(MaxManifestBytes: 100_000));
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, f =>
+            f.Contains("exceeds the 100000-byte input budget", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Verify_FileCountBudget_IsEnforced()
+    {
+        string package = CopyPackage("spikes/github-stats");
+        for (int i = 0; i < 5; i++)
+        {
+            File.WriteAllText(Path.Combine(package, $"extra-{i}.txt"), "x");
+        }
+
+        PluginPackageVerifier.VerificationResult result = PluginPackageVerifier.Verify(
+            package,
+            PluginPackageVerificationPolicy.Development,
+            new PluginVerificationLimits(MaxFileCount: 4));
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Failures, f => f.Contains("file-count budget", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void StreamingFileHash_MatchesBufferedHash()
+    {
+        string path = Path.Combine(_tempRoot, "hash-sample.bin");
+        File.WriteAllBytes(path, Enumerable.Range(0, 100_000).Select(i => (byte)(i % 251)).ToArray());
+
+        using FileStream stream = File.OpenRead(path);
+        string buffered = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(stream)).ToLowerInvariant();
+
+        Assert.Equal(buffered, PluginPackageVerifier.Sha256HexFile(path));
+    }
+
+    [Fact]
+    public void GrantStore_RoundTripsAndFailsClosed()
+    {
+        var grants = new PluginGrantStore(PluginsRoot);
+
+        Assert.Empty(grants.GetGrants("com.example.x"));
+
+        grants.SetGrants("com.example.x", "network.fetch", ["API.GitHub.com", "api.github.com", "example.org"]);
+        grants.SetGrants("com.example.x", "shell.open", ["github.com"]);
+
+        IReadOnlyDictionary<string, IReadOnlyList<string>> stored = grants.GetGrants("com.example.x");
+        Assert.Equal(["api.github.com", "example.org"], stored["network.fetch"].OrderBy(h => h));
+        Assert.Equal(["github.com"], stored["shell.open"]);
+
+        // A corrupt grants file fails closed (no grants), not throws.
+        File.WriteAllText(
+            Path.Combine(PluginsRoot, "grants.json"),
+            "{ not valid json");
+        var reloaded = new PluginGrantStore(PluginsRoot);
+        Assert.Empty(reloaded.GetGrants("com.example.x"));
+    }
+
+    private string CopyPackage(string relativePackagePath)
+    {
+        string source = TestPaths.FromRepository(relativePackagePath);
+        string destination = Path.Combine(_tempRoot, "src-" + Path.GetFileName(relativePackagePath) + "-" + Guid.NewGuid().ToString("N")[..8]);
+        foreach (string file in Directory.GetFiles(source, "*", SearchOption.AllDirectories))
+        {
+            string target = Path.Combine(destination, Path.GetRelativePath(source, file));
+            Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+            File.Copy(file, target);
+        }
+        return destination;
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempRoot))
+            {
+                foreach (string file in Directory.GetFiles(_tempRoot, "*", SearchOption.AllDirectories))
+                {
+                    File.SetAttributes(file, FileAttributes.Normal);
+                }
+                Directory.Delete(_tempRoot, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup for files briefly held by antivirus.
+        }
+    }
+}


### PR DESCRIPTION
feat: B1b - package manager pipeline, grant store, input budgets, streaming hashes

The untrusted-package pipeline (roadmap 16.12): quarantine-verify-commit
as a single managed flow. With this, B1 (the store's foundation) is
functionally complete.

- PluginPackageManager: Install = full-chain verification -> typed model
  build -> content-addressed immutable commit
  (plugins/<packageId>/<contentHash16>/, payload files read-only) ->
  InstalledPackageHandle registry. Uninstall removes files, registry
  entry, AND grants. The registry is hand-rolled
  JsonDocument/Utf8JsonWriter persistence - the frozen JsonSerializer
  baseline stays untouched.
- Update discipline: same packageId must present the SAME publisher
  fingerprint (takeover blocked), version must not decrease, and new
  content requires a strictly increasing version. Same-content reinstall
  is an idempotent no-op (matching the content-addressed store).
- VerifiedPluginPackage: the typed semantic model (PackageId/Version/
  PublisherFingerprint/Runtime/Permissions/Contributions/DataSources/
  Actions/ContentHash/EntryMain) built ONCE inside the pipeline;
  downstream never reparses raw manifest JSON, so interpretation drift
  is structurally impossible.
- PluginGrantStore: requested != granted made persistent -
  packageId -> permissionId -> granted hosts (lowercased, deduped) at
  plugins/grants.json with atomic writes; corrupt file fails closed to
  no-grants. GetGateGrants feeds the PluginCapabilityGate directly.
- PluginVerificationLimits: the verifier OWNS its input budgets (roadmap
  16.12) - manifest/integrity byte caps checked BEFORE reading, file
  count, single-file and total-expanded caps, and relative-path length
  enforced during the tree walk. Default limits are generous but finite;
  callers cannot forget to pre-check.
- Streaming hashes: payload files hash via FileStream (SHA256.HashData
  over the stream) instead of ReadAllBytes - no memory spike on large
  assets.

Tests: +10 (content-addressed immutable commit with read-only payload;
idempotent same-content reinstall; uninstall removes files+registry+
grants; publisher takeover blocked; version downgrade blocked; invalid
package leaves no side effects; manifest byte budget; file-count budget;
streaming-hash equals buffered-hash; grant store round-trip +
corrupt-file fail-closed). 3505/3505 green x64. Canonical Debug rebuilt
and restarted (pid 34676).

Known follow-ups for B2 (recorded, not blocking): the Rust
ed25519-dalek trust-root migration, the declarative executor consuming
handles + grants through the gate with DNS pinning, and install UI.
