### PR TITLE
feat: batch B round 4 - full glance slice with images, menu, settings, persistence

### DIFF
--- a/docs/architecture/official-widget-packages-plan.md
+++ b/docs/architecture/official-widget-packages-plan.md
@@ -44,7 +44,7 @@ NativeAOT DLL 不支持 FreeLibrary 卸载，首发按重启应用新版本设�
 - 内容哈希路径和 ReadOnly 属性只防误写，不构成对同一 OS 用户的权限隔离。执行前重新验证实际包；未来原生激活必须把验证与打开模块的生命周期绑定。
 - 注册表存在但损坏时拒绝新安装覆盖，不当作首次安装。授权同时绑定包和发布者，旧的无发布者授权格式不能自动继承。
 - Store 安装额外验证宿主配置的可信发布者；仓库公开开发密钥只用于显式测试/Development。正式发布密钥、撤销和轮换记录必须在上线前配置，不把有效自签名当作官方身份。
-- 包元数据约束版本、哈希、架构和宿主兼容范围。下载托管可使用 GitHub，可信更新索引与密钥治理独立建设，可参考 [TUF](https://theupdateframework.github.io/specification/latest/)。
+- 包元数据约束版本、哈希、架构和宿主兼容范围。**Windows App SDK 版本对齐**：包引用的 WinAppSDK 不得超过宿主（跨大版本无 ABI 保证），宿主兼容范围必须涵盖 WinAppSDK 版本并实测"旧宿主拒载新包"。下载托管可使用 GitHub，可信更新索引与密钥治理独立建设，可参考 [TUF](https://theupdateframework.github.io/specification/latest/)。
 - 包二进制、用户数据、实例设置、授权和缓存的存储/备份边界分别定义。卸载清理所有包版本，文件被占用时如实报告未完成，不删除用户业务数据。
 - 二进制回退必须配套兼容数据或一致快照，不能只切换目录后承诺恢复。
 
@@ -56,6 +56,15 @@ NativeAOT DLL 不支持 FreeLibrary 卸载，首发按重启应用新版本设�
 
 Store 路径在批次 B 前期就核对，不能等发布前才验证。动态代码、依赖披露及实际提交类型需对应 [当前 Store 政策](https://learn.microsoft.com/en-us/windows/apps/publish/store-policies#102-security)。MSIX optional code package 的 related set/许可要求及旧 UWP 示例不能直接推导当前 NativeAOT 方案可行。
 
+### Store 政策核对结论（2026-09-08，政策版本 7.19 原文）
+
+- **10.1.5**：产品在初始下载后获取"发布者自己的其他产品"，前提是那些产品**也经 Microsoft Store 分发且获取经 Store 完成**。→ **Store 版宿主的应用内功能包下载不得从 GitHub 等外部源拉取原生 DLL**。
+- **10.2.2**：动态包含代码不是一刀切禁止，禁止的是"以与描述不一致的方式执行"。→ Store listing 必须明确描述功能包/插件能力；功能包内容不得超出描述范围。
+- **10.2.9**：直链安装器不能是 downloader stub（对我们的 Inno 安装器无影响，它是完整独立安装器）。
+- **10.2.7**：干净卸载——现有三清卸载（文件+注册表+授权）符合。
+
+**渠道决策**：Direct/GitHub 渠道（现行安装器+release）不受上述约束，功能包按 B1 管线从 GitHub 索引下载；**Store 渠道的功能包交付=捆绑进主包或 Store add-ons，不做 Store 版外部下载**。因此批次 C 的原生包格式必须同时支撑两种交付形态（同一包内容，两种分发通道），批次 E 按渠道分别验收。
+
 ## 执行记录
 
 - 2026-09-08：用户授权按复评建议开始实施，工作区干净；创建本地分支 `codex/official-widget-packages`，从 `527f63d8` 开始。
@@ -65,4 +74,5 @@ Store 路径在批次 B 前期就核对，不能等发布前才验证。动态�
 - 批次 B：第一项 x64 ABI/UI 探针通过。相同 AOT 宿主哈希，替换独立 DLL 后，实际 CalendarView 高度和业务结果均由 244 变为 268，标题绑定同步更新；详见 [可复现实验及边界](../../spikes/glance-native/README.md)。完整 Glance、待办切片、资源/生命周期/渠道仍待完成，B 尚未验收。
 - 批次 B 第二轮（2026-09-08 晚）：真实 Glance 切片（生产 XAML 移植 + 生产服务源码链接：本地月源/传统历法/节日/布局/装饰记录；固定 2026-09 实测 42/42 农历文本、中秋节日、真实传统历法标题）；同一进程销毁重建；双 DLL 单进程并存渲染；待办编辑/持久化切片（automation peer 真实点击路径 + 包目录 JSON 持久化 + 重建恢复）。六场景断言全绿，证据与批次 C 契约发现（包 XAML 无转换器、ThemeResource 需资源自含、元数据聚合待设计）见 [试点 README](../../spikes/glance-native/README.md)。尚未验收项：编译 XBF/PRI/本地化/自定义 WinRT 激活、物理输入/IME、完整 Glance 与其余五功能、ARM64 运行、系统化测量、叠放合并容器、渠道。
 - 批次 B 第三轮（2026-09-08 深夜）：编译 XAML/PRI/WinRT 激活三问全部实测为**当前不可行**，已钉进回归断言（XBF 在动态 AOT DLL 中无法定位——无类型最简控件同样失败，问题在定位层；AOT DLL 不导出 DllGetActivationFactory——C 导出是唯一 ABI；类库发布不产独立 PRI 且 MrtCore 无文件级加载——包本地化需自带字符串机制）。**运行时文本 XAML + 预计算可绑定属性确认为正式渲染路径**；`Application.ResourceManagerRequested` 记为未来逃逸口（未实验）。七场景全绿。
+- 批次 B 第四轮（2026-09-08 深夜）：完整 Glance 代表切片全绿（八场景）——背景轮播+操作栏真实点击+右键菜单+设置面板（程序化 Toggled 驱动月份数据实时重建）+设置持久化+销毁重建恢复；Store 政策结论（10.1.5/10.2.2 原文）与 WinAppSDK 版本对齐要求写入本计划。在线图片源归批次 D。
 - 批次 C–E：尚未实施。六功能仍保留在现有应用中；正式包格式、商店界面和升级迁移未在本批次提前切换。

--- a/scripts/spike/run-glance-native.ps1
+++ b/scripts/spike/run-glance-native.ps1
@@ -126,6 +126,39 @@ try {
         }
         $results += [pscustomobject]@{ scenario = "compiled-xaml-pinned-negative"; result = $result; evidence = $evidence }
 
+        # Full Glance slice: rotation timer, action-bar click, settings toggle,
+        # destroy/recreate persistence. Backgrounds are generated (no binaries in
+        # the repository); settings file cleared for a deterministic first run.
+        $backgrounds = Join-Path $packageOutputs[3] "backgrounds"
+        New-Item -ItemType Directory -Path $backgrounds -Force | Out-Null
+        Add-Type -AssemblyName System.Drawing
+        foreach ($pair in @(@("bg-1.png", "40, 70, 130"), @("bg-2.png", "130, 55, 45"))) {
+            $bitmap = New-Object System.Drawing.Bitmap(440, 560)
+            $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+            $channels = $pair[1].Split(",") | ForEach-Object { [int]$_.Trim() }
+            $graphics.Clear([System.Drawing.Color]::FromArgb($channels[0], $channels[1], $channels[2]))
+            $graphics.Dispose()
+            $bitmap.Save((Join-Path $backgrounds $pair[0]), [System.Drawing.Imaging.ImageFormat]::Png)
+            $bitmap.Dispose()
+        }
+        Remove-Item -LiteralPath (Join-Path $packageOutputs[3] "glance-settings.json") -ErrorAction SilentlyContinue
+        $evidence = Join-Path $runRoot "result-full"
+        $result = Invoke-Probe -Exe $hostExe -WorkingDirectory $hostOutput -Evidence $evidence -Arguments @(
+            "--full-package", ('"{0}"' -f $packageOutputs[3]), ('"{0}"' -f $evidence))
+        if ($result.dynamicCodeSupported -or
+            $result.rotationIndexAfterTimer -lt 1 -or
+            $result.indexAfterNextClick -eq $result.rotationIndexAfterTimer -or
+            $result.afterFestivalOff.showFestivals -or
+            $result.afterFestivalOff.festivalDayCount -ne 0 -or
+            $result.afterRecreate.showFestivals -or
+            $result.afterRecreate.festivalDayCount -ne 0 -or
+            $result.afterRecreate.currentImageIndex -ne 0 -or
+            $result.afterRecreate.traditionalTextDayCount -ne 42) {
+            throw "Full-Glance slice assertion failed: $evidence"
+        }
+        if (-not (Test-Path -LiteralPath (Join-Path $evidence "view.png"))) { throw "Missing rendered view: $evidence" }
+        $results += [pscustomobject]@{ scenario = "full-glance"; result = $result; evidence = $evidence }
+
         # Lifecycle: destroy and recreate the view within one process.
         $evidence = Join-Path $runRoot "result-lifecycle"
         $result = Invoke-Probe -Exe $hostExe -WorkingDirectory $hostOutput -Evidence $evidence -Arguments @(

--- a/spikes/glance-native/Host/Program.cs
+++ b/spikes/glance-native/Host/Program.cs
@@ -17,6 +17,7 @@ internal enum Scenario
     Simple,
     RealGlance,
     CompiledGlance,
+    FullGlance,
     Lifecycle,
     MultiPackage,
     TodoEdit,
@@ -40,6 +41,9 @@ internal static class Program
                 break;
             case ["--compiled-package", string package, string outDir]:
                 (scenario, packages, output) = (Scenario.CompiledGlance, [package], outDir);
+                break;
+            case ["--full-package", string package, string outDir]:
+                (scenario, packages, output) = (Scenario.FullGlance, [package], outDir);
                 break;
             case ["--lifecycle-package", string package, string outDir]:
                 (scenario, packages, output) = (Scenario.Lifecycle, [package], outDir);
@@ -148,6 +152,7 @@ public sealed partial class ProbeApplication : Application
             case Scenario.Simple: RunSimple(); break;
             case Scenario.RealGlance: RunReal(); break;
             case Scenario.CompiledGlance: RunCompiled(); break;
+            case Scenario.FullGlance: RunFull(); break;
             case Scenario.Lifecycle: RunLifecycle(); break;
             case Scenario.MultiPackage: RunMulti(); break;
             case Scenario.TodoEdit: RunTodo(); break;
@@ -311,6 +316,104 @@ public sealed partial class ProbeApplication : Application
         }
         catch (Exception error) { File.WriteAllText(Path.Combine(_output, "error.txt"), error.ToString()); }
         finally { _window?.Close(); Exit(); }
+    }
+
+    private unsafe void RunFull()
+    {
+        nint module = LoadModule(_packages[0], "DeskBox.Glance.NativePackage.dll", _output);
+        FrameworkElement content = CreateView(module, "glance_probe_create_full_view", _packages[0], _output);
+        content.Width = 440;
+        content.Height = 560;
+        _window = new Window { Title = "Glance full slice probe", Content = content };
+        _window.AppWindow.Resize(new Windows.Graphics.SizeInt32(460, 610));
+        content.Loaded += (sender, args) => _ = FinishFull(module, content);
+        _window.Activate();
+    }
+
+    private async Task FinishFull(nint module, FrameworkElement first)
+    {
+        try
+        {
+            // Stage 1: the package's own rotation timer advances the background.
+            await Task.Delay(4000);
+            JsonDocument stage1 = await ReadSummary("full-summary.json");
+            int rotationIndex = stage1.RootElement.GetProperty("currentImageIndex").GetInt32();
+            int revision1 = stage1.RootElement.GetProperty("revision").GetInt32();
+
+            // Stage 2: a real click on the action bar's next button; wait for the
+            // package's summary revision to advance so the read is not stale.
+            var nextButton = first.FindName("NextButton").As<Button>();
+            new Microsoft.UI.Xaml.Automation.Peers.ButtonAutomationPeer(nextButton).Invoke();
+            JsonDocument stage2 = await ReadSummaryAfterRevision(revision1);
+            int clickedIndex = stage2.RootElement.GetProperty("currentImageIndex").GetInt32();
+
+            // Stage 3: programmatic toggle drives the package's Toggled handler.
+            int revision2 = stage2.RootElement.GetProperty("revision").GetInt32();
+            var festivalToggle = first.FindName("FestivalToggle").As<ToggleSwitch>();
+            festivalToggle.IsOn = false;
+            JsonDocument stage3 = await ReadSummaryAfterRevision(revision2);
+
+            // Stage 4: destroy and recreate; settings must persist.
+            var firstUnloaded = new TaskCompletionSource();
+            first.Unloaded += (_, _) => firstUnloaded.TrySetResult();
+            _window!.Content = null;
+            await firstUnloaded.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            FrameworkElement second = CreateView(module, "glance_probe_create_full_view", _packages[0], _output);
+            second.Width = 440;
+            second.Height = 560;
+            _window.Content = second;
+            await WhenLoadedAsync(second);
+            await Task.Delay(600);
+            JsonDocument stage4 = await ReadSummary("full-summary.json");
+            await CaptureAsync(second, "view.png");
+
+            WriteResult(result =>
+            {
+                result.WriteBoolean("dynamicCodeSupported", RuntimeFeature.IsDynamicCodeSupported);
+                result.WriteNumber("rotationIndexAfterTimer", rotationIndex);
+                result.WriteNumber("indexAfterNextClick", clickedIndex);
+                result.WritePropertyName("afterFestivalOff");
+                stage3.RootElement.WriteTo(result);
+                result.WritePropertyName("afterRecreate");
+                stage4.RootElement.WriteTo(result);
+            });
+        }
+        catch (Exception error) { File.WriteAllText(Path.Combine(_output, "error.txt"), error.ToString()); }
+        finally { _window?.Close(); Exit(); }
+    }
+
+    private async Task<JsonDocument> ReadSummaryAfterRevision(int previousRevision)
+    {
+        for (int attempt = 0; attempt < 40; attempt++)
+        {
+            JsonDocument document = await ReadSummary("full-summary.json");
+            if (document.RootElement.TryGetProperty("revision", out JsonElement revision) &&
+                revision.GetInt32() > previousRevision)
+            {
+                return document;
+            }
+            await Task.Delay(100);
+        }
+        throw new InvalidOperationException("summary revision did not advance");
+    }
+
+    private async Task<JsonDocument> ReadSummary(string fileName)
+    {
+        for (int attempt = 0; attempt < 20; attempt++)
+        {
+            try
+            {
+                string path = Path.Combine(_packages[0], fileName);
+                if (File.Exists(path))
+                {
+                    using FileStream stream = File.OpenRead(path);
+                    return await JsonDocument.ParseAsync(stream);
+                }
+            }
+            catch (IOException) { }
+            await Task.Delay(100);
+        }
+        throw new InvalidOperationException($"summary not available: {fileName}");
     }
 
     private unsafe void RunLifecycle()

--- a/spikes/glance-native/Package/Exports.cs
+++ b/spikes/glance-native/Package/Exports.cs
@@ -88,9 +88,28 @@ public static unsafe class Exports
             return error.HResult;
         }
     }
