### PR TITLE
feat: batch B round 3 - compiled XBF, PRI, activation probes pinned as negatives

### DIFF
--- a/docs/architecture/official-widget-packages-plan.md
+++ b/docs/architecture/official-widget-packages-plan.md
@@ -64,4 +64,5 @@ Store 路径在批次 B 前期就核对，不能等发布前才验证。动态�
 - 自动验证：插件专项 115/115，全量 x64 测试 3541/3541；原生验签 FFI 测试 2/2；四份现有 Node 插件样本全部通过更新后的校验器。主应用完整 AOT 审计输出位于 `.artifacts/aot-audit/win-x64/summary.json`，与真实设备交互和渠道验收分别记录。
 - 批次 B：第一项 x64 ABI/UI 探针通过。相同 AOT 宿主哈希，替换独立 DLL 后，实际 CalendarView 高度和业务结果均由 244 变为 268，标题绑定同步更新；详见 [可复现实验及边界](../../spikes/glance-native/README.md)。完整 Glance、待办切片、资源/生命周期/渠道仍待完成，B 尚未验收。
 - 批次 B 第二轮（2026-09-08 晚）：真实 Glance 切片（生产 XAML 移植 + 生产服务源码链接：本地月源/传统历法/节日/布局/装饰记录；固定 2026-09 实测 42/42 农历文本、中秋节日、真实传统历法标题）；同一进程销毁重建；双 DLL 单进程并存渲染；待办编辑/持久化切片（automation peer 真实点击路径 + 包目录 JSON 持久化 + 重建恢复）。六场景断言全绿，证据与批次 C 契约发现（包 XAML 无转换器、ThemeResource 需资源自含、元数据聚合待设计）见 [试点 README](../../spikes/glance-native/README.md)。尚未验收项：编译 XBF/PRI/本地化/自定义 WinRT 激活、物理输入/IME、完整 Glance 与其余五功能、ARM64 运行、系统化测量、叠放合并容器、渠道。
+- 批次 B 第三轮（2026-09-08 深夜）：编译 XAML/PRI/WinRT 激活三问全部实测为**当前不可行**，已钉进回归断言（XBF 在动态 AOT DLL 中无法定位——无类型最简控件同样失败，问题在定位层；AOT DLL 不导出 DllGetActivationFactory——C 导出是唯一 ABI；类库发布不产独立 PRI 且 MrtCore 无文件级加载——包本地化需自带字符串机制）。**运行时文本 XAML + 预计算可绑定属性确认为正式渲染路径**；`Application.ResourceManagerRequested` 记为未来逃逸口（未实验）。七场景全绿。
 - 批次 C–E：尚未实施。六功能仍保留在现有应用中；正式包格式、商店界面和升级迁移未在本批次提前切换。

