### PR TITLE
fix: audit round 11 - pilot dispose path, session cache, single day-item subscription

### DIFF
--- a/docs/architecture/official-widget-packages-plan.md
+++ b/docs/architecture/official-widget-packages-plan.md
@@ -65,7 +65,26 @@ Store 路径在批次 B 前期就核对，不能等发布前才验证。动态�
 
 **渠道决策**：Direct/GitHub 渠道（现行安装器+release）不受上述约束，功能包按 B1 管线从 GitHub 索引下载；**Store 渠道的功能包交付=捆绑进主包或 Store add-ons，不做 Store 版外部下载**。因此批次 C 的原生包格式必须同时支撑两种交付形态（同一包内容，两种分发通道），批次 E 按渠道分别验收。
 
-### 批次 C 输入（2026-09-08 外部二次审计吸收，逐条对码核实）
+### 批次 C 输入·第十一轮审计吸收（2026-09-09，逐条对码核实）
+
+**已修的产品/代码缺陷**：①试点内容未实现 IDisposable——宿主只 Dispose `IDisposable`（WidgetManager:1598/2099），导致 `widget_destroy`/`shutdown` 从未被调用；已实现 Dispose→DestroyWidget（不触发 shutdown，防误伤其他实例）。②试点每 Widget 重新 Activate 覆盖包静态会话——已加宿主侧会话缓存（每包根一次激活）。③FullGlance 每次 Rebuild 重复订阅 CalendarViewDayItemChanging（叠处理器+旧状态捕获）——已改单订阅+可变状态持有者。④脚本 XBF 拷贝路径硬编码 x64——已改平台感知。
+
+**C1（下一批，运行时契约收口，全部真运行测试而非源码扫描）**：
+- ABI 重塑：`activate(packageRoot, packageDataRoot, hostApi*)` 去掉 instanceId（包生命周期）；`create_widget(contributionId, instanceId, instanceDataRoot, out widgetHandle, out view)`（补贡献身份+实例数据根+包侧不透明句柄）；`destroy_widget(widgetHandle)`；`shutdown()`。
+- `NativePackageSession/RuntimeManager`：PackageId+ContentHash→会话（module/roots/liveInstances[]）；最后实例销毁才 shutdown；模块仍不 FreeLibrary。
+- **加载器只接受 `VerifiedInstalledPackage`**（B1 管线绑定：验证→不可变根→LoadLibrary，禁止任意目录直载）。
+- **PackageDataRoot 绝不由安装目录名推导**（叶子名=内容哈希，更新即漂移）：`data/packages/<publisherFingerprint>/<packageId>/`，实例 `instances/<instanceId>/`。
+- 必测：同包双实例数据隔离、销毁 A 后 B 继续工作、关窗恰好销毁一次、v1→v2 更新后数据根不变、包更新不丢数据。
+
+**C2（宿主 UI/主题/输入）**：真实 `WidgetTitleIcon` 替代 HostBadge；Segmented 订阅自身事件验证完整交互契约；主题走 HostApi GetTheme/ThemeChanged（非数据根 JSON；合并而非替换资源字典）；本地化 zh-CN/en-US 切换实测；Drag/Drop/KeyDown/IME/焦点；**Host UI Kit 不直接暴露 CommunityToolkit**（版本耦合风险，宿主包一层 DeskBox 控件）。
+
+**批次 D 迁移顺序（审计建议，已采纳）**：Glance→Music→Search→Weather→Todo→QuickCapture（最重交互最后）。
+
+**措辞收窄**：XBF 结论限定为"当前 NativeAOT 动态 DLL+运行时文本 XAML 路线中，宿主编译 Page 的 XBF 须保持 ms-appx 可解析"；Direct/Store 渠道分别实测，非平台定律。FullGlance 设置仍写包目录=已知 spike 债务（README 已标注反模式，C1 随三根落地一并清理）。
+
+
+
+### 批次 C 输入·第十轮审计吸收（2026-09-08，逐条对码核实）
 
 - **P0 存储三根拆分**：PackageRoot（只读，二进制/XAML/资源）／PackageDataRoot（可写，包级持久数据）／InstanceDataRoot（可写，实例级数据）；激活 ABI 从单一 `directory` 改为 `packageRoot + dataRoot + widgetInstanceId`。Spike 把数据写进包目录是被否决的反模式（与只读内容寻址安装/更新换目录/卸载清理直接冲突）。
 - **宿主类型/主题/本地化契约**：先做 QuickCapture/Todo 综合 probe（它们比 Glance 难：CommunityToolkit 控件、拖放、KeyDown、宿主自定义控件 `WidgetTitleIcon`、局部转换器——均已对码核实）；宿主元数据提供器覆盖宿主类型（84 处命中）→"包文本 XAML 能否解析宿主自定义控件/工具包控件"是最高价值未验证项。主题走 HostThemeContract token（host→package 激活时注入，package 映射为本地 ResourceDictionary——本地字典解析已被 spike 证明可行）；本地化走包内 strings/*.json+展示层预本地化，不用 x:Uid/PRI。

--- a/scripts/spike/run-glance-native.ps1
+++ b/scripts/spike/run-glance-native.ps1
@@ -45,8 +45,9 @@ try {
     Invoke-DotNet -CommandArguments (@("publish", $hostProject, "--no-restore") + $common + @("-o", $hostOutput))
     # CONTRACT FINDING: publish drops Page XBFs for this unpackaged layout, but
     # ms-appx resolution needs them on disk next to the exe (App.xaml's
-    # ApplicationDefinition XBF embeds differently). Copy Page XBFs explicitly.
-    $xbfSource = Join-Path $repoRoot "spikes\glance-native\Host\obj\x64\Release\net10.0-windows10.0.22621.0\win-x64"
+    # ApplicationDefinition XBF embeds differently). Copy Page XBFs explicitly;
+    # path is platform-aware so ARM64 BuildOnly keeps honest evidence.
+    $xbfSource = Join-Path $repoRoot "spikes\glance-native\Host\obj\$Platform\Release\net10.0-windows10.0.22621.0\$rid"
     Get-ChildItem -LiteralPath $xbfSource -Filter "*.xbf" -ErrorAction SilentlyContinue |
         Where-Object Name -ne "App.xbf" |
         ForEach-Object { Copy-Item -LiteralPath $_.FullName -Destination $hostOutput -Force }

--- a/spikes/glance-native/Package/FullGlanceView.cs
+++ b/spikes/glance-native/Package/FullGlanceView.cs
@@ -44,7 +44,11 @@ internal static class FullGlanceView
         content.DataContext = presentation;
 
         var calendarView = content.FindName("NativeCalendarView").As<CalendarView>();
-        WireDayDecoration(calendarView, month, dayItemHeight, state.ShowTraditional, state.ShowFestivals, state);
+        // Single subscription (audit round 11): settings changes update the
+        // decoration state in place; re-subscribing per rebuild would stack
+        // handlers that capture stale calendar state.
+        var decoration = new CalendarDecorationState(month, dayItemHeight, state.ShowTraditional, state.ShowFestivals);
+        SubscribeDayDecoration(calendarView, decoration);
 
         // Image pipeline: package-local folder, A/B cross-fade borders.
         string[] images = Directory.Exists(Path.Combine(root, "backgrounds"))
@@ -104,13 +108,13 @@ internal static class FullGlanceView
         festivalToggle.Toggled += (_, _) =>
         {
             state.ShowFestivals = festivalToggle.IsOn;
-            Rebuild(root, state, calendarView, dayItemHeight);
+            Rebuild(root, state, calendarView, decoration, dayItemHeight);
             SaveState(root, state);
         };
         traditionalToggle.Toggled += (_, _) =>
         {
             state.ShowTraditional = traditionalToggle.IsOn;
-            Rebuild(root, state, calendarView, dayItemHeight);
+            Rebuild(root, state, calendarView, decoration, dayItemHeight);
             SaveState(root, state);
         };
 
@@ -138,40 +142,57 @@ internal static class FullGlanceView
         return content;
     }
 
-    private static void Rebuild(string root, FullState state, CalendarView calendarView, double dayItemHeight)
+    private static void Rebuild(string root, FullState state, CalendarView calendarView, CalendarDecorationState decoration, double dayItemHeight)
     {
         (GlanceCalendarMonth rebuilt, _, _, _, _, _) = RealGlanceModel.Build(state.ShowTraditional, state.ShowFestivals);
-        WireDayDecoration(calendarView, rebuilt, dayItemHeight, state.ShowTraditional, state.ShowFestivals, state);
+        decoration.Update(rebuilt, dayItemHeight, state.ShowTraditional, state.ShowFestivals);
         WriteSummary(root, [], state, rebuilt);
     }
 
-    private static void WireDayDecoration(
-        CalendarView calendarView,
+    /// <summary>Mutable decoration state read by the single day-item handler.</summary>
+    private sealed class CalendarDecorationState(
         GlanceCalendarMonth month,
         double dayItemHeight,
         bool showTraditional,
-        bool showFestivals,
-        FullState state)
+        bool showFestivals)
+    {
+        public GlanceCalendarMonth Month = month;
+        public double DayItemHeight = dayItemHeight;
+        public bool ShowTraditional = showTraditional;
+        public bool ShowFestivals = showFestivals;
+
+        public void Update(GlanceCalendarMonth rebuilt, double itemHeight, bool traditional, bool festivals)
+        {
+            Month = rebuilt;
+            DayItemHeight = itemHeight;
+            ShowTraditional = traditional;
+            ShowFestivals = festivals;
+        }
+    }
+
+    private static void SubscribeDayDecoration(CalendarView calendarView, CalendarDecorationState decoration)
     {
         System.Globalization.CultureInfo culture = RealGlanceModel.Culture;
         DateOnly pinned = new(RealGlanceModel.PinnedYear, RealGlanceModel.PinnedMonth, 1);
         DateOnly today = DateOnly.FromDateTime(DateTime.Today);
-        Dictionary<DateOnly, GlanceCalendarDay> days = month.Days.ToDictionary(day => day.Date);
-        int decorated = 0;
         calendarView.CalendarViewDayItemChanging += (_, args) =>
         {
             CalendarViewDayItem item = args.Item;
             if (args.InRecycleQueue) { item.Tag = null; return; }
             DateOnly date = DateOnly.FromDateTime(item.Date.DateTime);
-            days.TryGetValue(date, out GlanceCalendarDay? day);
-            string secondaryText = !showTraditional ? string.Empty
-                : showFestivals && !string.IsNullOrWhiteSpace(day?.FestivalText) ? day.FestivalText
+            GlanceCalendarDay? day = null;
+            foreach (GlanceCalendarDay candidate in decoration.Month.Days)
+            {
+                if (candidate.Date == date) { day = candidate; break; }
+            }
+            string secondaryText = !decoration.ShowTraditional ? string.Empty
+                : decoration.ShowFestivals && !string.IsNullOrWhiteSpace(day?.FestivalText) ? day.FestivalText
                 : day?.TraditionalText ?? string.Empty;
             bool hasSecondaryText = !string.IsNullOrWhiteSpace(secondaryText);
             bool isFestival = hasSecondaryText && day?.HasFestival == true;
             bool isCurrentMonth = day?.IsCurrentMonth ?? date.Month == pinned.Month;
-            item.MinHeight = dayItemHeight;
-            item.Height = dayItemHeight;
+            item.MinHeight = decoration.DayItemHeight;
+            item.Height = decoration.DayItemHeight;
             item.Tag = new RealGlanceDayDecoration(
                 day?.DayText ?? date.Day.ToString(culture),
                 secondaryText,
@@ -181,9 +202,7 @@ internal static class FullGlanceView
                 isFestival ? Microsoft.UI.Text.FontWeights.SemiBold : Microsoft.UI.Text.FontWeights.Normal,
                 isCurrentMonth ? 1.0 : 0.42,
                 !isCurrentMonth ? 0.34 : isFestival ? 0.88 : 0.62);
-            if (hasSecondaryText) decorated++;
         };
-        state.Decorated = decorated;
     }
 
     private static FullState LoadState(string root)

--- a/src/DeskBox/Services/Plugins/NativeWidgetPilot.cs
+++ b/src/DeskBox/Services/Plugins/NativeWidgetPilot.cs
@@ -12,30 +12,38 @@ namespace DeskBox.Services.Plugins;
 /// </summary>
 internal static class NativeWidgetPilot
 {
+    // Interim session cache (audit round 11): one activation per package root
+    // per process - re-activating per widget would overwrite the package's
+    // static session state and pair the wrong instance id. The full
+    // NativePackageSession/instance model lands in batch C1.
+    private static NativeWidgetPackage? _activePackage;
+    private static string? _activePackageRoot;
+
     public static bool TryCreate(WidgetConfig config, out IWidgetContent? content)
     {
         content = null;
         string? packageRoot = NativeWidgetPackageLoader.TryGetDevelopmentPackageRoot();
         if (packageRoot is null) return false;
-        NativeWidgetPackage? package = NativeWidgetPackageLoader.TryActivate(
-            packageRoot,
-            NativeWidgetPackageLoader.ResolveDataRoot(packageRoot, DeskBoxDataPathService.Current.DataDirectory),
-            config.Id);
+        NativeWidgetPackage? package = _activePackageRoot == packageRoot
+            ? _activePackage
+            : NativeWidgetPackageLoader.TryActivate(
+                packageRoot,
+                NativeWidgetPackageLoader.ResolveDataRoot(packageRoot, DeskBoxDataPathService.Current.DataDirectory),
+                "pilot-session");
         if (package is null) return false;
+        _activePackage = package;
+        _activePackageRoot = packageRoot;
         FrameworkElement? view = package.TryCreateWidget(config.Id);
-        if (view is null)
-        {
-            package.Shutdown();
-            return false;
-        }
+        if (view is null) return false;
         content = new NativeWidgetPilotContent(config, package, view);
         return true;
     }
 }
 
-internal sealed class NativeWidgetPilotContent : IWidgetContent
+internal sealed class NativeWidgetPilotContent : IWidgetContent, IDisposable
 {
     private readonly NativeWidgetPackage _package;
+    private bool _disposed;
 
     internal NativeWidgetPilotContent(WidgetConfig config, NativeWidgetPackage package, FrameworkElement view)
     {
@@ -59,4 +67,24 @@ internal sealed class NativeWidgetPilotContent : IWidgetContent
     public void ApplyAppearance() { }
     public void OnActivated() { }
     public void OnDeactivated() { }
+
+    /// <summary>
+    /// The host disposes widget content via IDisposable (WidgetManager); route
+    /// that to the package's instance destroy. Package shutdown intentionally
+    /// NOT triggered here - other widget instances may still use the session.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        try
+        {
+            _package.DestroyWidget(WidgetId);
+            App.LogVerbose($"[NativePackage] pilot widget destroyed: {WidgetId}");
+        }
+        catch (Exception error)
+        {
+            App.Log($"[NativePackage] destroy failed for {WidgetId}: {error.Message}");
+        }
+    }
 }


### PR DESCRIPTION
Round-11 external audit verified claim-by-claim against code - all substantive findings confirmed. Fixes the concrete defects now; the forward-looking items (C1 runtime contract, C2 host UI/theme/input) are absorbed into the plan. (1) Pilot content never disposed: the host only disposes IDisposable content (WidgetManager), so widget_destroy/shutdown were never called - NativeWidgetPilotContent now implements IDisposable routing to DestroyWidget without triggering package shutdown (other instances may live). (2) Per-widget re-activation overwrote the package's static session state - added a host-side session cache (one activation per package root per process; the full NativePackageSession model is batch C1). (3) FullGlance re-subscribed CalendarViewDayItemChanging on every settings rebuild, stacking handlers that captured stale state - restructured to a single subscription reading a mutable decoration state. (4) The spike script's XBF copy path was hardcoded to x64, making ARM64 BuildOnly evidence impure - now platform-aware. Plan doc gains the C1 spec (ABI reshape: activate without instanceId, create with contributionId/instanceId/instanceDataRoot returning an opaque handle, destroy by handle; VerifiedInstalledPackage-only loader binding; stable data roots keyed by publisher+packageId, never by install directory name since leaf dirs are content hashes; real-run test matrix incl. update-path stability) and C2 (real WidgetTitleIcon, Segmented self-event subscription, HostApi theme with merge-not-replace, localization round-trip, drag/keyboard/IME, no direct CommunityToolkit exposure in packages), plus the batch D migration order (Glance->Music->Search->Weather->Todo->QuickCapture). Suite 3545/3545.