+
+    [UnmanagedCallersOnly(EntryPoint = "glance_probe_create_full_view", CallConvs = [typeof(CallConvCdecl)])]
+    public static int CreateFullView(char* directory, int length, nint* view)
+    {
+        if (directory is null || length is <= 0 or > 32767 || view is null) return -1;
+        *view = 0;
+        string root = new(directory, 0, length);
+        try
+        {
+            FrameworkElement content = FullGlanceView.Create(root);
+            *view = WinRT.MarshalInspectable<FrameworkElement>.FromManaged(content);
+            return 0;
+        }
+        catch (Exception error)
+        {
+            File.WriteAllText(Path.Combine(root, "activation-error.txt"), error.ToString());
+            return error.HResult;
+        }
+    }
 }
 
-[WinRT.GeneratedBindableCustomProperty]
+    [WinRT.GeneratedBindableCustomProperty]
 public sealed partial class GlancePresentation
 {
     public string Title { get; init; } = "";

--- a/spikes/glance-native/Package/FullGlanceView.cs
+++ b/spikes/glance-native/Package/FullGlanceView.cs
@@ -1,0 +1,235 @@
+using System.Text.Json;
+using DeskBox.Models;
+using DeskBox.Services;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Imaging;
+using Microsoft.UI.Xaml.Markup;
+using WinRT;
+
+namespace DeskBox.Glance.NativePackage;
+
+/// <summary>
+/// Full Glance slice: background image rotation, calendar (production services),
+/// action bar with real click handling, right-click menu and a settings flyout
+/// persisted to the package directory. Online image sources are out of scope
+/// (batch D migrates the production image service); this slice loads images
+/// from &lt;package&gt;\backgrounds\*.
+/// </summary>
+internal static class FullGlanceView
+{
+    private sealed class FullState
+    {
+        public int ImageIndex;
+        public bool Paused;
+        public bool ShowFestivals = true;
+        public bool ShowTraditional = true;
+        public int Decorated;
+        public int Revision;
+    }
+
+    public static FrameworkElement Create(string root)
+    {
+        var state = LoadState(root);
+        FrameworkElement content = (FrameworkElement)XamlReader.Load(
+            File.ReadAllText(Path.Combine(root, "full-glance.xaml")));
+
+        (GlanceCalendarMonth month, bool isCompact, double panelHeight, double panelWidth, double dayItemHeight, _) =
+            RealGlanceModel.Build(state.ShowTraditional, state.ShowFestivals);
+        var presentation = RealGlanceModel.CreatePresentation(month, isCompact, panelHeight, panelWidth);
+        presentation.PlayIconVisibility = state.Paused ? Visibility.Visible : Visibility.Collapsed;
+        presentation.PauseIconVisibility = state.Paused ? Visibility.Collapsed : Visibility.Visible;
+        content.DataContext = presentation;
+
+        var calendarView = content.FindName("NativeCalendarView").As<CalendarView>();
+        WireDayDecoration(calendarView, month, dayItemHeight, state.ShowTraditional, state.ShowFestivals, state);
+
+        // Image pipeline: package-local folder, A/B cross-fade borders.
+        string[] images = Directory.Exists(Path.Combine(root, "backgrounds"))
+            ? Directory.GetFiles(Path.Combine(root, "backgrounds"), "*.png")
+                .Concat(Directory.GetFiles(Path.Combine(root, "backgrounds"), "*.jpg"))
+                .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+                .ToArray()
+            : [];
+        var backgroundA = content.FindName("BackgroundA").As<Border>();
+        var backgroundB = content.FindName("BackgroundB").As<Border>();
+        bool showingA = true;
+        void Show(int index)
+        {
+            if (images.Length == 0) return;
+            state.ImageIndex = ((index % images.Length) + images.Length) % images.Length;
+            var brush = new ImageBrush { ImageSource = new BitmapImage(new Uri(images[state.ImageIndex])), Stretch = Stretch.UniformToFill };
+            Border next = showingA ? backgroundB : backgroundA;
+            Border fadeOut = showingA ? backgroundA : backgroundB;
+            next.Background = brush;
+            next.Opacity = 1;
+            fadeOut.Opacity = 0;
+            showingA = !showingA;
+            WriteSummary(root, images, state, month);
+        }
+        Show(state.ImageIndex);
+
+        var timer = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread().CreateTimer();
+        timer.Interval = TimeSpan.FromSeconds(3);
+        timer.Tick += (_, _) =>
+        {
+            if (!state.Paused) Show(state.ImageIndex + 1);
+        };
+        if (!state.Paused && images.Length > 1) timer.Start();
+        content.Unloaded += (_, _) => timer.Stop();
+
+        var pauseButton = content.FindName("PauseButton").As<Button>();
+        void TogglePause()
+        {
+            state.Paused = !state.Paused;
+            if (state.Paused) timer.Stop();
+            else if (images.Length > 1) timer.Start();
+            presentation.PlayIconVisibility = state.Paused ? Visibility.Visible : Visibility.Collapsed;
+            presentation.PauseIconVisibility = state.Paused ? Visibility.Collapsed : Visibility.Visible;
+            WriteSummary(root, images, state, month);
+        }
+        pauseButton.Click += (_, _) => TogglePause();
+        var nextButton = content.FindName("NextButton").As<Button>();
+        nextButton.Click += (_, _) => Show(state.ImageIndex + 1);
+
+        // Settings panel lives in the XAML namescope (host-side probes can drive
+        // the same Toggled handlers); the menu item reveals it.
+        var settingsLayer = content.FindName("SettingsLayer").As<FrameworkElement>();
+        var festivalToggle = content.FindName("FestivalToggle").As<ToggleSwitch>();
+        var traditionalToggle = content.FindName("TraditionalToggle").As<ToggleSwitch>();
+        festivalToggle.IsOn = state.ShowFestivals;
+        traditionalToggle.IsOn = state.ShowTraditional;
+        festivalToggle.Toggled += (_, _) =>
+        {
+            state.ShowFestivals = festivalToggle.IsOn;
+            Rebuild(root, state, calendarView, dayItemHeight);
+            SaveState(root, state);
+        };
+        traditionalToggle.Toggled += (_, _) =>
+        {
+            state.ShowTraditional = traditionalToggle.IsOn;
+            Rebuild(root, state, calendarView, dayItemHeight);
+            SaveState(root, state);
+        };
+
+        // Right-click menu (code-built: runtime XAML cannot wire handlers).
+        var menu = new MenuFlyout();
+        var nextItem = new MenuFlyoutItem { Text = "下一张背景" };
+        nextItem.Click += (_, _) => Show(state.ImageIndex + 1);
+        var pauseItem = new MenuFlyoutItem { Text = "暂停轮播" };
+        pauseItem.Click += (_, _) => TogglePause();
+        var settingsItem = new MenuFlyoutItem { Text = "设置" };
+        settingsItem.Click += (_, _) =>
+        {
+            settingsLayer.Visibility = settingsLayer.Visibility == Visibility.Visible
+                ? Visibility.Collapsed
+                : Visibility.Visible;
+        };
+        var aboutItem = new MenuFlyoutItem { Text = "DeskBox.Glance.NativePackage 完整切片" };
+        menu.Items.Add(nextItem);
+        menu.Items.Add(pauseItem);
+        menu.Items.Add(settingsItem);
+        menu.Items.Add(aboutItem);
+        content.ContextFlyout = menu;
+
+        content.Loaded += (_, _) => WriteSummary(root, images, state, month);
+        return content;
+    }
+
+    private static void Rebuild(string root, FullState state, CalendarView calendarView, double dayItemHeight)
+    {
+        (GlanceCalendarMonth rebuilt, _, _, _, _, _) = RealGlanceModel.Build(state.ShowTraditional, state.ShowFestivals);
+        WireDayDecoration(calendarView, rebuilt, dayItemHeight, state.ShowTraditional, state.ShowFestivals, state);
+        WriteSummary(root, [], state, rebuilt);
+    }
+
+    private static void WireDayDecoration(
+        CalendarView calendarView,
+        GlanceCalendarMonth month,
+        double dayItemHeight,
+        bool showTraditional,
+        bool showFestivals,
+        FullState state)
+    {
+        System.Globalization.CultureInfo culture = RealGlanceModel.Culture;
+        DateOnly pinned = new(RealGlanceModel.PinnedYear, RealGlanceModel.PinnedMonth, 1);
+        DateOnly today = DateOnly.FromDateTime(DateTime.Today);
+        Dictionary<DateOnly, GlanceCalendarDay> days = month.Days.ToDictionary(day => day.Date);
+        int decorated = 0;
+        calendarView.CalendarViewDayItemChanging += (_, args) =>
+        {
+            CalendarViewDayItem item = args.Item;
+            if (args.InRecycleQueue) { item.Tag = null; return; }
+            DateOnly date = DateOnly.FromDateTime(item.Date.DateTime);
+            days.TryGetValue(date, out GlanceCalendarDay? day);
+            string secondaryText = !showTraditional ? string.Empty
+                : showFestivals && !string.IsNullOrWhiteSpace(day?.FestivalText) ? day.FestivalText
+                : day?.TraditionalText ?? string.Empty;
+            bool hasSecondaryText = !string.IsNullOrWhiteSpace(secondaryText);
+            bool isFestival = hasSecondaryText && day?.HasFestival == true;
+            bool isCurrentMonth = day?.IsCurrentMonth ?? date.Month == pinned.Month;
+            item.MinHeight = dayItemHeight;
+            item.Height = dayItemHeight;
+            item.Tag = new RealGlanceDayDecoration(
+                day?.DayText ?? date.Day.ToString(culture),
+                secondaryText,
+                hasSecondaryText ? Visibility.Visible : Visibility.Collapsed,
+                date == today ? Visibility.Visible : Visibility.Collapsed,
+                date == today ? Visibility.Collapsed : Visibility.Visible,
+                isFestival ? Microsoft.UI.Text.FontWeights.SemiBold : Microsoft.UI.Text.FontWeights.Normal,
+                isCurrentMonth ? 1.0 : 0.42,
+                !isCurrentMonth ? 0.34 : isFestival ? 0.88 : 0.62);
+            if (hasSecondaryText) decorated++;
+        };
+        state.Decorated = decorated;
+    }
+
+    private static FullState LoadState(string root)
+    {
+        var state = new FullState();
+        string path = Path.Combine(root, "glance-settings.json");
+        if (!File.Exists(path)) return state;
+        using JsonDocument document = JsonDocument.Parse(File.ReadAllText(path));
+        if (document.RootElement.TryGetProperty("showFestivals", out JsonElement festivals))
+            state.ShowFestivals = festivals.GetBoolean();
+        if (document.RootElement.TryGetProperty("showTraditional", out JsonElement traditional))
+            state.ShowTraditional = traditional.GetBoolean();
+        if (document.RootElement.TryGetProperty("paused", out JsonElement paused))
+            state.Paused = paused.GetBoolean();
+        return state;
+    }
+
+    private static void SaveState(string root, FullState state)
+    {
+        using var stream = File.Create(Path.Combine(root, "glance-settings.json"));
+        using var writer = new Utf8JsonWriter(stream);
+        writer.WriteStartObject();
+        writer.WriteBoolean("showFestivals", state.ShowFestivals);
+        writer.WriteBoolean("showTraditional", state.ShowTraditional);
+        writer.WriteBoolean("paused", state.Paused);
+        writer.WriteEndObject();
+    }
+
+    private static void WriteSummary(string root, string[] images, FullState state, GlanceCalendarMonth month)
+    {
+        state.Revision++;
+        File.AppendAllText(Path.Combine(root, "full-writes.log"),
+            $"r{state.Revision} idx={state.ImageIndex} imgs={images.Length} fest={state.ShowFestivals} trad={state.ShowTraditional} paused={state.Paused} t={DateTime.Now:HH:mm:ss.fff}\n");
+        using var stream = File.Create(Path.Combine(root, "full-summary.json"));
+        using var writer = new Utf8JsonWriter(stream);
+        writer.WriteStartObject();
+        writer.WriteNumber("revision", state.Revision);
+        writer.WriteString("variant", "full-glance");
+        writer.WriteNumber("imageCount", images.Length);
+        writer.WriteNumber("currentImageIndex", state.ImageIndex);
+        writer.WriteBoolean("paused", state.Paused);
+        writer.WriteBoolean("showFestivals", state.ShowFestivals);
+        writer.WriteBoolean("showTraditional", state.ShowTraditional);
+        writer.WriteNumber("festivalDayCount", month.Days.Count(day => day.HasFestival));
+        writer.WriteNumber("traditionalTextDayCount", month.Days.Count(day => !string.IsNullOrWhiteSpace(day.TraditionalText)));
+        writer.WriteString("traditionalTitle", month.TraditionalTitle);
+        writer.WriteEndObject();
+    }
+}

--- a/spikes/glance-native/Package/Glance.NativePackage.csproj
+++ b/spikes/glance-native/Package/Glance.NativePackage.csproj
@@ -38,6 +38,8 @@
     <None Update="calendar.xaml" CopyToOutputDirectory="PreserveNewest" />
     <Page Remove="glance-real.xaml" />
     <None Update="glance-real.xaml" CopyToOutputDirectory="PreserveNewest" />
+    <Page Remove="full-glance.xaml" />
+    <None Update="full-glance.xaml" CopyToOutputDirectory="PreserveNewest" />
     <!-- RealGlanceControl.xaml stays a compiled Page (XBF + XamlMetaDataProvider). -->
     <PRIResource Include="Strings\zh-CN\Resources.resw" />
     <PRIResource Include="Strings\en-US\Resources.resw" />

--- a/spikes/glance-native/Package/RealGlanceModel.cs
+++ b/spikes/glance-native/Package/RealGlanceModel.cs
@@ -24,7 +24,11 @@ internal static class RealGlanceModel
 
     public static CultureInfo Culture { get; } = CultureInfo.GetCultureInfo("zh-CN");
 
-    public static (GlanceCalendarMonth Month, bool IsCompact, double PanelHeight, double PanelWidth, double DayItemHeight, bool ShowSecondaryText) Build()
+    public static (GlanceCalendarMonth Month, bool IsCompact, double PanelHeight, double PanelWidth, double DayItemHeight, bool ShowSecondaryText) Build() =>
+        Build(showTraditional: true, showFestivals: true);
+
+    public static (GlanceCalendarMonth Month, bool IsCompact, double PanelHeight, double PanelWidth, double DayItemHeight, bool ShowSecondaryText) Build(
+        bool showTraditional, bool showFestivals)
     {
         DateOnly month = new(PinnedYear, PinnedMonth, 1);
         DateOnly today = DateOnly.FromDateTime(DateTime.Today);
@@ -32,10 +36,13 @@ internal static class RealGlanceModel
         GlanceCalendarMonth calendarMonth = new LocalCalendarPresentationSource()
             .GetMonthAsync(month, Culture).GetAwaiter().GetResult();
         DateOnly titleDate = month == new DateOnly(today.Year, today.Month, 1) ? today : month.AddDays(14);
+        GlanceTraditionalCalendarMode mode = showTraditional
+            ? GlanceTraditionalCalendarMode.ChineseLunar
+            : GlanceTraditionalCalendarMode.None;
         calendarMonth = new GlanceTraditionalCalendarService().Apply(
-            calendarMonth, GlanceTraditionalCalendarMode.ChineseLunar, Culture, titleDate);
+            calendarMonth, mode, Culture, titleDate);
         calendarMonth = new GlanceFestivalService().Apply(
-            calendarMonth, showChineseFestivals: true, GlanceTraditionalCalendarMode.ChineseLunar, Culture);
+            calendarMonth, showChineseFestivals: showFestivals && showTraditional, mode, Culture);
 
         bool isCompact = GlanceCalendarLayoutCalculator.IsCompact(AvailableHeight);
         double panelHeight = GlanceCalendarLayoutCalculator.CalculatePanelHeight(AvailableHeight, isCompact, true);