--- a/scripts/spike/fast-glance-real.ps1
+++ b/scripts/spike/fast-glance-real.ps1
@@ -24,8 +24,20 @@ try {
     New-Item -ItemType Directory -Path $evidence -Force | Out-Null
     $process = Start-Process -FilePath $hostExe -WorkingDirectory $hostOutput -WindowStyle Hidden -PassThru -ArgumentList @(
         "--real-package", ('"{0}"' -f $packageOutput), ('"{0}"' -f $evidence))
-    if (-not $process.WaitForExit(30000)) { Stop-Process -Id $process.Id; throw "probe timed out" }
-    Write-Output ("exit=" + $process.ExitCode)
+    if (-not $process.WaitForExit(30000)) { Stop-Process -Id $process.Id; throw "real probe timed out" }
+    Write-Output ("real exit=" + $process.ExitCode)
+    if (Test-Path -LiteralPath (Join-Path $evidence "result.json")) {
+        Get-Content -LiteralPath (Join-Path $evidence "result.json") -Raw
+    }
+    $evidence = Join-Path $latestRun.FullName "result-compiled-fast"
+    Remove-Item -LiteralPath $evidence -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath (Join-Path $packageOutput "compiled-stages.txt") -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath (Join-Path $packageOutput "activation-error.txt") -ErrorAction SilentlyContinue
+    New-Item -ItemType Directory -Path $evidence -Force | Out-Null
+    $process = Start-Process -FilePath $hostExe -WorkingDirectory $hostOutput -WindowStyle Hidden -PassThru -ArgumentList @(
+        "--compiled-package", ('"{0}"' -f $packageOutput), ('"{0}"' -f $evidence))
+    if (-not $process.WaitForExit(30000)) { Stop-Process -Id $process.Id; throw "compiled probe timed out" }
+    Write-Output ("compiled exit=" + $process.ExitCode)
     if (Test-Path -LiteralPath (Join-Path $evidence "result.json")) {
         Get-Content -LiteralPath (Join-Path $evidence "result.json") -Raw
     }

--- a/scripts/spike/run-glance-native.ps1
+++ b/scripts/spike/run-glance-native.ps1
@@ -108,6 +108,24 @@ try {
         if (-not (Test-Path -LiteralPath (Join-Path $evidence "view.png"))) { throw "Missing rendered view: $evidence" }
         $results += [pscustomobject]@{ scenario = "real-glance"; result = $result; evidence = $evidence }
 
+        # Compiled-XAML (XBF) slice: PINNED NEGATIVE. XBF LoadComponent cannot
+        # locate compiled XAML in a dynamically loaded AOT DLL (even a type-free
+        # minimal control); AOT DLLs export no DllGetActivationFactory; the
+        # class-library build produces no standalone .pri and MrtCore has no
+        # file-based loading. The scenario records all three outcomes; if a
+        # future Windows App SDK flips any of them, the assertion forces the
+        # spike contract findings to be re-evaluated.
+        $evidence = Join-Path $runRoot "result-compiled"
+        $result = Invoke-Probe -Exe $hostExe -WorkingDirectory $hostOutput -Evidence $evidence -Arguments @(
+            "--compiled-package", ('"{0}"' -f $packageOutputs[3]), ('"{0}"' -f $evidence))
+        if ($result.compiledXamlLoads -or
+            $result.compiledStages -ne "none" -or
+            $result.activationFactoryExport -or
+            $result.localizationProbe.priFilesNextToDll -ne "none") {
+            throw "Compiled-XAML pin flipped - re-evaluate the spike contract findings: $evidence"
+        }
+        $results += [pscustomobject]@{ scenario = "compiled-xaml-pinned-negative"; result = $result; evidence = $evidence }
+
         # Lifecycle: destroy and recreate the view within one process.
         $evidence = Join-Path $runRoot "result-lifecycle"
         $result = Invoke-Probe -Exe $hostExe -WorkingDirectory $hostOutput -Evidence $evidence -Arguments @(

--- a/spikes/glance-native/Host/Program.cs
+++ b/spikes/glance-native/Host/Program.cs
@@ -16,6 +16,7 @@ internal enum Scenario
 {
     Simple,
     RealGlance,
+    CompiledGlance,
     Lifecycle,
     MultiPackage,
     TodoEdit,
@@ -36,6 +37,9 @@ internal static class Program
                 break;
             case ["--real-package", string package, string outDir]:
                 (scenario, packages, output) = (Scenario.RealGlance, [package], outDir);
+                break;
+            case ["--compiled-package", string package, string outDir]:
+                (scenario, packages, output) = (Scenario.CompiledGlance, [package], outDir);
                 break;
             case ["--lifecycle-package", string package, string outDir]:
                 (scenario, packages, output) = (Scenario.Lifecycle, [package], outDir);
@@ -143,6 +147,7 @@ public sealed partial class ProbeApplication : Application
         {
             case Scenario.Simple: RunSimple(); break;
             case Scenario.RealGlance: RunReal(); break;
+            case Scenario.CompiledGlance: RunCompiled(); break;
             case Scenario.Lifecycle: RunLifecycle(); break;
             case Scenario.MultiPackage: RunMulti(); break;
             case Scenario.TodoEdit: RunTodo(); break;
@@ -220,6 +225,88 @@ public sealed partial class ProbeApplication : Application
                 result.WriteString("traditionalTitle", title);
                 result.WritePropertyName("packageSummary");
                 summary.RootElement.WriteTo(result);
+            });
+        }
+        catch (Exception error) { File.WriteAllText(Path.Combine(_output, "error.txt"), error.ToString()); }
+        finally { _window?.Close(); Exit(); }
+    }
+
+    private unsafe void RunCompiled()
+    {
+        nint module = LoadModule(_packages[0], "DeskBox.Glance.NativePackage.dll", _output);
+        bool activationFactoryExport = NativeLibrary.TryGetExport(module, "DllGetActivationFactory", out _);
+        File.AppendAllText(Path.Combine(_output, "stages.txt"),
+            $"DllGetActivationFactory present: {activationFactoryExport}\n");
+        FrameworkElement? content = null;
+        string failure = "";
+        try
+        {
+            content = CreateView(module, "glance_probe_create_compiled_view", _packages[0], _output);
+        }
+        catch (Exception error)
+        {
+            // Pinned negative: XBF LoadComponent cannot locate compiled XAML in a
+            // dynamically loaded AOT DLL (even a type-free minimal control). If a
+            // future Windows App SDK loads it, this probe flips and the script
+            // forces the spike contract findings to be re-evaluated.
+            failure = error.Message;
+        }
+        if (content is null)
+        {
+            string stages = File.Exists(Path.Combine(_packages[0], "compiled-stages.txt"))
+                ? File.ReadAllText(Path.Combine(_packages[0], "compiled-stages.txt")).Trim()
+                : "none";
+            string localization = File.Exists(Path.Combine(_packages[0], "localization-probe.json"))
+                ? File.ReadAllText(Path.Combine(_packages[0], "localization-probe.json"))
+                : "{}";
+            JsonDocument localizationProbe = JsonDocument.Parse(localization);
+            WriteResult(result =>
+            {
+                result.WriteBoolean("compiledXamlLoads", false);
+                result.WriteString("compiledStages", stages);
+                result.WriteBoolean("activationFactoryExport", activationFactoryExport);
+                result.WriteString("failure", failure);
+                result.WritePropertyName("localizationProbe");
+                localizationProbe.RootElement.WriteTo(result);
+            });
+            Exit();
+            return;
+        }
+        content.Width = 440;
+        content.Height = 560;
+        _window = new Window { Title = "Glance compiled slice probe", Content = content };
+        _window.AppWindow.Resize(new Windows.Graphics.SizeInt32(460, 610));
+        content.Loaded += (sender, args) => _ = FinishCompiled(content, activationFactoryExport);
+        _window.Activate();
+    }
+
+    private async Task FinishCompiled(FrameworkElement content, bool activationFactoryExport)
+    {
+        try
+        {
+            await Task.Delay(900);
+            await CaptureAsync(content, "view.png");
+            var calendar = content.FindName("NativeCalendarView").As<CalendarView>();
+            var themeProbe = content.FindName("ThemeProbeText").As<TextBlock>();
+            bool themeForegroundResolved = themeProbe.Foreground is not null;
+            string title = content.FindName("TraditionalCalendarTitlePresenter").As<TextBlock>().Text;
+            JsonDocument summary = JsonDocument.Parse(
+                await File.ReadAllTextAsync(Path.Combine(_packages[0], "compiled-summary.json")));
+            string localization = File.Exists(Path.Combine(_packages[0], "localization-probe.json"))
+                ? await File.ReadAllTextAsync(Path.Combine(_packages[0], "localization-probe.json"))
+                : "{}";
+            JsonDocument localizationProbe = JsonDocument.Parse(localization);
+            WriteResult(result =>
+            {
+                result.WriteBoolean("dynamicCodeSupported", RuntimeFeature.IsDynamicCodeSupported);
+                result.WriteBoolean("activationFactoryExport", activationFactoryExport);
+                result.WriteBoolean("themeForegroundResolved", themeForegroundResolved);
+                result.WriteNumber("calendarActualHeight", calendar.ActualHeight);
+                result.WriteString("traditionalTitle", title);
+                result.WritePropertyName("packageSummary");
+                summary.RootElement.WriteTo(result);
+                result.WritePropertyName("localizationProbe");
+                localizationProbe.RootElement.WriteTo(result);
             });
         }
         catch (Exception error) { File.WriteAllText(Path.Combine(_output, "error.txt"), error.ToString()); }

--- a/spikes/glance-native/Package/Converters.cs
+++ b/spikes/glance-native/Package/Converters.cs
@@ -1,0 +1,31 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Data;
+
+namespace DeskBox.Glance.NativePackage;
+
+// Same semantics as the GlanceWidgetContent code-behind converters. Declared in
+// the package namespace: compiled XAML resolves them through this assembly's
+// generated XamlMetaDataProvider (runtime text XAML cannot - see README).
+public sealed class GlanceBoolToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+        => value is true ? Visibility.Visible : Visibility.Collapsed;
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+        => throw new NotSupportedException();
+}
+
+public sealed class GlanceInverseBoolToVisibilityConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+        => value is true ? Visibility.Collapsed : Visibility.Visible;
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+        => throw new NotSupportedException();
+}
+
+public sealed class GlanceBoolToFontWeightConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language)
+        => value is true ? Microsoft.UI.Text.FontWeights.SemiBold : Microsoft.UI.Text.FontWeights.Normal;
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+        => throw new NotSupportedException();
+}

--- a/spikes/glance-native/Package/Exports.cs
+++ b/spikes/glance-native/Package/Exports.cs
@@ -62,6 +62,32 @@ public static unsafe class Exports
             return error.HResult;
         }
     }
+    [UnmanagedCallersOnly(EntryPoint = "glance_probe_create_compiled_view", CallConvs = [typeof(CallConvCdecl)])]
+    public static int CreateCompiledView(char* directory, int length, nint* view)
+    {
+        if (directory is null || length is <= 0 or > 32767 || view is null) return -1;
+        *view = 0;
+        string root = new(directory, 0, length);
+        try
+        {
+            PackageContext.Root = root;
+            LocalizationProbe.RunAsync(root).GetAwaiter().GetResult();
+            // Discrimination step: a type-free compiled control first, so the
+            // activation error names the failing layer (XBF locator vs type
+            // resolution vs localization).
+            var minimal = new MinimalControl();
+            File.AppendAllText(Path.Combine(root, "compiled-stages.txt"), "minimal ok\n");
+            var control = new RealGlanceControl();
+            File.AppendAllText(Path.Combine(root, "compiled-stages.txt"), "real compiled ok\n");
+            *view = WinRT.MarshalInspectable<FrameworkElement>.FromManaged(control);
+            return 0;
+        }
+        catch (Exception error)
+        {
+            File.WriteAllText(Path.Combine(root, "activation-error.txt"), error.ToString());
+            return error.HResult;
+        }
+    }
 }
 
 [WinRT.GeneratedBindableCustomProperty]

