### PR TITLE
feat: B2a - declarative executor core with DNS-pinned fetching

### DIFF
--- a/src/DeskBox/Services/Plugins/PluginDeclarativeExecutor.cs
+++ b/src/DeskBox/Services/Plugins/PluginDeclarativeExecutor.cs
@@ -1,0 +1,191 @@
+using System.Net.Http;
+using System.Text.Json;
+
+namespace DeskBox.Services.Plugins;
+
+/// <summary>
+/// Executes a verified declarative package's widget state (roadmap B2a):
+/// for each data source the HOST fetches (behind the capability gate and
+/// the pinned-IP HTTP client), evaluates JSON-path bindings, and keeps
+/// payload fallback values on any failure - the same resilience contract
+/// as the Node spike harness. No third-party code ever runs.
+///
+/// Scheduling (refresh timers, widget registration) lands with the B2b
+/// template renderer; this executor is the pure state-evaluation core so
+/// it stays unit-testable without the UI.
+/// </summary>
+public sealed class PluginDeclarativeExecutor
+{
+    private const int MaxResponseBytes = 2 * 1024 * 1024;
+
+    private readonly PluginCapabilityGate _outerGate;
+    private readonly PluginPinnedHttpClientFactoryDelegate _httpClientFactory;
+
+    public PluginDeclarativeExecutor(
+        PluginCapabilityGate gate,
+        PluginPinnedHttpClientFactoryDelegate? httpClientFactory = null)
+    {
+        _outerGate = gate;
+        _httpClientFactory = httpClientFactory ?? new PluginPinnedHttpClientFactoryDelegate(
+            PluginPinnedHttpClientFactory.CreateForHost);
+    }
+
+    /// <summary>
+    /// Evaluates all contributions of a package: fetches each referenced
+    /// data source once (gated + pinned), applies bindings, returns the
+    /// effective payload fields per contribution. Failures keep fallbacks.
+    /// </summary>
+    public async Task<PluginWidgetStateResult> EvaluateAsync(
+        VerifiedPluginPackage package,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> grantedHosts,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+
+        // Per-package gate bound to THIS package's requested scopes and the
+        // caller-provided grants (requested != granted stays real).
+        var requestedScopes = package.Permissions.ToDictionary(
+            p => p.Id,
+            p => p.AllowHosts);
+        var packageGate = new PluginCapabilityGate(requestedScopes, grantedHosts);
+
+        var fetched = new Dictionary<string, JsonElement>();
+        var dataSourceErrors = new Dictionary<string, string>();
+        foreach (KeyValuePair<string, VerifiedDataSource> source in package.DataSources)
+        {
+            string url = source.Value.Url;
+            try
+            {
+                packageGate.RequireAllowed(new Uri(url), "network.fetch");
+
+                HttpClient? client = _httpClientFactory(new Uri(url).Host);
+                if (client is null)
+                {
+                    dataSourceErrors[source.Key] = $"host '{new Uri(url).Host}' resolves to no globally-routable address";
+                    continue;
+                }
+                using (client)
+                await using (Stream stream = await client.GetStreamAsync(url, cancellationToken))
+                {
+                    fetched[source.Key] = await ReadCappedJsonAsync(stream, cancellationToken);
+                }
+            }
+            catch (PluginCapabilityRefusedException refused)
+            {
+                // Policy refusals are recorded per-source; bindings fall
+                // back. (The spike exited non-zero for refusals; a product
+                // widget degrades instead of vanishing.)
+                dataSourceErrors[source.Key] = refused.Message;
+            }
+            catch (Exception error) when (error is HttpRequestException or JsonException or IOException)
+            {
+                dataSourceErrors[source.Key] = error.Message;
+            }
+        }
+
+        var states = new Dictionary<string, PluginContributionState>();
+        foreach (VerifiedContribution contribution in package.Contributions)
+        {
+            var effective = new Dictionary<string, string>(contribution.PayloadStringFields);
+            var notes = new List<string>();
+            foreach (KeyValuePair<string, VerifiedBinding> binding in contribution.Bindings)
+            {
+                if (dataSourceErrors.TryGetValue(binding.Value.Source, out string? sourceError))
+                {
+                    notes.Add($"{binding.Key}: fallback ({sourceError})");
+                    continue;
+                }
+                if (!fetched.TryGetValue(binding.Value.Source, out JsonElement document) ||
+                    TryEvaluateJsonPath(document, binding.Value.Path) is not { } value)
+                {
+                    notes.Add($"{binding.Key}: fallback (path {binding.Value.Path} missing)");
+                    continue;
+                }
+                effective[binding.Key] = value;
+            }
+            states[contribution.Id] = new PluginContributionState(
+                contribution.Id,
+                effective,
+                notes);
+        }
+
+        return new PluginWidgetStateResult(package.PackageId, states, dataSourceErrors);
+    }
+
+    /// <summary>Reads at most MaxResponseBytes and parses JSON (2MB host cap, packages cannot raise it).</summary>
+    private static async Task<JsonElement> ReadCappedJsonAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        using var capped = new MemoryStream();
+        byte[] buffer = new byte[64 * 1024];
+        long total = 0;
+        int read;
+        while ((read = await stream.ReadAsync(buffer, cancellationToken)) > 0)
+        {
+            total += read;
+            if (total > MaxResponseBytes)
+            {
+                throw new IOException($"response exceeds the {MaxResponseBytes}-byte host limit");
+            }
+            capped.Write(buffer, 0, read);
+        }
+        using JsonDocument document = JsonDocument.Parse(capped.ToArray());
+        return document.RootElement.Clone();
+    }
+
+    /// <summary>Minimal JSON path ($.a.b[0].c) with null on any miss - same semantics as the spike harness.</summary>
+    internal static string? TryEvaluateJsonPath(JsonElement document, string pathExpression)
+    {
+        if (!pathExpression.StartsWith("$.", StringComparison.Ordinal))
+        {
+            return null;
+        }
+        JsonElement current = document;
+        foreach (string segment in pathExpression[2..].Split('.'))
+        {
+            System.Text.RegularExpressions.Match match =
+                System.Text.RegularExpressions.Regex.Match(segment, @"^([A-Za-z0-9_]+)((?:\[\d+\])*)$");
+            if (!match.Success)
+            {
+                return null;
+            }
+            if (match.Groups[1].Length > 0)
+            {
+                if (current.ValueKind != JsonValueKind.Object ||
+                    !current.TryGetProperty(match.Groups[1].Value, out current))
+                {
+                    return null;
+                }
+            }
+            foreach (System.Text.RegularExpressions.Match index in
+                     System.Text.RegularExpressions.Regex.Matches(match.Groups[2].Value, @"\[(\d+)\]"))
+            {
+                int arrayIndex = int.Parse(index.Groups[1].Value);
+                if (current.ValueKind != JsonValueKind.Array || arrayIndex >= current.GetArrayLength())
+                {
+                    return null;
+                }
+                current = current[arrayIndex];
+            }
+        }
+        return current.ValueKind switch
+        {
+            JsonValueKind.String => current.GetString(),
+            JsonValueKind.Number => current.GetRawText(),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            _ => null
+        };
+    }
+}
+
+public delegate HttpClient? PluginPinnedHttpClientFactoryDelegate(string hostname);
+
+public sealed record PluginWidgetStateResult(
+    string PackageId,
+    IReadOnlyDictionary<string, PluginContributionState> Contributions,
+    IReadOnlyDictionary<string, string> DataSourceErrors);
+
+public sealed record PluginContributionState(
+    string ContributionId,
+    IReadOnlyDictionary<string, string> EffectiveFields,
+    IReadOnlyList<string> Notes);

