### PR TITLE
docs: absorb external audit - storage three-root split, host-type probe, ABI wording

### DIFF
--- a/docs/architecture/official-widget-packages-plan.md
+++ b/docs/architecture/official-widget-packages-plan.md
@@ -65,7 +65,18 @@ Store 路径在批次 B 前期就核对，不能等发布前才验证。动态�
 
 **渠道决策**：Direct/GitHub 渠道（现行安装器+release）不受上述约束，功能包按 B1 管线从 GitHub 索引下载；**Store 渠道的功能包交付=捆绑进主包或 Store add-ons，不做 Store 版外部下载**。因此批次 C 的原生包格式必须同时支撑两种交付形态（同一包内容，两种分发通道），批次 E 按渠道分别验收。
 
+### 批次 C 输入（2026-09-08 外部二次审计吸收，逐条对码核实）
+
+- **P0 存储三根拆分**：PackageRoot（只读，二进制/XAML/资源）／PackageDataRoot（可写，包级持久数据）／InstanceDataRoot（可写，实例级数据）；激活 ABI 从单一 `directory` 改为 `packageRoot + dataRoot + widgetInstanceId`。Spike 把数据写进包目录是被否决的反模式（与只读内容寻址安装/更新换目录/卸载清理直接冲突）。
+- **宿主类型/主题/本地化契约**：先做 QuickCapture/Todo 综合 probe（它们比 Glance 难：CommunityToolkit 控件、拖放、KeyDown、宿主自定义控件 `WidgetTitleIcon`、局部转换器——均已对码核实）；宿主元数据提供器覆盖宿主类型（84 处命中）→"包文本 XAML 能否解析宿主自定义控件/工具包控件"是最高价值未验证项。主题走 HostThemeContract token（host→package 激活时注入，package 映射为本地 ResourceDictionary——本地字典解析已被 spike 证明可行）；本地化走包内 strings/*.json+展示层预本地化，不用 x:Uid/PRI。
+- **事件接线约定**：运行时 XAML 无 code-behind，XAML 只描述结构、包代码 FindName 显式订阅；迁移成本必须在 probe 中量化（复杂视图的接线数量）。
+- **正式 ABI 收敛**：统一小面（get_abi_version/activate/widget_create/widget_destroy/package_shutdown）+ HostApi 函数表回调；钉死引用计数/销毁时机/缓存/线程要求。
+- **内存硬数据**：Host only / +1 / +3 / +6 包加载，及"全部视图销毁但 DLL 常驻"的长期占用（Private WS/Commit/mapped image），批次 D 前必须有数。
+- **批次 D 退出条件补充**：迁移完成后源码归包所有，宿主不再编译同一 .cs（禁止长期 dual ownership）。
+
 ## 执行记录
+
+
 
 - 2026-09-08：用户授权按复评建议开始实施，工作区干净；创建本地分支 `codex/official-widget-packages`，从 `527f63d8` 开始。
 - 已建立本执行计划，历史路线保留并指向此处。

--- a/spikes/glance-native/README.md
+++ b/spikes/glance-native/README.md
@@ -24,14 +24,14 @@ v2 的结论不变：宿主 `RuntimeFeature.IsDynamicCodeSupported`=false，输�
 
 - **销毁重建**（lifecycle 场景）：同一进程内创建→卸载（Unloaded 事件确认）→再创建，第二个视图正常渲染（业务值 244 + 标题绑定恢复）。
 - **多包并存**（multi-package 场景）：同一宿主进程同时加载 v2（简单切片）与 v3（真实切片）两个原生 DLL，两个模块句柄不同、两个视图同时渲染（v2 高度 268 + v3 农历标题），宿主哈希不变。
-- **待办编辑/持久化**（todo-package 场景，`TodoPackage/`）：宿主通过投影设置包内 TextBox 文本、直接构造 `ButtonAutomationPeer` 触发真实点击路径，包代码将条目写入包目录 `todo-items.json`；销毁视图后重建，条目从文件恢复（1→1，内容一致）。数据所有权按"包目录"划分。
+- **待办编辑/持久化**（todo-package 场景，`TodoPackage/`）：宿主通过投影设置包内 TextBox 文本、直接构造 `ButtonAutomationPeer` 触发真实点击路径，包代码将条目写入包目录 `todo-items.json`；销毁视图后重建，条目从文件恢复（1→1，内容一致）。**注意：数据写入包目录是 spike 简化，不是契约**——与 B1 的只读内容寻址安装目录/更新换目录模型冲突（更新后数据悬空、卸载误删、ReadOnly 无法写入），批次 C 必须拆分 PackageRoot（只读）/PackageDataRoot（可写）/InstanceDataRoot（实例级），激活 ABI 传 packageRoot+dataRoot+widgetInstanceId 三参。
 
 ### 第三轮：编译 XAML / PRI / WinRT 激活（钉住的负结论）
 
 第三轮（2026-09-08 深夜）用可复现探针回答了三个悬而未决的问题，全部为**当前不可行**，已作为回归断言钉进脚本（`compiled-xaml-pinned-negative` 场景；若未来 Windows App SDK 行为翻转，断言会失败并强制重评契约）：
 
 1. **编译 XAML（XBF）在动态加载的 AOT DLL 中无法定位。** 包项目为 `RealGlanceControl.xaml` 正常走完 XAML 编译（生成 XBF + XamlMetaDataProvider），但运行时 `Application.LoadComponent`（`ComponentResourceLocation.Nested`，`ms-appx:///DeskBox.Glance.NativePackage/...`）抛 XamlParseException。判别实验：**无任何包内自定义类型的最小编译控件同样失败**——问题在 XBF 定位层而非类型解析。把 XBF 按 ms-appx 布局拷到宿主目录子路径也不行（已试）。宿主自己的 XBF 无磁盘文件且 exe 内无明文名，说明解包应用的 XBF 解析内嵌在宿主 exe 的资源体系里，动态 DLL 借不到。**运行时文本 XAML + 预计算可绑定属性（第二轮）仍是已验证路径。** 若未来必须编译 XAML：`Application.ResourceManagerRequested` 提供自定义 `IResourceManager` 是候选逃逸口（未实验）。
-2. **AOT DLL 不导出 `DllGetActivationFactory`。** C#/WinRT 组件激活路径对 NativeAOT 包不可用，原生 C 导出（`UnmanagedCallersOnly`）是唯一 ABI。
+2. **本试点的 AOT DLL 产物不导出 `DllGetActivationFactory`。** 当前 C# NativeAOT 动态类库配置中，raw C 导出（`UnmanagedCallersOnly`）是唯一**已验证可工作**的 ABI；C#/WinRT 本身仍支持组件激活/registration-free activation 等机制，本试点未验证，不构成平台定律。
 3. **独立 PRI 不随类库发布产生，MrtCore 无文件级加载。** `PRIResource`（resw）进了编译但发布输出没有 `.pri` 文件；MrtCore `ResourceManager` 两个构造路径均抛 COMException（找不到元素）；UWP 遗留 `LoadPriFiles` 因无文件可载而跳过。**包本地化需要自带字符串文件机制（或批次 C 重新决策布局）。**
 
 包体积变化：v1-v3 ≈ 6.18MB/个（编译控件+PRIResource 加入后，此前 4.55MB），todo 包 4.26MB。


### PR DESCRIPTION
Second external audit of #271/#273/#275 verified claim-by-claim against code (all six substantive claims confirmed; four production-XAML complexity claims verified by grep; host XamlTypeInfo provider covers WidgetTitleIcon/Segmented). Fixes applied: (1) spike README no longer states data-in-package-directory as the ownership model - marked as a rejected anti-pattern with the batch C three-root split (PackageRoot read-only / PackageDataRoot / InstanceDataRoot, activation ABI takes packageRoot+dataRoot+widgetInstanceId); (2) ABI conclusion narrowed from platform law to 'only verified working ABI in this configuration'; (3) plan doc gains a batch C input section: QuickCapture/Todo comprehensive probe (host custom controls + toolkit + event-wiring cost + theme tokens + localization + formal ABI + resident-DLL memory matrix) and a batch D exit condition (source ownership transfer, no dual compilation).