--- a/spikes/glance-native/Package/Glance.NativePackage.csproj
+++ b/spikes/glance-native/Package/Glance.NativePackage.csproj
@@ -38,5 +38,8 @@
     <None Update="calendar.xaml" CopyToOutputDirectory="PreserveNewest" />
     <Page Remove="glance-real.xaml" />
     <None Update="glance-real.xaml" CopyToOutputDirectory="PreserveNewest" />
+    <!-- RealGlanceControl.xaml stays a compiled Page (XBF + XamlMetaDataProvider). -->
+    <PRIResource Include="Strings\zh-CN\Resources.resw" />
+    <PRIResource Include="Strings\en-US\Resources.resw" />
   </ItemGroup>
 </Project>

--- a/spikes/glance-native/Package/LocalizationProbe.cs
+++ b/spikes/glance-native/Package/LocalizationProbe.cs
@@ -1,0 +1,82 @@
+using System.Text.Json;
+
+namespace DeskBox.Glance.NativePackage;
+
+/// <summary>
+/// PRI/localization probe. WinAppSDK MrtCore exposes no file-based PRI loading
+/// (main app map only); the legacy UWP Windows.ApplicationModel.Resources.Core
+/// ResourceManager can load external PRI files but may require package
+/// identity. Both paths are attempted and their outcomes recorded - the spike
+/// value is the recorded evidence either way.
+/// </summary>
+internal static class LocalizationProbe
+{
+    public static async Task RunAsync(string root)
+    {
+        var outcomes = new List<(string Method, string Result)>();
+
+        string[] priFiles = Directory.Exists(root)
+            ? Directory.GetFiles(root, "*.pri", SearchOption.TopDirectoryOnly)
+            : [];
+        outcomes.Add(("priFilesNextToDll", priFiles.Length == 0
+            ? "none"
+            : string.Join(",", priFiles.Select(Path.GetFileName))));
+
+        try
+        {
+            var manager = new Microsoft.Windows.ApplicationModel.Resources.ResourceManager();
+            string? value = manager.MainResourceMap?.GetValue("GlanceTitle")?.ValueAsString;
+            outcomes.Add(("mrtCoreMainMap", string.IsNullOrEmpty(value) ? "key not found in host main map" : value));
+        }
+        catch (Exception error)
+        {
+            outcomes.Add(("mrtCoreMainMap", "failed: " + error.GetType().Name + ": " + error.Message));
+        }
+
+        try
+        {
+            var named = new Microsoft.Windows.ApplicationModel.Resources.ResourceManager("DeskBox.Glance.NativePackage/Resources");
+            string? value = named.MainResourceMap?.GetValue("GlanceTitle")?.ValueAsString;
+            outcomes.Add(("mrtCoreNamedMap", string.IsNullOrEmpty(value) ? "key not found" : value));
+        }
+        catch (Exception error)
+        {
+            outcomes.Add(("mrtCoreNamedMap", "failed: " + error.GetType().Name + ": " + error.Message));
+        }
+
+        if (priFiles.Length > 0)
+        {
+            try
+            {
+                Windows.Storage.StorageFolder folder = await Windows.Storage.StorageFolder.GetFolderFromPathAsync(root);
+                var files = new List<Windows.Storage.StorageFile>();
+                foreach (string pri in priFiles)
+                {
+                    files.Add(await folder.GetFileAsync(Path.GetFileName(pri)));
+                }
+                Windows.ApplicationModel.Resources.Core.ResourceManager.Current.LoadPriFiles(files);
+                var candidate = Windows.ApplicationModel.Resources.Core.ResourceManager.Current.MainResourceMap
+                    .GetValue("DeskBox.Glance.NativePackage/Resources/GlanceTitle");
+                string? loaded = candidate?.ValueAsString;
+                outcomes.Add(("uwpLoadPriFiles", string.IsNullOrEmpty(loaded) ? "loaded, key not found" : loaded));
+            }
+            catch (Exception error)
+            {
+                outcomes.Add(("uwpLoadPriFiles", "failed: " + error.GetType().Name + ": " + error.Message));
+            }
+        }
+        else
+        {
+            outcomes.Add(("uwpLoadPriFiles", "skipped: no pri file"));
+        }
+
+        using var stream = File.Create(Path.Combine(root, "localization-probe.json"));
+        using var writer = new Utf8JsonWriter(stream);
+        writer.WriteStartObject();
+        foreach ((string method, string result) in outcomes)
+        {
+            writer.WriteString(method, result);
+        }
+        writer.WriteEndObject();
+    }
+}

--- a/spikes/glance-native/Package/MinimalControl.xaml
+++ b/spikes/glance-native/Package/MinimalControl.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Minimal compiled-XAML control with no package-local types: discriminates
+     XBF-locator failures from XAML-type-resolution failures. -->
+<UserControl
+    x:Class="DeskBox.Glance.NativePackage.MinimalControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Padding="12">
+    <StackPanel Spacing="6">
+        <TextBlock x:Name="MinimalText" FontSize="14" Text="compiled minimal control" />
+    </StackPanel>
+</UserControl>

--- a/spikes/glance-native/Package/MinimalControl.xaml.cs
+++ b/spikes/glance-native/Package/MinimalControl.xaml.cs
@@ -1,0 +1,12 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace DeskBox.Glance.NativePackage;
+
+public sealed partial class MinimalControl : UserControl
+{
+    public MinimalControl()
+    {
+        InitializeComponent();
+    }
+}

