### PR TITLE
feat: format hardening from audit round 13 - rollback, EntryMain, architecture, native gate

### DIFF
--- a/docs/architecture/plugin-schema-v0.json
+++ b/docs/architecture/plugin-schema-v0.json
@@ -20,7 +20,17 @@
         "displayName": { "type": "string", "minLength": 1 },
         "template": {
           "enum": ["metric", "list", "status", "gallery", "action-list", "simple-form"],
-          "description": "Host-rendered declarative template (roadmap 13.5). v0 deliberately has no free-form layout primitives."
+          "description": "Host-rendered declarative template (roadmap 13.5). Required for runtime:none/wasm/process; optional for runtime:native (native packages render via their own DLL, not via host templates)."
+        },
+        "fallback": {
+          "type": "object",
+          "required": ["template"],
+          "properties": {
+            "template": { "enum": ["status"] },
+            "message": { "type": "string" }
+          },
+          "additionalProperties": false,
+          "description": "Declarative fallback for native packages: what the host renders when the native runtime is unavailable (package missing, wrong architecture, restart required, load failure). Only meaningful for runtime:native."
         },
         "payload": {
           "type": "object",
@@ -231,6 +241,10 @@
           "type": "string",
           "minLength": 1,
           "description": "Path to the runtime entry artifact inside the package. process: script path (plugin/main.mjs). wasm: module path. native: the NativeAOT DLL file name (e.g. package.dll) - must be an integrity-listed payload file and must resolve via the package path grammar. Required for runtime wasm/process/native; forbidden for runtime:none."
+        },
+        "architecture": {
+          "enum": ["x64", "arm64"],
+          "description": "CPU architecture of the native DLL. Required for runtime:native; the verifier cross-checks the manifest claim against the PE machine header of the entry DLL. Install refuses when the manifest architecture does not match the running host."
         }
       },
       "description": "Runtime entry point for code-bearing packages. runtime:none packages have no entry."