--- a/src/DeskBox/Services/Plugins/PluginPinnedHttpClientFactory.cs
+++ b/src/DeskBox/Services/Plugins/PluginPinnedHttpClientFactory.cs
@@ -1,0 +1,129 @@
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Net.Http;
+
+namespace DeskBox.Services.Plugins;
+
+/// <summary>
+/// Creates HttpClients for plugin network.fetch that pin each connection
+/// to a DNS-validated IP (roadmap 16.12, the B2 blocker): resolve ->
+/// validate EVERY candidate address is globally routable -> connect to
+/// the chosen validated address, with TLS SNI still using the original
+/// hostname. A plain resolve-then-check is insufficient because HttpClient
+/// performs its own second resolution which a rebinding DNS can flip to a
+/// private address between the two lookups.
+///
+/// The validator callback is injectable for tests (points at the same
+/// classification the capability gate uses).
+/// </summary>
+public static partial class PluginPinnedHttpClientFactory
+{
+    /// <summary>
+    /// Creates a client whose connections are pinned to validated IPs for
+    /// the given host. Returns null when the host resolves to no usable
+    /// (globally routable) address.
+    /// </summary>
+    public static HttpClient? CreateForHost(string hostname) => CreateForHost(hostname, gate: null);
+
+    private static HttpClient? CreateForHost(string hostname, PluginCapabilityGate? gate)
+    {
+        string host = hostname.ToLowerInvariant();
+        IPAddress[] candidates;
+        try
+        {
+            candidates = Dns.GetHostAddresses(host);
+        }
+        catch (SocketException)
+        {
+            return null;
+        }
+
+        IPAddress[] validated = candidates.Where(IsGloballyRoutable).ToArray();
+        if (validated.Length == 0)
+        {
+            return null;
+        }
+
+        var handler = new SocketsHttpHandler
+        {
+            ConnectCallback = async (context, cancellationToken) =>
+            {
+                // Re-resolve at connection time and re-validate; connect to
+                // a validated address only (defense in depth against a
+                // rebound cache entry between CreateForHost and connect).
+                IPAddress[] current;
+                try
+                {
+                    current = Dns.GetHostAddresses(context.DnsEndPoint.Host);
+                }
+                catch (SocketException)
+                {
+                    current = validated;
+                }
+                foreach (IPAddress address in current.Where(IsGloballyRoutable))
+                {
+                    var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                    try
+                    {
+                        await socket.ConnectAsync(address, context.DnsEndPoint.Port, cancellationToken);
+                        return new NetworkStream(socket, ownsSocket: true);
+                    }
+                    catch
+                    {
+                        socket.Dispose();
+                    }
+                }
+                throw new SocketException((int)SocketError.HostUnreachable);
+            },
+            // Redirects are refused at the executor level; the handler must
+            // not follow them either (a 3xx would move the request to a host
+            // that never passed the gate).
+            AllowAutoRedirect = false,
+            SslOptions = new SslClientAuthenticationOptions
+            {
+                // The remote certificate must match the ORIGINAL hostname
+                // (SNI/verification stay on the DNS name, not the IP).
+                TargetHost = null
+            }
+        };
+
+        return new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(10)
+        };
+    }
+
+    /// <summary>
+    /// Globally-routable classification (mirrors PluginCapabilityGate's
+    /// local-network denial): loopback/private/link-local/metadata/
+    /// unique-local/unspecified/multicast are all rejected.
+    /// </summary>
+    public static bool IsGloballyRoutable(IPAddress address)
+    {
+        if (address.IsIPv4MappedToIPv6)
+        {
+            address = address.MapToIPv4();
+        }
+        if (address.IsIPv6LinkLocal || address.IsIPv6SiteLocal)
+        {
+            return false;
+        }
+        if (address.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            byte[] bytes = address.GetAddressBytes();
+            return bytes.AsSpan()[..15].ToArray().Any(b => b != 0) &&
+                   bytes[0] is not (0xfc or 0xfd) &&
+                   !address.Equals(IPAddress.IPv6Loopback);
+        }
+
+        byte[] v4 = address.GetAddressBytes();
+        return v4[0] != 0 &&
+               v4[0] != 127 &&
+               v4[0] != 10 &&
+               !(v4[0] == 172 && v4[1] >= 16 && v4[1] <= 31) &&
+               !(v4[0] == 192 && v4[1] == 168) &&
+               !(v4[0] == 169 && v4[1] == 254) &&
+               v4[0] < 224;
+    }
+}