--- a/spikes/glance-native/Package/RealGlanceControl.xaml
+++ b/spikes/glance-native/Package/RealGlanceControl.xaml
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Batch B round 3: the real-Glance port as COMPILED XAML (XBF). Unlike the
+     runtime-text slice (glance-real.xaml), compiled XAML resolves package-local
+     converter types through this assembly's generated XamlMetaDataProvider and
+     resolves ThemeResource keys through the live tree at apply time - this file
+     therefore restores the production converter pattern and production
+     ThemeResource references verbatim. -->
+<UserControl
+    x:Class="DeskBox.Glance.NativePackage.RealGlanceControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:pkg="using:DeskBox.Glance.NativePackage"
+    Padding="20,22,20,18"
+    Background="Transparent">
+
+    <UserControl.Resources>
+        <pkg:GlanceBoolToVisibilityConverter x:Key="BoolToVisibility" />
+        <pkg:GlanceInverseBoolToVisibilityConverter x:Key="InverseBoolToVisibility" />
+        <pkg:GlanceBoolToFontWeightConverter x:Key="BoolToFontWeight" />
+        <AcrylicBrush
+            x:Key="GlanceCalendarAcrylicBrush"
+            FallbackColor="{ThemeResource SolidBackgroundFillColorBase}"
+            TintColor="{ThemeResource SolidBackgroundFillColorBase}" />
+        <Style x:Key="GlanceCalendarDayItemStyle" TargetType="CalendarViewDayItem">
+            <Setter Property="MinWidth" Value="34" />
+            <Setter Property="MinHeight" Value="24" />
+            <Setter Property="Margin" Value="0" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="UseSystemFocusVisuals" Value="True" />
+            <Setter Property="FocusVisualMargin" Value="-2" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="CalendarViewDayItem">
+                        <Grid MinWidth="34" MinHeight="24" Background="Transparent">
+                            <StackPanel
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Opacity="{Binding Tag.PrimaryOpacity, RelativeSource={RelativeSource TemplatedParent}}"
+                                Spacing="0"
+                                Visibility="{Binding Tag.IsToday, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource InverseBoolToVisibility}}">
+                                <TextBlock
+                                    HorizontalAlignment="Center"
+                                    FontSize="11"
+                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                                    LineHeight="13"
+                                    LineStackingStrategy="BlockLineHeight"
+                                    Text="{Binding Tag.DayText, RelativeSource={RelativeSource TemplatedParent}}"
+                                    Typography.NumeralAlignment="Tabular" />
+                                <TextBlock
+                                    MaxWidth="32"
+                                    HorizontalAlignment="Center"
+                                    FontSize="7.5"
+                                    FontWeight="{Binding Tag.IsFestival, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BoolToFontWeight}}"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    LineHeight="10"
+                                    LineStackingStrategy="BlockLineHeight"
+                                    MaxLines="1"
+                                    Opacity="{Binding Tag.SecondaryOpacity, RelativeSource={RelativeSource TemplatedParent}}"
+                                    Text="{Binding Tag.SecondaryText, RelativeSource={RelativeSource TemplatedParent}}"
+                                    TextTrimming="CharacterEllipsis"
+                                    Visibility="{Binding Tag.HasSecondaryText, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BoolToVisibility}}" />
+                            </StackPanel>
+                            <StackPanel
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Spacing="0"
+                                Visibility="{Binding Tag.IsToday, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BoolToVisibility}}">
+                                <TextBlock
+                                    HorizontalAlignment="Center"
+                                    FontSize="11"
+                                    FontWeight="SemiBold"
+                                    Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+                                    LineHeight="13"
+                                    LineStackingStrategy="BlockLineHeight"
+                                    Text="{Binding Tag.DayText, RelativeSource={RelativeSource TemplatedParent}}"
+                                    Typography.NumeralAlignment="Tabular" />
+                                <TextBlock
+                                    MaxWidth="32"
+                                    HorizontalAlignment="Center"
+                                    FontSize="7.5"
+                                    FontWeight="{Binding Tag.IsFestival, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BoolToFontWeight}}"
+                                    Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+                                    LineHeight="10"
+                                    LineStackingStrategy="BlockLineHeight"
+                                    MaxLines="1"
+                                    Opacity="0.86"
+                                    Text="{Binding Tag.SecondaryText, RelativeSource={RelativeSource TemplatedParent}}"
+                                    TextTrimming="CharacterEllipsis"
+                                    Visibility="{Binding Tag.HasSecondaryText, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BoolToVisibility}}" />
+                            </StackPanel>
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
+
+    <Grid
+        x:Name="CalendarLayoutRoot"
+        Visibility="{Binding IsCalendarLayout, Converter={StaticResource BoolToVisibility}}">
+
+        <StackPanel
+            HorizontalAlignment="Left"
+            VerticalAlignment="Top"
+            Spacing="-1"
+            Visibility="{Binding IsExpandedCalendarPresentation, Converter={StaticResource BoolToVisibility}}">
+            <TextBlock
+                FontFamily="{Binding TimeFontFamily}"
+                FontSize="{Binding CompactTimeFontSize}"
+                FontWeight="SemiBold"
+                Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                Text="{Binding TimeText}"
+                Typography.NumeralAlignment="Tabular"
+                Visibility="{Binding ShowTime, Converter={StaticResource BoolToVisibility}}" />
+            <StackPanel Orientation="Horizontal" Spacing="7">
+                <TextBlock FontSize="12" FontWeight="SemiBold" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Text="{Binding DateText}" Visibility="{Binding ShowDate, Converter={StaticResource BoolToVisibility}}" />
+                <TextBlock FontSize="12" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{Binding WeekdayText}" Visibility="{Binding ShowWeekday, Converter={StaticResource BoolToVisibility}}" />
+            </StackPanel>
+            <!-- Runtime probe: host asserts this Foreground resolved to a real
+                 ThemeResource brush from the host's XamlControlsResources. -->
+            <TextBlock x:Name="ThemeProbeText" FontSize="1" Opacity="0.01" Foreground="{ThemeResource TextFillColorPrimaryBrush}" Text="probe" />
+        </StackPanel>
+
+        <Border
+            x:Name="CalendarGlassSurface"
+            Height="{Binding CalendarPanelHeight}"
+            HorizontalAlignment="Center"
+            Margin="-6,0,-6,0"
+            MaxWidth="{Binding CalendarPanelMaxWidth}"
+            VerticalAlignment="Bottom"
+            Width="{Binding CalendarPanelWidth}"
+            CornerRadius="{Binding CalendarCornerRadius}">
+            <Grid>
+                <Border
+                    x:Name="CalendarMaterialSurface"
+                    Background="{StaticResource GlanceCalendarAcrylicBrush}"
+                    CornerRadius="{Binding CalendarCornerRadius}"
+                    IsHitTestVisible="False" />
+                <Grid Margin="8,0,8,4">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+
+                    <Grid
+                        Grid.Row="0"
+                        Height="27"
+                        Margin="13,7,6,0"
+                        Visibility="{Binding IsCompactCalendarPresentation, Converter={StaticResource BoolToVisibility}}">
+                        <TextBlock
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Top"
+                            FontFamily="{Binding TimeFontFamily}"
+                            FontSize="{Binding CalendarCompactTimeFontSize}"
+                            FontWeight="SemiBold"
+                            Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                            LineHeight="26"
+                            LineStackingStrategy="BlockLineHeight"
+                            Margin="0,5,0,-5"
+                            Text="{Binding TimeText}"
+                            Typography.NumeralAlignment="Tabular"
+                            Visibility="{Binding ShowTime, Converter={StaticResource BoolToVisibility}}" />
+                        <StackPanel Margin="0,5,0,-5" HorizontalAlignment="Right" VerticalAlignment="Top" Spacing="0">
+                            <TextBlock HorizontalAlignment="Right" FontSize="10" FontWeight="SemiBold" Foreground="{ThemeResource TextFillColorPrimaryBrush}" LineHeight="12" LineStackingStrategy="BlockLineHeight" Text="{Binding CompactCalendarDateText}" Visibility="{Binding ShowDate, Converter={StaticResource BoolToVisibility}}" />
+                            <TextBlock HorizontalAlignment="Right" FontSize="9.5" Foreground="{ThemeResource TextFillColorSecondaryBrush}" LineHeight="11" LineStackingStrategy="BlockLineHeight" Text="{Binding WeekdayText}" Visibility="{Binding ShowWeekday, Converter={StaticResource BoolToVisibility}}" />
+                        </StackPanel>
+                    </Grid>
+
+                    <Grid Grid.Row="1">
+                        <CalendarView
+                            x:Name="NativeCalendarView"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            Background="Transparent"
+                            BorderBrush="Transparent"
+                            BorderThickness="0"
+                            CalendarItemBackground="Transparent"
+                            CalendarItemBorderBrush="Transparent"
+                            CalendarItemBorderThickness="0"
+                            CalendarItemCornerRadius="6"
+                            CalendarItemForeground="{ThemeResource TextFillColorPrimaryBrush}"
+                            CalendarItemHoverBackground="{ThemeResource SubtleFillColorSecondaryBrush}"
+                            CalendarItemPressedBackground="{ThemeResource SubtleFillColorTertiaryBrush}"
+                            CalendarViewDayItemChanging="OnDayItemChanging"
+                            CalendarViewDayItemStyle="{StaticResource GlanceCalendarDayItemStyle}"
+                            DayItemFontSize="0.1"
+                            DayItemMargin="0"
+                            DayOfWeekFormat="{}{dayofweek.abbreviated(1)}"
+                            Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                            HorizontalDayItemAlignment="Center"
+                            IsGroupLabelVisible="False"
+                            IsOutOfScopeEnabled="True"
+                            IsTodayHighlighted="True"
+                            NumberOfWeeksInView="6"
+                            OutOfScopeBackground="Transparent"
+                            OutOfScopeForeground="{ThemeResource TextFillColorDisabledBrush}"
+                            SelectionMode="None"
+                            TodayBackground="{ThemeResource AccentFillColorDefaultBrush}"
+                            TodayFontWeight="SemiBold"
+                            TodayForeground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+                            VerticalDayItemAlignment="Center">
+                            <CalendarView.Resources>
+                                <x:Double x:Key="CalendarViewHeaderNavigationButtonFontSize">13</x:Double>
+                                <x:Double x:Key="CalendarViewNavigationButtonFontSize">10</x:Double>
+                                <Thickness x:Key="CalendarViewDayItemMargin">0</Thickness>
+                                <Thickness x:Key="CalendarViewWeekDayMargin">0</Thickness>
+                                <Thickness x:Key="CalendarViewWeekDayPadding">1,4,1,4</Thickness>
+                                <Thickness x:Key="CalendarViewMonthYearItemMargin">3</Thickness>
+                                <Thickness x:Key="CalendarViewHeaderNavigationButtonPadding">8,6,8,6</Thickness>
+                                <Thickness x:Key="CalendarViewNavigationButtonPadding">9,6,9,6</Thickness>
+                                <Thickness x:Key="CalendarViewHeaderNavigationButtonMargin">4,2,2,2</Thickness>
+                                <Thickness x:Key="CalendarViewNavigationPreviousButtonMargin">2,2,1,2</Thickness>
+                                <Thickness x:Key="CalendarViewNavigationNextButtonMargin">1,2,4,2</Thickness>
+                            </CalendarView.Resources>
+                        </CalendarView>
+                        <TextBlock
+                            x:Name="TraditionalCalendarTitlePresenter"
+                            Height="29"
+                            Margin="98,0,70,0"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Top"
+                            FontSize="8"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            IsHitTestVisible="False"
+                            LineHeight="29"
+                            LineStackingStrategy="BlockLineHeight"
+                            MaxLines="1"
+                            Opacity="0.68"
+                            Text="{Binding TraditionalCalendarTitle}"
+                            TextAlignment="Center"
+                            TextTrimming="CharacterEllipsis"
+                            Visibility="Visible" />
+                    </Grid>
+                </Grid>
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/spikes/glance-native/Package/RealGlanceControl.xaml.cs
+++ b/spikes/glance-native/Package/RealGlanceControl.xaml.cs
@@ -1,0 +1,109 @@
+using System.Text.Json;
+using DeskBox.Models;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace DeskBox.Glance.NativePackage;
+
+/// <summary>
+/// Compiled-XAML (XBF) variant of the real-Glance slice. The XAML restores the
+/// production converter pattern and ThemeResource references; day decoration
+/// uses the production GlanceCalendarDayDecoration record directly.
+/// </summary>
+public sealed partial class RealGlanceControl : UserControl
+{
+    private readonly DeskBox.Models.GlanceCalendarMonth _month;
+    private readonly double _dayItemHeight;
+    private readonly bool _showSecondaryText;
+    private readonly System.Globalization.CultureInfo _culture = RealGlanceModel.Culture;
+    private readonly DateOnly _pinnedMonth;
+    private int _decorated;
+
+    public RealGlanceControl()
+    {
+        InitializeComponent();
+        (_month, bool isCompact, double panelHeight, double panelWidth, double dayItemHeight, bool showSecondaryText) = RealGlanceModel.Build();
+        _dayItemHeight = dayItemHeight;
+        _showSecondaryText = showSecondaryText;
+        _pinnedMonth = new DateOnly(RealGlanceModel.PinnedYear, RealGlanceModel.PinnedMonth, 1);
+        DataContext = RealGlanceModel.CreatePresentation(_month, isCompact, panelHeight, panelWidth);
+        Loaded += (_, _) =>
+        {
+            var timer = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread().CreateTimer();
+            timer.Interval = TimeSpan.FromMilliseconds(600);
+            timer.Tick += (_, _) =>
+            {
+                timer.Stop();
+                WriteSummary();
+            };
+            timer.Start();
+        };
+    }
+
+    private void OnDayItemChanging(CalendarView sender, CalendarViewDayItemChangingEventArgs args)
+    {
+        CalendarViewDayItem item = args.Item;
+        if (args.InRecycleQueue)
+        {
+            item.Tag = null;
+            return;
+        }
+        // Replicates GlanceWidgetContent.ApplyCalendarDayDecoration with the
+        // production decoration record (converters resolve in compiled XAML).
+        DateOnly date = DateOnly.FromDateTime(item.Date.DateTime);
+        DeskBox.Models.GlanceCalendarDay? day = null;
+        foreach (DeskBox.Models.GlanceCalendarDay candidate in _month.Days)
+        {
+            if (candidate.Date == date) { day = candidate; break; }
+        }
+        string secondaryText = _showSecondaryText
+            ? !string.IsNullOrWhiteSpace(day?.FestivalText)
+                ? day.FestivalText
+                : day?.TraditionalText ?? string.Empty
+            : string.Empty;
+        bool hasSecondaryText = !string.IsNullOrWhiteSpace(secondaryText);
+        bool isFestival = hasSecondaryText && day?.HasFestival == true;
+        bool isCurrentMonth = day?.IsCurrentMonth ?? date.Month == _pinnedMonth.Month;
+        item.MinHeight = _dayItemHeight;
+        item.Height = _dayItemHeight;
+        item.Tag = new GlanceCalendarDayDecoration(
+            day?.DayText ?? date.Day.ToString(_culture),
+            secondaryText,
+            hasSecondaryText,
+            date == DateOnly.FromDateTime(DateTime.Today),
+            isFestival,
+            isCurrentMonth ? 1.0 : 0.42,
+            !isCurrentMonth ? 0.34 : isFestival ? 0.88 : 0.62);
+        if (hasSecondaryText) _decorated++;
+    }
+
+    private void WriteSummary()
+    {
+        // The runtime-text slice writes real-summary.json into the package
+        // directory; the compiled variant keeps the same contract but with its
+        // own file so both slices can run in one process.
+        string path = Path.Combine(PackageContext.Root, "compiled-summary.json");
+        using var stream = File.Create(path);
+        using var writer = new Utf8JsonWriter(stream);
+        writer.WriteStartObject();
+        writer.WriteString("variant", "compiled-xbf");
+        writer.WriteString("pinnedMonth", $"{RealGlanceModel.PinnedYear:0000}-{RealGlanceModel.PinnedMonth:00}");
+        writer.WriteString("traditionalTitle", _month.TraditionalTitle);
+        writer.WriteNumber("traditionalTextDayCount",
+            _month.Days.Count(day => !string.IsNullOrWhiteSpace(day.TraditionalText)));
+        writer.WriteStartArray("festivalDays");
+        foreach (DeskBox.Models.GlanceCalendarDay day in _month.Days)
+        {
+            if (day.HasFestival) writer.WriteStringValue($"{day.Date:yyyy-MM-dd} {day.FestivalText}");
+        }
+        writer.WriteEndArray();
+        writer.WriteNumber("decoratedDayCount", _decorated);
+        writer.WriteEndObject();
+    }
+}
+
+/// <summary>Set by the export before construction: package directory for diagnostics.</summary>
+internal static class PackageContext
+{
+    public static string Root { get; set; } = "";
+}