--- a/scripts/spike/build-official-glance.ps1
+++ b/scripts/spike/build-official-glance.ps1
@@ -31,10 +31,18 @@ try {
     New-Item -ItemType Directory -Path $packageDir -Force | Out-Null
     $sourceDll = Join-Path $publishDir "DeskBox.Glance.NativePackage.dll"
     if (-not (Test-Path $sourceDll)) { throw "AOT DLL not found: $sourceDll" }
-    Copy-Item $sourceDll (Join-Path $packageDir "package.dll")
-    Copy-Item (Join-Path $publishDir "glance-real.xaml") $packageDir -ErrorAction SilentlyContinue
-    Copy-Item (Join-Path $publishDir "calendar.xaml") $packageDir -ErrorAction SilentlyContinue
-    Copy-Item (Join-Path $publishDir "full-glance.xaml") $packageDir -ErrorAction SilentlyContinue
+    # Required payload files - fail fast if any is missing (audit round 13 §30).
+    foreach ($requiredFile in @("DeskBox.Glance.NativePackage.dll", "glance-real.xaml")) {
+        $source = Join-Path $publishDir $requiredFile
+        if (-not (Test-Path $source)) { throw "required payload missing from AOT publish: $requiredFile" }
+    }
+    Copy-Item (Join-Path $publishDir "DeskBox.Glance.NativePackage.dll") (Join-Path $packageDir "package.dll")
+    Copy-Item (Join-Path $publishDir "glance-real.xaml") $packageDir
+    # Optional XAML files (probe variants; may be absent without breaking the package).
+    foreach ($optionalFile in @("calendar.xaml", "full-glance.xaml")) {
+        $source = Join-Path $publishDir $optionalFile
+        if (Test-Path $source) { Copy-Item $source $packageDir }
+    }
     Copy-Item (Join-Path $repoRoot "spikes\glance-native\OfficialPackage\manifest.json") $packageDir
 
     # 3. Generate integrity manifest and signature using the Node tooling.

--- a/scripts/spike/validate-lib.mjs
+++ b/scripts/spike/validate-lib.mjs
@@ -46,7 +46,7 @@ export function validatePackage(pkgDir) {
       fail('entry.main must be a non-empty string');
     }
     for (const key of Object.keys(manifest.entry ?? {})) {
-      if (key !== 'main') fail(`entry: unknown property '${key}'`);
+      if (key !== 'main' && key !== 'architecture') fail(`entry: unknown property '${key}'`);
     }
     if (typeof manifest.entry?.main === 'string') {
       const violation = packagePathViolation(manifest.entry.main);
@@ -70,7 +70,7 @@ export function validatePackage(pkgDir) {
 
   const contributions = manifest.contributions;
   if (!Array.isArray(contributions) || contributions.length < 1) fail('contributions: minItems 1');
-  const widgetClosed = ['type', 'id', 'displayName', 'template', 'payload', 'bindings', 'defaultSize', 'activationEvents'];
+  const widgetClosed = ['type', 'id', 'displayName', 'template', 'payload', 'bindings', 'defaultSize', 'activationEvents', 'fallback'];
   const templates = ['metric', 'list', 'status', 'gallery', 'action-list', 'simple-form'];
   const dataSources = manifest.dataSources ?? {};
   const actions = manifest.actions ?? {};
@@ -83,11 +83,19 @@ export function validatePackage(pkgDir) {
   }
   (contributions ?? []).forEach((c, i) => {
     const where = `contributions[${i}]`;
-    for (const key of ['type', 'id', 'displayName', 'template']) {
+    // template is required for non-native runtimes; optional for native
+    // (native packages render via their own DLL, audit round 13 §2).
+    const isNative = manifest.runtime === 'native';
+    for (const key of ['type', 'id', 'displayName']) {
       if (!(key in c)) fail(`${where}: missing required '${key}'`);
     }
+    if (!isNative && !('template' in c)) fail(`${where}: missing required 'template' for runtime:${manifest.runtime}`);
     for (const key of Object.keys(c)) {
       if (!widgetClosed.includes(key)) fail(`${where}: unknown property '${key}'`);
+    }
+    if (c.fallback !== undefined) {
+      if (c.fallback.template !== 'status') fail(`${where}.fallback.template must be 'status'`);
+      if (typeof c.fallback.message !== 'string') fail(`${where}.fallback.message must be a string`);
     }
     if (c.type !== undefined && c.type !== 'widget') fail(`${where}: unknown contribution type`);
     if (c.id !== undefined && !/^[a-z0-9][a-z0-9-]*$/.test(c.id)) fail(`${where}: id pattern`);

--- a/spikes/glance-native/OfficialPackage/manifest.json
+++ b/spikes/glance-native/OfficialPackage/manifest.json
@@ -10,19 +10,17 @@
     "max": "1.0.0"
   },
   "entry": {
-    "main": "package.dll"
+    "main": "package.dll",
+    "architecture": "x64"
   },
   "contributions": [
     {
       "type": "widget",
       "id": "glance",
       "displayName": "Glance",
-      "template": "simple-form",
-      "payload": {
-        "version": 1,
-        "label": "Glance",
-        "value": "Calendar",
-        "caption": "DeskBox official native package"
+      "fallback": {
+        "template": "status",
+        "message": "Glance is unavailable. Install or restart DeskBox."
       }
     }
   ],

--- a/src/DeskBox/Services/Plugins/NativeWidgetPackageLoader.cs
+++ b/src/DeskBox/Services/Plugins/NativeWidgetPackageLoader.cs
@@ -41,19 +41,22 @@ internal sealed record NativePackageDescriptor(
 }
 
 /// <summary>
-/// Structurally paired installed-package handle: the record and its resolved
-/// install root travel together and can only be produced through
-/// PluginPackageManager.TryCreateNativeHandle - the runtime never accepts a
-/// separable "verified package + arbitrary path" pair.
+/// Structurally paired installed-package handle: the registry record, the
+/// verified package model, and the resolved install root travel together and
+/// can only be produced through PluginPackageManager.TryCreateNativeHandle.
+/// The verified model carries the actual EntryMain (not a runtime guess).
 /// </summary>
 public sealed record NativeInstalledPackageHandle
 {
     internal InstalledPackageRecord Record { get; }
+    internal VerifiedPluginPackage Verified { get; }
     internal string InstallRoot { get; }
+    internal string EntryMain => Verified.EntryMain ?? "package.dll";
 
-    internal NativeInstalledPackageHandle(InstalledPackageRecord record, string installRoot)
+    internal NativeInstalledPackageHandle(InstalledPackageRecord record, VerifiedPluginPackage verified, string installRoot)
     {
         Record = record;
+        Verified = verified;
         InstallRoot = installRoot;
     }
 }
@@ -217,13 +220,21 @@ internal static class NativeWidgetRuntimeManager
             App.LogVerbose($"[NativePackage] installed package {record.PackageId} runtime '{record.Runtime}' is not native; refusing to activate");
             return false;
         }
+        // Contribution must exist in the verified manifest before the runtime
+        // forwards it to the package DLL (audit round 13 §22).
+        if (!handle.Verified.Contributions.Any(contribution =>
+                string.Equals(contribution.Id, contributionId, StringComparison.Ordinal)))
+        {
+            App.LogVerbose($"[NativePackage] contribution '{contributionId}' not found in {record.PackageId}; refusing to create");
+            return false;
+        }
         return TryCreateInstance(
             new NativePackageDescriptor(
                 record.PublisherFingerprint,
                 record.PackageId,
                 record.ContentHash,
                 handle.InstallRoot,
-                NativeWidgetPackageLoader.ProductEntryModuleFileName),
+                handle.EntryMain),
             contributionId,
             instanceId,
             dataDirectory,
@@ -348,18 +359,21 @@ internal sealed unsafe class NativePackageSession
         {
             status = create(contribution, contributionId.Length, instance, instanceId.Length, dataRoot, instanceDataRoot.Length, &handle, &viewAbi);
         }
-        if (status != 0)
+        // Creation transaction (audit round 13): any incomplete output is
+        // rolled back regardless of the reported status - a partial success
+        // must never leave an untracked instance or a leaked ABI reference.
+        if (status != 0 || handle == 0 || viewAbi == 0)
         {
-            // Partial outputs (handle/view set despite failure) must be rolled
-            // back so the package never keeps an untracked instance.
             if (handle != 0) DestroyWidget(handle);
             if (viewAbi != 0) WinRT.MarshalInspectable<Microsoft.UI.Xaml.FrameworkElement>.DisposeAbi(viewAbi);
-            App.Log($"[NativePackage] create {contributionId}/{instanceId} failed: 0x{status:X8}");
-            return null;
-        }
-        if (handle == 0 || viewAbi == 0)
-        {
-            App.Log($"[NativePackage] create {contributionId}/{instanceId} returned incomplete outputs");
+            if (status != 0)
+            {
+                App.Log($"[NativePackage] create {contributionId}/{instanceId} failed: 0x{status:X8}");
+            }
+            else
+            {
+                App.Log($"[NativePackage] create {contributionId}/{instanceId} returned incomplete outputs (handle={handle:X}, view={viewAbi:X}); rolled back");
+            }
             return null;
         }
         Microsoft.UI.Xaml.FrameworkElement? view = null;

--- a/src/DeskBox/Services/Plugins/PluginPackageManager.cs
+++ b/src/DeskBox/Services/Plugins/PluginPackageManager.cs
@@ -150,7 +150,32 @@ public sealed class PluginPackageManager
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
         InstalledPackageRecord? record = Find(packageId);
         if (record is null || record.Runtime != NativeWidgetRuntimeManager.NativeRuntimeType) return null;
-        return new NativeInstalledPackageHandle(record, ResolveInstallPath(record));
+        // Native packages are in-process full-trust code; Development-mode
+        // records are refused unless the explicit dev override is set (audit
+        // round 13 §5: a valid signature alone is insufficient - the publisher
+        // must be trusted, which Development-mode records skip by design).
+        if (record.IsDevelopment &&
+            Environment.GetEnvironmentVariable("DESKBOX_ALLOW_UNTRUSTED_NATIVE_DEV") != "1")
+        {
+            return null;
+        }
+        string installRoot = ResolveInstallPath(record);
+        // Re-verify the installed content and rebuild the typed model; the
+        // runtime needs the actual EntryMain, not a hardcoded DLL name.
+        PluginPackageVerifier.VerificationResult verification = PluginPackageVerifier.Verify(installRoot, PluginPackageVerificationPolicy.Store);
+        if (!verification.IsValid) return null;
+        try
+        {
+            using var document = System.Text.Json.JsonDocument.Parse(
+                System.IO.File.ReadAllText(Path.Combine(installRoot, "manifest.json")));
+            VerifiedPluginPackage? verified = BuildVerifiedModel(document.RootElement, record.ContentHash);
+            if (verified is null) return null;
+            return new NativeInstalledPackageHandle(record, verified, installRoot);
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     public bool Uninstall(string packageId)
@@ -283,7 +308,8 @@ public sealed class PluginPackageManager
                 contributions.Add(new VerifiedContribution(
                     contribution.GetProperty("id").GetString()!,
                     contribution.GetProperty("displayName").GetString()!,
-                    contribution.GetProperty("template").GetString()!,
+                    // Template is optional for runtime:native (native renders via its own DLL).
+                    contribution.TryGetProperty("template", out JsonElement templateElement) ? templateElement.GetString()! : "native",
                     payloadFields,
                     bindings)
                 {

--- a/src/DeskBox/Services/Plugins/PluginPackageVerifier.cs
+++ b/src/DeskBox/Services/Plugins/PluginPackageVerifier.cs
@@ -67,7 +67,7 @@ public static partial class PluginPackageVerifier
         [.. RootRequired, "permissions", "data", "signature", "fallback", "dataSources", "actions", "entry"];
 
     private static readonly string[] WidgetClosed =
-        ["type", "id", "displayName", "template", "payload", "bindings", "defaultSize", "activationEvents"];
+        ["type", "id", "displayName", "template", "payload", "bindings", "defaultSize", "activationEvents", "fallback"];
 
     private static readonly string[] Templates =
         ["metric", "list", "status", "gallery", "action-list", "simple-form"];
@@ -261,7 +261,7 @@ public static partial class PluginPackageVerifier
         {
             foreach (JsonProperty property in entry.EnumerateObject())
             {
-                if (property.Name != "main")
+                if (property.Name != "main" && property.Name != "architecture")
                 {
                     Fail($"entry: unknown property '{property.Name}'");
                 }
@@ -279,6 +279,33 @@ public static partial class PluginPackageVerifier
                 else if (!File.Exists(Path.Combine(packageDirectory, entryMain)))
                 {
                     Fail($"entry.main file not found in package: {entryMain}");
+                }
+            }
+            // Architecture cross-check for native packages (audit round 13):
+            // the manifest claim must match the PE machine header of the DLL.
+            string? architecture = StringValue(entry, "architecture");
+            if (runtime is "native")
+            {
+                if (architecture is not ("x64" or "arm64"))
+                {
+                    Fail("runtime:native requires entry.architecture (x64 or arm64)");
+                }
+                else if (StringValue(entry, "main") is { } nativeEntry &&
+                         File.Exists(Path.Combine(packageDirectory, nativeEntry)))
+                {
+                    ushort? machine = ReadPeMachine(Path.Combine(packageDirectory, nativeEntry));
+                    if (machine is null)
+                    {
+                        Fail($"entry.main is not a valid PE file: {nativeEntry}");
+                    }
+                    else
+                    {
+                        ushort expected = architecture == "x64" ? (ushort)0x8664 : (ushort)0xAA64;
+                        if (machine != expected)
+                        {
+                            Fail($"entry.architecture '{architecture}' does not match PE machine 0x{machine.Value:X4}");
+                        }
+                    }
                 }
             }
         }
@@ -358,7 +385,12 @@ public static partial class PluginPackageVerifier
                 Fail($"{where}: must be an object");
                 continue;
             }
-            foreach (string key in new[] { "type", "id", "displayName", "template" })
+            // template is required for non-native runtimes; optional for native
+            // (native packages render via their own DLL, audit round 13 §2).
+            bool isNativeRuntime = StringValue(root, "runtime") == "native";
+            foreach (string key in isNativeRuntime
+                ? new[] { "type", "id", "displayName" }
+                : new[] { "type", "id", "displayName", "template" })
             {
                 if (!contribution.TryGetProperty(key, out _))
                 {
@@ -395,9 +427,27 @@ public static partial class PluginPackageVerifier
             {
                 Fail($"{where}: displayName must be a non-empty string");
             }
-            if (StringValue(contribution, "template") is not { } template || !Templates.Contains(template))
+            if (contribution.TryGetProperty("template", out JsonElement templateElement))
             {
-                Fail($"{where}: template enum");
+                string? template = StringValue(contribution, "template");
+                if (template is null || !Templates.Contains(template))
+                {
+                    Fail($"{where}: template enum");
+                }
+            }
+            if (contribution.TryGetProperty("fallback", out JsonElement fallback) && fallback.ValueKind == JsonValueKind.Object)
+            {
+                foreach (JsonProperty fallbackProperty in fallback.EnumerateObject())
+                {
+                    if (fallbackProperty.Name is not ("template" or "message"))
+                    {
+                        Fail($"{where}.fallback: unknown property '{fallbackProperty.Name}'");
+                    }
+                }
+                if (StringValue(fallback, "template") is not "status")
+                {
+                    Fail($"{where}.fallback.template must be 'status'");
+                }
             }
 
             if (contribution.TryGetProperty("defaultSize", out JsonElement size))
@@ -886,6 +936,27 @@ public static partial class PluginPackageVerifier
     // the integrity strings must denote the same object.
     private static readonly string[] ReservedDeviceNames =
         ["CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"];
+
+    // ---------- PE machine header reader (architecture cross-check) ----------
+    /// <summary>Reads the Machine field from a PE/COFF header, or null if not a valid PE.</summary>
+    internal static ushort? ReadPeMachine(string filePath)
+    {
+        try
+        {
+            using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var reader = new BinaryReader(stream);
+            stream.Position = 0x3C;
+            uint peOffset = reader.ReadUInt32();
+            stream.Position = peOffset;
+            uint signature = reader.ReadUInt32();
+            if (signature != 0x4550) return null; // "PE\0\0"
+            return reader.ReadUInt16(); // Machine field
+        }
+        catch
+        {
+            return null;
+        }
+    }
 
     // ---------- package path grammar (zip-slip defense, shared with the Node tooling) ----------
     internal static string? PackagePathViolation(string relativePath)


### PR DESCRIPTION
Round-13 audit absorbed (7 items fixed, 3 wording/design corrections): (1) incomplete-output rollback: any partial create result (handle!=0 or viewAbi!=0 regardless of status) is now rolled back - orphan instances and ABI leaks eliminated; (2) EntryMain flows through the verified model: NativeInstalledPackageHandle carries the full VerifiedPluginPackage and TryCreateFromInstalled uses the actual verified EntryMain, not a hardcoded 'package.dll' constant; (3) contribution template is now optional for runtime:native (native packages render via their own DLL) and a fallback block (template:status + message) is added to the schema for host-side placeholder rendering when the native runtime is unavailable; (4) architecture field: manifest requires entry.architecture (x64/arm64), cross-validated against the PE machine header of the actual DLL (AMD64/ARM64) - install refuses on mismatch before LoadLibrary can fail; (5) Dev policy native gate: TryCreateNativeHandle refuses IsDevelopment records unless DESKBOX_ALLOW_UNTRUSTED_NATIVE_DEV=1 (a self-signed third-party native package can no longer enter the process via Development mode); (6) contribution ID is validated against the verified manifest before the runtime forwards it to the DLL (placeholder-eligible failures now detectable at host level); (7) build script required XAML files fail-fast (no more silently-fresh cryptographically-valid packages missing runtime XAML). Suite 3550/3550.