--- a/spikes/glance-native/Package/RealGlanceView.cs
+++ b/spikes/glance-native/Package/RealGlanceView.cs
@@ -150,7 +150,9 @@ internal static class RealGlanceView
     nameof(TimeFontFamily),
     nameof(TimeText),
     nameof(TraditionalCalendarTitle),
-    nameof(WeekdayText)
+    nameof(WeekdayText),
+    nameof(PlayIconVisibility),
+    nameof(PauseIconVisibility)
 ], [])]
 public sealed partial class RealGlancePresentation
 {
@@ -178,6 +180,8 @@ public sealed partial class RealGlancePresentation
     public bool IsCalendarLayout { get; init; }
     public bool IsCompactCalendarPresentation { get; init; }
     public bool IsExpandedCalendarPresentation { get; init; }
+    public Visibility PlayIconVisibility { get; set; }
+    public Visibility PauseIconVisibility { get; set; }
 }
 
 // Package-local mirror of the production GlanceCalendarDayDecoration contract:

--- a/spikes/glance-native/Package/full-glance.xaml
+++ b/spikes/glance-native/Package/full-glance.xaml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Batch B round 4: FULL Glance slice. Ports from production XAML: image
+     background layers, readability layer, calendar layout (as in glance-real),
+     and the photo action bar (pause/next). Adds a right-click MenuFlyout and a
+     settings flyout with persistence. Self-contained resources per the round-2
+     contract findings (no converters, no control-theme ThemeResource keys). -->
+<Grid
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    x:Name="RootGrid"
+    Background="#FF141414">
+
+    <Grid.Resources>
+        <ResourceDictionary>
+            <SolidColorBrush x:Key="TextFillColorPrimaryBrush" Color="#FFFFFFFF" />
+            <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="#C5FFFFFF" />
+            <SolidColorBrush x:Key="TextFillColorDisabledBrush" Color="#5DFFFFFF" />
+            <SolidColorBrush x:Key="TextOnAccentFillColorPrimaryBrush" Color="#FFFFFFFF" />
+            <SolidColorBrush x:Key="SubtleFillColorSecondaryBrush" Color="#0FFFFFFF" />
+            <SolidColorBrush x:Key="SubtleFillColorTertiaryBrush" Color="#0AFFFFFF" />
+            <SolidColorBrush x:Key="AccentFillColorDefaultBrush" Color="{ThemeResource SystemAccentColor}" />
+            <Color x:Key="SolidBackgroundFillColorBase">#202020</Color>
+            <AcrylicBrush
+                x:Key="GlanceCalendarAcrylicBrush"
+                FallbackColor="{ThemeResource SolidBackgroundFillColorBase}"
+                TintColor="{ThemeResource SolidBackgroundFillColorBase}" />
+        </ResourceDictionary>
+    </Grid.Resources>
+
+    <Grid x:Name="BackgroundImageLayer" IsHitTestVisible="False">
+        <Border x:Name="BackgroundA" Opacity="0" />
+        <Border x:Name="BackgroundB" Opacity="0" />
+    </Grid>
+
+    <Border
+        x:Name="ReadabilityLayer"
+        Background="Black"
+        IsHitTestVisible="False"
+        Opacity="0.42" />
+
+    <Grid x:Name="CalendarLayoutRoot" Padding="20,22,20,18">
+        <Border
+            x:Name="CalendarGlassSurface"
+            Height="{Binding CalendarPanelHeight}"
+            HorizontalAlignment="Center"
+            Margin="-6,0,-6,0"
+            MaxWidth="{Binding CalendarPanelMaxWidth}"
+            VerticalAlignment="Bottom"
+            Width="{Binding CalendarPanelWidth}"
+            CornerRadius="{Binding CalendarCornerRadius}">
+            <Grid>
+                <Border
+                    x:Name="CalendarMaterialSurface"
+                    Background="{StaticResource GlanceCalendarAcrylicBrush}"
+                    CornerRadius="{Binding CalendarCornerRadius}"
+                    IsHitTestVisible="False" />
+                <Grid Margin="8,0,8,4">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <Grid Grid.Row="0" Height="27" Margin="13,7,6,0" Visibility="Collapsed">
+                        <TextBlock x:Name="CompactTimeText" Margin="0,5,0,-5" HorizontalAlignment="Left" FontSize="22" FontWeight="SemiBold" Foreground="{StaticResource TextFillColorPrimaryBrush}" LineHeight="26" LineStackingStrategy="BlockLineHeight" Text="{Binding TimeText}" Typography.NumeralAlignment="Tabular" />
+                    </Grid>
+                    <Grid Grid.Row="1">
+                        <CalendarView
+                            x:Name="NativeCalendarView"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch"
+                            Background="Transparent"
+                            BorderBrush="Transparent"
+                            BorderThickness="0"
+                            CalendarItemBackground="Transparent"
+                            CalendarItemBorderBrush="Transparent"
+                            CalendarItemBorderThickness="0"
+                            CalendarItemCornerRadius="6"
+                            CalendarItemForeground="{StaticResource TextFillColorPrimaryBrush}"
+                            CalendarItemHoverBackground="{StaticResource SubtleFillColorSecondaryBrush}"
+                            CalendarItemPressedBackground="{StaticResource SubtleFillColorTertiaryBrush}"
+                            DayItemFontSize="0.1"
+                            DayItemMargin="0"
+                            DayOfWeekFormat="{}{dayofweek.abbreviated(1)}"
+                            Foreground="{StaticResource TextFillColorPrimaryBrush}"
+                            HorizontalDayItemAlignment="Center"
+                            IsGroupLabelVisible="False"
+                            IsOutOfScopeEnabled="True"
+                            IsTodayHighlighted="True"
+                            NumberOfWeeksInView="6"
+                            OutOfScopeBackground="Transparent"
+                            OutOfScopeForeground="{StaticResource TextFillColorDisabledBrush}"
+                            SelectionMode="None"
+                            TodayBackground="{StaticResource AccentFillColorDefaultBrush}"
+                            TodayFontWeight="SemiBold"
+                            TodayForeground="{StaticResource TextOnAccentFillColorPrimaryBrush}"
+                            VerticalDayItemAlignment="Center">
+                            <CalendarView.Resources>
+                                <x:Double x:Key="CalendarViewHeaderNavigationButtonFontSize">13</x:Double>
+                                <x:Double x:Key="CalendarViewNavigationButtonFontSize">10</x:Double>
+                                <Thickness x:Key="CalendarViewDayItemMargin">0</Thickness>
+                                <Thickness x:Key="CalendarViewWeekDayMargin">0</Thickness>
+                                <Thickness x:Key="CalendarViewWeekDayPadding">1,4,1,4</Thickness>
+                                <Thickness x:Key="CalendarViewMonthYearItemMargin">3</Thickness>
+                                <Thickness x:Key="CalendarViewHeaderNavigationButtonPadding">8,6,8,6</Thickness>
+                                <Thickness x:Key="CalendarViewNavigationButtonPadding">9,6,9,6</Thickness>
+                                <Thickness x:Key="CalendarViewHeaderNavigationButtonMargin">4,2,2,2</Thickness>
+                                <Thickness x:Key="CalendarViewNavigationPreviousButtonMargin">2,2,1,2</Thickness>
+                                <Thickness x:Key="CalendarViewNavigationNextButtonMargin">1,2,4,2</Thickness>
+                            </CalendarView.Resources>
+                        </CalendarView>
+                        <TextBlock
+                            x:Name="TraditionalCalendarTitlePresenter"
+                            Height="29"
+                            Margin="98,0,70,0"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Top"
+                            FontSize="8"
+                            Foreground="{StaticResource TextFillColorSecondaryBrush}"
+                            IsHitTestVisible="False"
+                            LineHeight="29"
+                            LineStackingStrategy="BlockLineHeight"
+                            MaxLines="1"
+                            Opacity="0.68"
+                            Text="{Binding TraditionalCalendarTitle}"
+                            TextAlignment="Center"
+                            TextTrimming="CharacterEllipsis" />
+                    </Grid>
+                </Grid>
+            </Grid>
+        </Border>
+    </Grid>
+
+    <Border
+        x:Name="ActionLayer"
+        Margin="12"
+        HorizontalAlignment="Right"
+        VerticalAlignment="Top"
+        Background="#B5202020"
+        CornerRadius="9"
+        Padding="3">
+        <Grid ColumnSpacing="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Button
+                x:Name="PauseButton"
+                Grid.Column="0"
+                Width="28"
+                Height="28"
+                Padding="0"
+                Background="Transparent"
+                BorderThickness="0"
+                CornerRadius="6"
+                Foreground="White">
+                <Viewbox Width="16" Height="16" IsHitTestVisible="False">
+                    <Canvas Width="16" Height="16">
+                        <Path x:Name="PlayIcon" Data="M5.75 3.06A.5.5 0 0 0 5 3.5v9c0 .38.41.62.75.44l8-4.5a.5.5 0 0 0 0-.88l-8-4.5ZM4 3.5a1.5 1.5 0 0 1 2.24-1.3l8 4.5a1.5 1.5 0 0 1 0 2.6l-8 4.5A1.5 1.5 0 0 1 4 12.5v-9Z" Fill="{Binding Foreground, ElementName=PauseButton}" Visibility="{Binding PlayIconVisibility}" />
+                        <Path x:Name="PauseIcon" Data="M3.75 2C2.78 2 2 2.78 2 3.75v8.5c0 .97.78 1.75 1.75 1.75h1.5C6.22 14 7 13.22 7 12.25v-8.5C7 2.78 6.22 2 5.25 2h-1.5ZM3 3.75c0-.41.34-.75.75-.75h1.5c.41 0 .75.34.75.75v8.5c0 .41-.34.75-.75.75h-1.5a.75.75 0 0 1-.75-.75v-8.5ZM10.75 2C9.78 2 9 2.78 9 3.75v8.5c0 .97.78 1.75 1.75 1.75h1.5c.97 0 1.75-.78 1.75-1.75v-8.5C14 2.78 13.22 2 12.25 2h-1.5ZM10 3.75c0-.41.34-.75.75-.75h1.5c.41 0 .75.34.75.75v8.5c0 .41-.34.75-.75.75h-1.5a.75.75 0 0 1-.75-.75v-8.5Z" Fill="{Binding Foreground, ElementName=PauseButton}" Visibility="{Binding PauseIconVisibility}" />
+                    </Canvas>
+                </Viewbox>
+            </Button>
+            <Button
+                x:Name="NextButton"
+                Grid.Column="1"
+                Width="28"
+                Height="28"
+                Padding="0"
+                Background="Transparent"
+                BorderThickness="0"
+                CornerRadius="6"
+                Foreground="White">
+                <Viewbox Width="16" Height="16" IsHitTestVisible="False">
+                    <Canvas Width="16" Height="16">
+                        <Path Data="M2.5 7.5a.5.5 0 1 0 0 1h9.7l-4.03 3.63a.5.5 0 1 0 .66.74l5-4.5a.5.5 0 0 0 0-.74l-5-4.5a.5.5 0 0 0-.66.74L12.2 7.5H2.5Z" Fill="{Binding Foreground, ElementName=NextButton}" />
+                    </Canvas>
+                </Viewbox>
+            </Button>
+        </Grid>
+    </Border>
+
+    <Border
+        x:Name="SettingsLayer"
+        Margin="12"
+        HorizontalAlignment="Left"
+        VerticalAlignment="Top"
+        Background="#E6202020"
+        CornerRadius="9"
+        Padding="10"
+        Visibility="Collapsed">
+        <StackPanel Spacing="10">
+            <TextBlock FontSize="12" FontWeight="SemiBold" Foreground="White" Text="设置" />
+            <ToggleSwitch x:Name="FestivalToggle" Header="节日显示" MinWidth="160" OffContent="关" OnContent="开" />
+            <ToggleSwitch x:Name="TraditionalToggle" Header="传统历法" MinWidth="160" OffContent="关" OnContent="开" />
+        </StackPanel>
+    </Border>
+</Grid>