--- a/spikes/glance-native/Package/RealGlanceModel.cs
+++ b/spikes/glance-native/Package/RealGlanceModel.cs
@@ -1,0 +1,82 @@
+using System.Globalization;
+using DeskBox.Contracts;
+using DeskBox.Models;
+using DeskBox.Services;
+
+namespace DeskBox.Glance.NativePackage;
+
+/// <summary>
+/// Shared month-building pipeline for both slice views: production month
+/// source, then production traditional-calendar and festival services, plus
+/// the mirrored panel metrics from GlanceWidgetViewModel.
+/// </summary>
+internal static class RealGlanceModel
+{
+    // Mirrors GlanceWidgetViewModel sizing at the probe's 440x560 content area:
+    // CalendarPanelMaximumWidth=360, CalendarPanelHorizontalInset=28.
+    public const double AvailableWidth = 440;
+    public const double AvailableHeight = 560;
+
+    // Pinned so festival assertions are deterministic; today-highlighting still
+    // follows the machine clock and is not asserted.
+    public const int PinnedYear = 2026;
+    public const int PinnedMonth = 9;
+
+    public static CultureInfo Culture { get; } = CultureInfo.GetCultureInfo("zh-CN");
+
+    public static (GlanceCalendarMonth Month, bool IsCompact, double PanelHeight, double PanelWidth, double DayItemHeight, bool ShowSecondaryText) Build()
+    {
+        DateOnly month = new(PinnedYear, PinnedMonth, 1);
+        DateOnly today = DateOnly.FromDateTime(DateTime.Today);
+
+        GlanceCalendarMonth calendarMonth = new LocalCalendarPresentationSource()
+            .GetMonthAsync(month, Culture).GetAwaiter().GetResult();
+        DateOnly titleDate = month == new DateOnly(today.Year, today.Month, 1) ? today : month.AddDays(14);
+        calendarMonth = new GlanceTraditionalCalendarService().Apply(
+            calendarMonth, GlanceTraditionalCalendarMode.ChineseLunar, Culture, titleDate);
+        calendarMonth = new GlanceFestivalService().Apply(
+            calendarMonth, showChineseFestivals: true, GlanceTraditionalCalendarMode.ChineseLunar, Culture);
+
+        bool isCompact = GlanceCalendarLayoutCalculator.IsCompact(AvailableHeight);
+        double panelHeight = GlanceCalendarLayoutCalculator.CalculatePanelHeight(AvailableHeight, isCompact, true);
+        double panelWidth = Math.Round(Math.Clamp(AvailableWidth - 28, 272, 360));
+        double dayItemHeight = Math.Round(GlanceCalendarLayoutCalculator.CalculateDayHeight(panelHeight, isCompact, true) * 2) / 2;
+        bool showSecondaryText = GlanceCalendarLayoutCalculator.ShouldShowTraditionalDetails(panelWidth, dayItemHeight, isCompact, true);
+        return (calendarMonth, isCompact, panelHeight, panelWidth, dayItemHeight, showSecondaryText);
+    }
+
+    public static RealGlancePresentation CreatePresentation(
+        GlanceCalendarMonth month, bool isCompact, double panelHeight, double panelWidth)
+    {
+        CultureInfo culture = Culture;
+        DateTime now = DateTime.Now;
+        double compactFontSize = Math.Round(Math.Clamp(Math.Min(AvailableWidth * 0.078, AvailableHeight * 0.095), 22, 28) * 2) / 2;
+        return new RealGlancePresentation
+        {
+            TimeText = now.ToString("HH:mm", culture),
+            DateText = now.ToString("M月d日", culture),
+            WeekdayText = culture.DateTimeFormat.GetDayName(now.DayOfWeek),
+            CompactCalendarDateText = now.ToString("M月d日", culture),
+            TraditionalCalendarTitle = month.TraditionalTitle,
+            TimeFontFamily = new Microsoft.UI.Xaml.Media.FontFamily("XamlAutoFontFamily"),
+            CompactTimeFontSize = compactFontSize,
+            CalendarCompactTimeFontSize = compactFontSize,
+            CalendarPanelHeight = panelHeight,
+            CalendarPanelWidth = panelWidth,
+            CalendarPanelMaxWidth = 360,
+            CalendarCornerRadius = new Microsoft.UI.Xaml.CornerRadius(12),
+            ShowTime = true,
+            ShowDate = true,
+            ShowWeekday = true,
+            IsCalendarLayout = true,
+            IsCompactCalendarPresentation = isCompact,
+            IsExpandedCalendarPresentation = !isCompact,
+            CalendarLayoutVisibility = Microsoft.UI.Xaml.Visibility.Visible,
+            IsCompactVisibility = isCompact ? Microsoft.UI.Xaml.Visibility.Visible : Microsoft.UI.Xaml.Visibility.Collapsed,
+            IsExpandedVisibility = isCompact ? Microsoft.UI.Xaml.Visibility.Collapsed : Microsoft.UI.Xaml.Visibility.Visible,
+            ShowTimeVisibility = Microsoft.UI.Xaml.Visibility.Visible,
+            ShowDateVisibility = Microsoft.UI.Xaml.Visibility.Visible,
+            ShowWeekdayVisibility = Microsoft.UI.Xaml.Visibility.Visible,
+        };
+    }
+}