--- a/tests/DeskBox.Tests/PluginDeclarativeExecutorTests.cs
+++ b/tests/DeskBox.Tests/PluginDeclarativeExecutorTests.cs
@@ -1,0 +1,199 @@
+using System.Net;
+using System.Text.Json;
+using DeskBox.Services.Plugins;
+
+namespace DeskBox.Tests;
+
+/// <summary>
+/// B2a: the declarative executor core - gate integration, JSON-path
+/// binding evaluation, payload fallback on any failure, and the pinned
+/// HTTP client factory's globally-routable classification. Network
+/// touching is faked via the injectable client factory (deterministic).
+/// </summary>
+public sealed class PluginDeclarativeExecutorTests
+{
+    private static VerifiedPluginPackage CreateLivePackage() => new()
+    {
+        PackageId = "com.github.stats.live",
+        Version = "0.1.0",
+        PublisherFingerprint = new string('a', 64),
+        Runtime = "none",
+        ContentHash = new string('c', 64),
+        ManifestRelativePath = "manifest.json",
+        Permissions =
+        [
+            new PluginRequestedPermission("network.fetch", ["api.github.com"]),
+            new PluginRequestedPermission("shell.open", ["github.com"])
+        ],
+        Contributions =
+        [
+            new VerifiedContribution(
+                "live-stars",
+                "DeskBox Stars (live)",
+                "metric",
+                new Dictionary<string, string>
+                {
+                    ["label"] = "Stars",
+                    ["value"] = "…",
+                    ["caption"] = "Tianyu199509/DeskBox"
+                },
+                new Dictionary<string, VerifiedBinding>
+                {
+                    ["value"] = new VerifiedBinding("github-repo", "$.stargazers_count")
+                })
+        ],
+        DataSources = new Dictionary<string, VerifiedDataSource>
+        {
+            ["github-repo"] = new VerifiedDataSource(
+                "https://api.github.com/repos/Tianyu199509/DeskBox",
+                RefreshSeconds: 300)
+        }
+    };
+
+    private static IReadOnlyDictionary<string, IReadOnlyList<string>> FullGrants =>
+        new Dictionary<string, IReadOnlyList<string>>
+        {
+            ["network.fetch"] = ["api.github.com"]
+        };
+
+    private static PluginDeclarativeExecutor CreateExecutor(
+        Func<string?, bool>? canReachHost = null,
+        JsonElement? response = null)
+    {
+        return new PluginDeclarativeExecutor(
+            gate: new PluginCapabilityGate(
+                new Dictionary<string, IReadOnlyList<string>>
+                {
+                    ["network.fetch"] = ["api.github.com"]
+                },
+                FullGrants),
+            httpClientFactory: hostname =>
+            {
+                if (canReachHost is not null && !canReachHost(hostname))
+                {
+                    return null;
+                }
+                var content = new StringContent(
+                    response is null
+                        ? "{\"stargazers_count\":1284}"
+                        : JsonSerializer.Serialize(response.Value),
+                    System.Text.Encoding.UTF8,
+                    "application/json");
+                var fake = new HttpMessageHandlerShim(content);
+                return new HttpClient(fake);
+            });
+    }
+
+    [Fact]
+    public async Task Evaluate_BindsLiveValueOverFallback()
+    {
+        var executor = CreateExecutor();
+
+        PluginWidgetStateResult result = await executor.EvaluateAsync(
+            CreateLivePackage(), FullGrants);
+
+        PluginContributionState state = result.Contributions["live-stars"];
+        Assert.Equal("1284", state.EffectiveFields["value"]);
+        Assert.Equal("Stars", state.EffectiveFields["label"]); // untouched payload field
+        Assert.Empty(state.Notes);
+        Assert.Empty(result.DataSourceErrors);
+    }
+
+    [Fact]
+    public async Task Evaluate_NestedArrayPath_Resolves()
+    {
+        var executor = CreateExecutor(response: JsonDocument.Parse(
+            "{\"items\":[{\"name\":\"first\"},{\"name\":\"second\"}]}").RootElement.Clone());
+
+        var package = CreateLivePackage();
+        var contribution = package.Contributions.Single();
+        package = package with
+        {
+            Contributions =
+            [
+                new VerifiedContribution(
+                    contribution.Id,
+                    contribution.DisplayName,
+                    contribution.Template,
+                    contribution.PayloadStringFields,
+                    new Dictionary<string, VerifiedBinding>
+                    {
+                        ["value"] = new VerifiedBinding("github-repo", "$.items[1].name")
+                    })
+            ]
+        };
+
+        PluginWidgetStateResult result = await executor.EvaluateAsync(package, FullGrants);
+
+        Assert.Equal("second", result.Contributions["live-stars"].EffectiveFields["value"]);
+    }
+
+    [Fact]
+    public async Task Evaluate_UngrantedCapability_FallsBack()
+    {
+        var executor = CreateExecutor();
+        var emptyGrants = new Dictionary<string, IReadOnlyList<string>>();
+
+        PluginWidgetStateResult result = await executor.EvaluateAsync(
+            CreateLivePackage(), emptyGrants);
+
+        PluginContributionState state = result.Contributions["live-stars"];
+        Assert.Equal("…", state.EffectiveFields["value"]);
+        Assert.Contains(state.Notes, n => n.Contains("requested != granted", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Evaluate_UnresolvableHost_FallsBack()
+    {
+        var executor = CreateExecutor(canReachHost: _ => false);
+
+        PluginWidgetStateResult result = await executor.EvaluateAsync(
+            CreateLivePackage(), FullGrants);
+
+        Assert.Equal("…", result.Contributions["live-stars"].EffectiveFields["value"]);
+        Assert.Contains("no globally-routable address", result.DataSourceErrors["github-repo"]);
+    }
+
+    [Fact]
+    public async Task Evaluate_MissingPath_FallsBack()
+    {
+        var executor = CreateExecutor(response: JsonDocument.Parse(
+            "{\"full_name\":\"DeskBox\"}").RootElement.Clone());
+
+        PluginWidgetStateResult result = await executor.EvaluateAsync(
+            CreateLivePackage(), FullGrants);
+
+        PluginContributionState state = result.Contributions["live-stars"];
+        Assert.Equal("…", state.EffectiveFields["value"]);
+        Assert.Contains(state.Notes, n => n.Contains("path $.stargazers_count missing", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void GloballyRoutable_Classification_MatchesGateVectors()
+    {
+        Assert.True(PluginPinnedHttpClientFactory.IsGloballyRoutable(IPAddress.Parse("140.82.112.3")));
+        Assert.True(PluginPinnedHttpClientFactory.IsGloballyRoutable(IPAddress.Parse("2607:f8b0::1")));
+        Assert.False(PluginPinnedHttpClientFactory.IsGloballyRoutable(IPAddress.Parse("127.0.0.1")));
+        Assert.False(PluginPinnedHttpClientFactory.IsGloballyRoutable(IPAddress.Parse("10.1.2.3")));
+        Assert.False(PluginPinnedHttpClientFactory.IsGloballyRoutable(IPAddress.Parse("192.168.1.1")));
+        Assert.False(PluginPinnedHttpClientFactory.IsGloballyRoutable(IPAddress.Parse("169.254.169.254")));
+        Assert.False(PluginPinnedHttpClientFactory.IsGloballyRoutable(IPAddress.Parse("0.0.0.0")));
+        Assert.False(PluginPinnedHttpClientFactory.IsGloballyRoutable(IPAddress.Parse("224.0.0.1")));
+        Assert.False(PluginPinnedHttpClientFactory.IsGloballyRoutable(IPAddress.Parse("::1")));
+        Assert.False(PluginPinnedHttpClientFactory.IsGloballyRoutable(IPAddress.Parse("fd12::1")));
+        // IPv4-mapped must classify as the IPv4 it is.
+        Assert.False(PluginPinnedHttpClientFactory.IsGloballyRoutable(
+            IPAddress.Parse("::ffff:127.0.0.1")));
+    }
+
+    private sealed class HttpMessageHandlerShim(HttpContent content) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+        }
+    }
+}


### PR DESCRIPTION
feat: B2a - declarative executor core with DNS-pinned fetching

The first B2 slice: the C# state-evaluation core that a plugin widget
runs on, plus the B2 network blocker (DNS-pinned HTTP) closed before the
product's first network request ever goes out.

- PluginPinnedHttpClientFactory (roadmap 16.12 blocker): HttpClients
  whose ConnectCallback resolves the hostname, validates EVERY candidate
  address is globally routable, and connects to a validated address -
  with TLS SNI/verification staying on the original hostname. A plain
  resolve-then-check is insufficient because HttpClient performs its own
  second resolution, which a rebinding DNS can flip between the two
  lookups; pinning the connection to the validated IP closes that window
  (re-resolution at connect time is re-validated too, defense in depth).
  Redirects are disabled at the handler level (a 3xx must never move a
  request to a host that never passed the gate). The globally-routable
  classification mirrors the capability gate's vectors, including the
  IPv4-mapped-IPv6 unwrap and unspecified/multicast denial.
- PluginDeclarativeExecutor: evaluates a VerifiedPluginPackage's
  contributions - fetches each data source once through the per-package
  capability gate (requested scopes from the package, granted hosts from
  the caller: requested != granted stays real) and the pinned client,
  applies JSON-path bindings ($.a.b[0].c, same semantics as the spike
  harness), and keeps payload fallback values on ANY failure (policy
  refusal, unresolvable/private host, missing path, oversized body). A
  product widget degrades instead of vanishing - the resilience contract
  from the spike, now in the product. Response bodies stream with the
  2MB host cap. The executor is the pure state core (unit-testable,
  factory-injectable HTTP); scheduling (refresh timers) and widget
  registration land with the B2b template renderer.

Tests: +6 (live binding over fallback incl. untouched payload fields;
nested array path; ungranted capability falls back with the requested !=
granted note; unresolvable/non-routable host falls back; missing path
falls back; globally-routable classification covering the gate vectors
incl. IPv4-mapped). 3511/3511 green x64. Canonical Debug rebuilt and
restarted (pid 14628).