--- a/spikes/glance-native/README.md
+++ b/spikes/glance-native/README.md
@@ -36,6 +36,10 @@ v2 的结论不变：宿主 `RuntimeFeature.IsDynamicCodeSupported`=false，输�
 
 包体积变化：v1-v3 ≈ 6.18MB/个（编译控件+PRIResource 加入后，此前 4.55MB），todo 包 4.26MB。
 
+### 第四轮：完整 Glance 切片（图片/交互/设置/持久化）
+
+第四轮（2026-09-08 深夜）补齐完整 Glance 代表性切片（`full-glance.xaml` + `FullGlanceView.cs`）：背景图片 A/B 交叉淡入轮播（包目录 `backgrounds/` 本地图，3s 定时器，Unloaded 停表）、生产结构操作栏（暂停/下一张，真实 Click 处理器）、代码构建右键 MenuFlyout（运行时 XAML 无法接线处理器）、XAML 名字域内设置面板（节日/传统历法 ToggleSwitch）经程序化 `IsOn` 驱动同一 Toggled 路径重建月份、设置持久化到 `glance-settings.json`。实测链：定时轮播推进（索引 1）→ automation peer 真实点击下一张（索引回绕 0，2 张图模运算）→ 关节日开关（festivalDayCount 42 格→0，月份数据实时重建）→ 销毁重建（设置保留、轮播重置）。在线图片源（Bing/在线目录）不在本切片范围，归批次 D 的生产 GlanceImageService 迁移。
+
 两轮所有场景的断言（业务值、实际布局、绑定、退出码、截图、宿主哈希一致）由 `scripts/spike/run-glance-native.ps1` 自动判定；本地证据在 `.artifacts/glance-native/runs/<timestamp>-x64/summary.json`，截图在各 `result-*/view.png`。二进制和运行证据不入库。
 
 ## 复现


### PR DESCRIPTION
Batch B round 4 of the official widget packages plan: the representative FULL Glance slice (background image rotation with A/B cross-fade, production-shaped action bar with real click handlers, code-built right-click MenuFlyout, in-namescope settings panel driving live month rebuilds through the same Toggled path, settings persistence with destroy/recreate restore) plus the Store-policy conclusions (10.1.5/10.2.2 verbatim) and the WinAppSDK version-alignment requirement written into the plan. Eight spike scenarios green (rotation index advances, automation-peer click wraps modulo, festival toggle rebuilds month data 42->0, settings persist across recreate); main suite 3541/3541; no src/ changes.