--- a/spikes/glance-native/Package/RealGlanceView.cs
+++ b/spikes/glance-native/Package/RealGlanceView.cs
@@ -19,58 +19,13 @@ namespace DeskBox.Glance.NativePackage;
 /// </summary>
 internal static class RealGlanceView
 {
-    // Pinned so festival assertions are deterministic; today-highlighting still
-    // follows the machine clock and is not asserted.
-    private const int PinnedYear = 2026;
-    private const int PinnedMonth = 9;
-
-    // Mirrors GlanceWidgetViewModel sizing at the probe's 440x560 content area:
-    // CalendarPanelMaximumWidth=360, CalendarPanelHorizontalInset=28.
-    private const double AvailableWidth = 440;
-    private const double AvailableHeight = 560;
-
     public static FrameworkElement Create(string root)
     {
-        CultureInfo culture = CultureInfo.GetCultureInfo("zh-CN");
-        DateOnly month = new(PinnedYear, PinnedMonth, 1);
+        (GlanceCalendarMonth calendarMonth, bool isCompact, double panelHeight, double panelWidth, double dayItemHeight, bool showSecondaryText) = RealGlanceModel.Build();
+        CultureInfo culture = RealGlanceModel.Culture;
+        DateOnly month = new(RealGlanceModel.PinnedYear, RealGlanceModel.PinnedMonth, 1);
         DateOnly today = DateOnly.FromDateTime(DateTime.Today);
-
-        GlanceCalendarMonth calendarMonth = new LocalCalendarPresentationSource()
-            .GetMonthAsync(month, culture).GetAwaiter().GetResult();
-        DateOnly titleDate = month == new DateOnly(today.Year, today.Month, 1) ? today : month.AddDays(14);
-        calendarMonth = new GlanceTraditionalCalendarService().Apply(
-            calendarMonth, GlanceTraditionalCalendarMode.ChineseLunar, culture, titleDate);
-        calendarMonth = new GlanceFestivalService().Apply(
-            calendarMonth, showChineseFestivals: true, GlanceTraditionalCalendarMode.ChineseLunar, culture);
-
-        bool isCompact = GlanceCalendarLayoutCalculator.IsCompact(AvailableHeight);
-        double panelHeight = GlanceCalendarLayoutCalculator.CalculatePanelHeight(AvailableHeight, isCompact, true);
-        double panelWidth = Math.Round(Math.Clamp(AvailableWidth - 28, 272, 360));
-        double dayItemHeight = Math.Round(GlanceCalendarLayoutCalculator.CalculateDayHeight(panelHeight, isCompact, true) * 2) / 2;
-        bool showSecondaryText = GlanceCalendarLayoutCalculator.ShouldShowTraditionalDetails(panelWidth, dayItemHeight, isCompact, true);
-
-        DateTime now = DateTime.Now;
-        var presentation = new RealGlancePresentation
-        {
-            TimeText = now.ToString("HH:mm", culture),
-            DateText = now.ToString("M月d日", culture),
-            WeekdayText = culture.DateTimeFormat.GetDayName(now.DayOfWeek),
-            CompactCalendarDateText = now.ToString("M月d日", culture),
-            TraditionalCalendarTitle = calendarMonth.TraditionalTitle,
-            TimeFontFamily = new FontFamily("XamlAutoFontFamily"),
-            CompactTimeFontSize = Math.Round(Math.Clamp(Math.Min(AvailableWidth * 0.078, AvailableHeight * 0.095), 22, 28) * 2) / 2,
-            CalendarCompactTimeFontSize = Math.Round(Math.Clamp(Math.Min(AvailableWidth * 0.078, AvailableHeight * 0.095), 22, 28) * 2) / 2,
-            CalendarPanelHeight = panelHeight,
-            CalendarPanelWidth = panelWidth,
-            CalendarPanelMaxWidth = 360,
-            CalendarCornerRadius = new CornerRadius(12),
-            CalendarLayoutVisibility = Visibility.Visible,
-            IsCompactVisibility = isCompact ? Visibility.Visible : Visibility.Collapsed,
-            IsExpandedVisibility = isCompact ? Visibility.Collapsed : Visibility.Visible,
-            ShowTimeVisibility = Visibility.Visible,
-            ShowDateVisibility = Visibility.Visible,
-            ShowWeekdayVisibility = Visibility.Visible,
-        };
+        var presentation = RealGlanceModel.CreatePresentation(calendarMonth, isCompact, panelHeight, panelWidth);
 
         FrameworkElement content = (FrameworkElement)XamlReader.Load(
             File.ReadAllText(Path.Combine(root, "glance-real.xaml")));
@@ -121,7 +76,7 @@ internal static class RealGlanceView
             .ToList();
         Dictionary<string, object?> Summary() => new()
         {
-            ["pinnedMonth"] = $"{PinnedYear:0000}-{PinnedMonth:00}",
+            ["pinnedMonth"] = $"{RealGlanceModel.PinnedYear:0000}-{RealGlanceModel.PinnedMonth:00}",
             ["traditionalTitle"] = calendarMonth.TraditionalTitle,
             ["showSecondaryText"] = showSecondaryText,
             ["panelHeight"] = panelHeight,
@@ -181,10 +136,16 @@ internal static class RealGlanceView
     nameof(CompactCalendarDateText),
     nameof(CompactTimeFontSize),
     nameof(DateText),
+    nameof(IsCalendarLayout),
+    nameof(IsCompactCalendarPresentation),
     nameof(IsCompactVisibility),
+    nameof(IsExpandedCalendarPresentation),
     nameof(IsExpandedVisibility),
+    nameof(ShowDate),
     nameof(ShowDateVisibility),
+    nameof(ShowTime),
     nameof(ShowTimeVisibility),
+    nameof(ShowWeekday),
     nameof(ShowWeekdayVisibility),
     nameof(TimeFontFamily),
     nameof(TimeText),
@@ -198,19 +159,25 @@ public sealed partial class RealGlancePresentation
     public string WeekdayText { get; init; } = "";
     public string CompactCalendarDateText { get; init; } = "";
     public string TraditionalCalendarTitle { get; init; } = "";
-    public FontFamily TimeFontFamily { get; init; } = new("XamlAutoFontFamily");
+    public Microsoft.UI.Xaml.Media.FontFamily TimeFontFamily { get; init; } = new("XamlAutoFontFamily");
     public double CompactTimeFontSize { get; init; }
     public double CalendarCompactTimeFontSize { get; init; }
     public double CalendarPanelHeight { get; init; }
     public double CalendarPanelWidth { get; init; }
     public double CalendarPanelMaxWidth { get; init; }
-    public CornerRadius CalendarCornerRadius { get; init; }
+    public Microsoft.UI.Xaml.CornerRadius CalendarCornerRadius { get; init; }
     public Visibility CalendarLayoutVisibility { get; init; }
     public Visibility IsCompactVisibility { get; init; }
     public Visibility IsExpandedVisibility { get; init; }
     public Visibility ShowTimeVisibility { get; init; }
     public Visibility ShowDateVisibility { get; init; }
     public Visibility ShowWeekdayVisibility { get; init; }
+    public bool ShowTime { get; init; }
+    public bool ShowDate { get; init; }
+    public bool ShowWeekday { get; init; }
+    public bool IsCalendarLayout { get; init; }
+    public bool IsCompactCalendarPresentation { get; init; }
+    public bool IsExpandedCalendarPresentation { get; init; }
 }
 
 // Package-local mirror of the production GlanceCalendarDayDecoration contract:

--- a/spikes/glance-native/Package/Strings/en-US/Resources.resw
+++ b/spikes/glance-native/Package/Strings/en-US/Resources.resw
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="GlanceTitle" xml:space="preserve">
+    <value>Official package compiled slice</value>
+  </data>
+</root>

--- a/spikes/glance-native/Package/Strings/zh-CN/Resources.resw
+++ b/spikes/glance-native/Package/Strings/zh-CN/Resources.resw
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="GlanceTitle" xml:space="preserve">
+    <value>官方功能包编译切片</value>
+  </data>
+</root>

--- a/spikes/glance-native/README.md
+++ b/spikes/glance-native/README.md
@@ -26,6 +26,16 @@ v2 的结论不变：宿主 `RuntimeFeature.IsDynamicCodeSupported`=false，输�
 - **多包并存**（multi-package 场景）：同一宿主进程同时加载 v2（简单切片）与 v3（真实切片）两个原生 DLL，两个模块句柄不同、两个视图同时渲染（v2 高度 268 + v3 农历标题），宿主哈希不变。
 - **待办编辑/持久化**（todo-package 场景，`TodoPackage/`）：宿主通过投影设置包内 TextBox 文本、直接构造 `ButtonAutomationPeer` 触发真实点击路径，包代码将条目写入包目录 `todo-items.json`；销毁视图后重建，条目从文件恢复（1→1，内容一致）。数据所有权按"包目录"划分。
 
+### 第三轮：编译 XAML / PRI / WinRT 激活（钉住的负结论）
+
+第三轮（2026-09-08 深夜）用可复现探针回答了三个悬而未决的问题，全部为**当前不可行**，已作为回归断言钉进脚本（`compiled-xaml-pinned-negative` 场景；若未来 Windows App SDK 行为翻转，断言会失败并强制重评契约）：
+
+1. **编译 XAML（XBF）在动态加载的 AOT DLL 中无法定位。** 包项目为 `RealGlanceControl.xaml` 正常走完 XAML 编译（生成 XBF + XamlMetaDataProvider），但运行时 `Application.LoadComponent`（`ComponentResourceLocation.Nested`，`ms-appx:///DeskBox.Glance.NativePackage/...`）抛 XamlParseException。判别实验：**无任何包内自定义类型的最小编译控件同样失败**——问题在 XBF 定位层而非类型解析。把 XBF 按 ms-appx 布局拷到宿主目录子路径也不行（已试）。宿主自己的 XBF 无磁盘文件且 exe 内无明文名，说明解包应用的 XBF 解析内嵌在宿主 exe 的资源体系里，动态 DLL 借不到。**运行时文本 XAML + 预计算可绑定属性（第二轮）仍是已验证路径。** 若未来必须编译 XAML：`Application.ResourceManagerRequested` 提供自定义 `IResourceManager` 是候选逃逸口（未实验）。
+2. **AOT DLL 不导出 `DllGetActivationFactory`。** C#/WinRT 组件激活路径对 NativeAOT 包不可用，原生 C 导出（`UnmanagedCallersOnly`）是唯一 ABI。
+3. **独立 PRI 不随类库发布产生，MrtCore 无文件级加载。** `PRIResource`（resw）进了编译但发布输出没有 `.pri` 文件；MrtCore `ResourceManager` 两个构造路径均抛 COMException（找不到元素）；UWP 遗留 `LoadPriFiles` 因无文件可载而跳过。**包本地化需要自带字符串文件机制（或批次 C 重新决策布局）。**
+
+包体积变化：v1-v3 ≈ 6.18MB/个（编译控件+PRIResource 加入后，此前 4.55MB），todo 包 4.26MB。
+
 两轮所有场景的断言（业务值、实际布局、绑定、退出码、截图、宿主哈希一致）由 `scripts/spike/run-glance-native.ps1` 自动判定；本地证据在 `.artifacts/glance-native/runs/<timestamp>-x64/summary.json`，截图在各 `result-*/view.png`。二进制和运行证据不入库。
 
 ## 复现
@@ -48,10 +58,10 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/spike/run-glance
 
 ## 尚未验证
 
-- 包内**编译 XAML/XBF**、**PRI 资源/本地化**、**自定义 WinRT 类型激活**、**依赖分发**（当前全部为运行时文本 XAML + 内联资源）。
 - 真实**物理键盘/IME 输入**与焦点迁移（当前输入通过投影与 automation peer 模拟）。
 - Glance 完整功能（图片/天气/设置/右键菜单）与其余五功能迁移。
 - ARM64 设备运行（脚本支持 `-Platform ARM64 -BuildOnly` 编译验证，未执行）、冷启动/工作集/多包规模化的系统测量（当前仅记录模块加载+建视图耗时与 DLL 体积）。
 - 叠放/合并/胶囊容器中的内容迁移、1.5.0 升级与 Store 渠道。
+- 编译 XAML 需求若回归：`Application.ResourceManagerRequested` 自定义 `IResourceManager` 逃逸口未实验。
 
 宿主命令行仅接受显式开发包目录，这里没有接入产品安装、签名、授权或实例恢复。官方原生包执行在进程内，必须作为可信代码管理。试点通过允许继续完善正式边界，不表示批次 B 或六功能迁移已经完成。


### PR DESCRIPTION
## Summary

Batch B round 3 of the [official widget packages plan](../blob/codex/official-widget-packages-batch-b3/docs/architecture/official-widget-packages-plan.md): the three open architectural questions — compiled XAML (XBF), PRI resources/localization, and WinRT activation — answered with reproducible probes. All three are **not currently viable** for dynamically loaded NativeAOT package DLLs, and each negative is **pinned as a regression assertion** (`compiled-xaml-pinned-negative` scenario): if a future Windows App SDK flips any of them, the spike fails and forces the contract to be re-evaluated.

**Findings (all evidence in the spike README):**

1. **Compiled XAML cannot be located in a dynamically loaded AOT DLL.** The package compiles `RealGlanceControl.xaml` normally (XBF + XamlMetaDataProvider generated), but runtime `Application.LoadComponent` (`ComponentResourceLocation.Nested`) throws. The discriminating experiment: a type-free minimal compiled control fails identically — the failure is in the XBF **locator** layer, not type resolution. Copying the XBF into the host directory at the ms-appx layout path does not help. The host's own XBF resolves through resources embedded inside the host exe, which a dynamic DLL cannot borrow. **Runtime text XAML + pre-computed bindable properties (round 2) is confirmed as the rendering path.** `Application.ResourceManagerRequested` with a custom `IResourceManager` is recorded as the future escape hatch (untested).
2. **AOT DLLs export no `DllGetActivationFactory`** — the C#/WinRT component activation path is unavailable; raw C exports (`UnmanagedCallersOnly`) are the only ABI.
3. **No standalone .pri is produced for the class-library layout** (`PRIResource` compiles but nothing lands in publish output), and MrtCore has no file-based PRI loading (both `ResourceManager` constructor paths throw "element not found"). Package localization needs its own string-file mechanism unless batch C decides otherwise.

Also includes the shared `RealGlanceModel` extraction (month pipeline reused by both slice variants) and a two-scenario fast iteration script (`fast-glance-real.ps1`).

## Verification

- Spike script: all seven scenarios pass (x64, exit 0) — v1/v2 simple, real-glance, **compiled-xaml-pinned-negative**, lifecycle, multi-package, todo-edit-persist. Run evidence: `.artifacts/glance-native/runs/20260908-210752-*/summary.json`.
- Package sizes now ≈ 6.18 MB each (compiled control + PRIResource added), todo package 4.26 MB.
- Main suite unaffected: **3541/3541**. No `src/` or `tests/` changes — spikes, docs and scripts only.
