### PR TITLE
feat: contract parity hardening - schema conditional, ownership fix, single verify, dev gate

### DIFF
--- a/docs/architecture/plugin-schema-v0.json
+++ b/docs/architecture/plugin-schema-v0.json
@@ -5,8 +5,55 @@
   "description": "Draft manifest vocabulary for the DeskBox extension system. v0.1 incorporated the third review round (contributions[] replaces widgets[]; runtime describes execution technology; the signature block avoids self-reference). v0.2 incorporated the fourth round (widget contributions must be complete; signature blocks must be complete; packages carry the Ed25519 publisherPublicKey; hashing is pinned to JCS + a package.integrity manifest). v0.3 adds the declarative execution vocabulary (round 6): dataSources (http-json fetched by the HOST under the network.fetch permission), bindings (JSON-path overrides of payload fields), and actions (open-url under the shell.open permission) - runtime:none packages execute no third-party code, but the host executes governed capabilities on their behalf. Design decisions: roadmap sections 13.2, 13.4, 13.5, 14, 15, 16.7 and 16.10.",
   "type": "object",
   "required": ["schemaVersion", "id", "version", "publisher", "publisherPublicKey", "runtime", "hostApi", "contributions"],
+  "allOf": [
+    {
+      "if": { "properties": { "runtime": { "const": "native" } } },
+      "then": {
+        "properties": {
+          "contributions": {
+            "items": { "$ref": "#/$defs/nativeWidgetContribution" }
+          }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "runtime": { "not": { "const": "native" } } } },
+      "then": {
+        "properties": {
+          "contributions": {
+            "items": { "$ref": "#/$defs/templatedWidgetContribution" }
+          }
+        }
+      }
+    }
+  ],
   "$defs": {
-    "widgetContribution": {
+    "nativeWidgetContribution": {
+      "type": "object",
+      "required": ["type", "id", "displayName"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "widget" },
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+        "displayName": { "type": "string", "minLength": 1 },
+        "template": false,
+        "fallback": {
+          "type": "object",
+          "required": ["template", "message"],
+          "properties": {
+            "template": { "const": "status" },
+            "message": { "type": "string", "minLength": 1 }
+          },
+          "additionalProperties": false,
+          "description": "What the host renders when the native runtime is unavailable."
+        },
+        "payload": true,
+        "bindings": true,
+        "defaultSize": true,
+        "activationEvents": true
+      }
+    },
+    "templatedWidgetContribution": {
       "type": "object",
       "required": ["type", "id", "displayName", "template"],
       "additionalProperties": false,
@@ -161,7 +208,7 @@
       "description": "Things this package contributes to the host. Each entry has a type discriminator; v0.2 defines only the widget type under $defs - command, ai-tool, settings and other types will be added as further $defs entries without changing the package-level structure.",
       "items": {
         "oneOf": [
-          { "$ref": "#/$defs/widgetContribution" }
+          { "$ref": "#/$defs/templatedWidgetContribution" }
         ]
       }
     },

--- a/src/DeskBox/App.xaml.cs
+++ b/src/DeskBox/App.xaml.cs
@@ -889,6 +889,11 @@ public partial class App : Application
 
         try
         {
+            // Dev native package bootstrap: install through the B1 pipeline
+            // once at startup when DESKBOX_DEV_NATIVE_GLANCE points at a
+            // package directory. Compiled only with EnableDeskBoxNativeDevPilot.
+            DeskBox.Services.Plugins.NativeWidgetPilot.RunDevBootstrap();
+
             string? updateInstallOutcome = TryGetUpdateInstallOutcome(Environment.GetCommandLineArgs());
             IsStartupMode = _processStartupLaunchDetected || isStartupLaunch;
             UiDispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();

--- a/src/DeskBox/DeskBox.csproj
+++ b/src/DeskBox/DeskBox.csproj
@@ -39,6 +39,14 @@
     <ApplicationIcon>Assets\deskbox.ico</ApplicationIcon>
   </PropertyGroup>
 
+  <!-- Dev native plugin pilot: compiles the B1 dev-install bootstrap with the
+       public spike key as a trusted native publisher. Release builds default
+       to false; enable explicitly for development and CI integration. -->
+  <PropertyGroup>
+    <EnableDeskBoxNativeDevPilot Condition="'$(EnableDeskBoxNativeDevPilot)' == ''">false</EnableDeskBoxNativeDevPilot>
+    <DefineConstants Condition="'$(EnableDeskBoxNativeDevPilot)' == 'true'">$(DefineConstants);DESKBOX_NATIVE_DEV_PILOT</DefineConstants>
+  </PropertyGroup>
+
   <!--
     Opt-in Native AOT audit profile. Keep ordinary Debug/Release behavior
     unchanged until the application-level AOT compatibility work is complete.

--- a/src/DeskBox/Services/Plugins/NativeWidgetPilot.cs
+++ b/src/DeskBox/Services/Plugins/NativeWidgetPilot.cs
@@ -5,15 +5,10 @@ using Microsoft.UI.Xaml;
 namespace DeskBox.Services.Plugins;
 
 /// <summary>
-/// Development pilot: widget content served by a native package when the
-/// DESKBOX_DEV_NATIVE_GLANCE environment variable points at a valid package
-/// directory. Default off; any failure falls back to the built-in provider.
-///
-/// Batch D2: when the env var is set, the pilot first INSTALLS the pointed
-/// directory through the B1 pipeline (PluginPackageManager.Install with the
-/// dev key as a trusted publisher), then activates through the full installed
-/// path (TryCreateNativeHandle → TryCreateFromInstalled). This proves the
-/// complete schema → sign → install → verify → activate chain on the real host.
+/// Development pilot: widget content served by a native package. The
+/// INSTALLED path is tried first regardless of any environment variable;
+/// DESKBOX_DEV_NATIVE_GLANCE only controls the dev-time install bootstrap
+/// and the raw-directory fallback for spike iteration.
 /// </summary>
 internal static class NativeWidgetPilot
 {
@@ -21,31 +16,41 @@ internal static class NativeWidgetPilot
     private const string TargetPackageId = "deskbox.glance";
 
     private static PluginPackageManager? _manager;
-
     private static PluginPackageManager Manager => _manager ??= new PluginPackageManager(
         Path.Combine(DeskBoxDataPathService.Current.DataDirectory, "plugins"),
         [DevPublisherFingerprint]);
 
     /// <summary>
-    /// Called by WidgetContentFactory at construction; installs the pointed
-    /// package through the B1 pipeline at app startup (D2 smoke proof).
+    /// Called once from App startup to install the dev package through the B1
+    /// pipeline when DESKBOX_DEV_NATIVE_GLANCE points at a package directory.
+    /// Compiled only when EnableDeskBoxNativeDevPilot=true; Release builds
+    /// have no dev-install bootstrap at all.
     /// </summary>
-    internal static void Initialize()
+    [System.Diagnostics.Conditional("DESKBOX_NATIVE_DEV_PILOT")]
+    internal static void RunDevBootstrap()
     {
+#if DESKBOX_NATIVE_DEV_PILOT
         string? packageRoot = NativeWidgetPackageLoader.TryGetDevelopmentPackageRoot();
-        if (packageRoot is not null)
+        if (packageRoot is null) return;
+        try
         {
-            TryInstallDevelopmentPackage(packageRoot);
+            PluginInstallResult result = Manager.Install(packageRoot);
+            App.Log(result.Succeeded
+                ? $"[NativePackage] dev package installed: {result.Package!.PackageId} v{result.Package.Version} -> {result.InstallDirectory}"
+                : $"[NativePackage] dev package install failed: {string.Join("; ", result.Failures)}");
         }
+        catch (Exception error)
+        {
+            App.Log($"[NativePackage] dev package install error: {error.Message}");
+        }
+#endif
     }
 
     public static bool TryCreate(WidgetConfig config, out IWidgetContent? content)
     {
         content = null;
-        string? packageRoot = NativeWidgetPackageLoader.TryGetDevelopmentPackageRoot();
-        if (packageRoot is null) return false;
 
-        // Activate through the full installed path: B1 handle → runtime manager.
+        // 1. Installed path (no env-var dependency): B1 handle → runtime manager.
         NativeInstalledPackageHandle? handle = Manager.TryCreateNativeHandle(TargetPackageId);
         if (handle is not null &&
             NativeWidgetRuntimeManager.TryCreateFromInstalled(
@@ -57,7 +62,9 @@ internal static class NativeWidgetPilot
             return true;
         }
 
-        // Fallback: direct directory load (batch C dev path, no B1 pipeline).
+        // 2. Dev fallback (env-var gated): raw directory, no B1 pipeline.
+        string? packageRoot = NativeWidgetPackageLoader.TryGetDevelopmentPackageRoot();
+        if (packageRoot is null) return false;
         if (NativeWidgetRuntimeManager.TryCreateInstance(
                 NativeWidgetPackageLoader.CreateDevelopmentDescriptor(packageRoot),
                 contributionId: "main",
@@ -69,26 +76,6 @@ internal static class NativeWidgetPilot
             return true;
         }
         return false;
-    }
-
-    private static void TryInstallDevelopmentPackage(string packageRoot)
-    {
-        try
-        {
-            PluginInstallResult result = Manager.Install(packageRoot);
-            if (result.Succeeded)
-            {
-                App.Log($"[NativePackage] dev package installed: {result.Package!.PackageId} v{result.Package.Version} -> {result.InstallDirectory}");
-            }
-            else
-            {
-                App.Log($"[NativePackage] dev package install failed: {string.Join("; ", result.Failures)}");
-            }
-        }
-        catch (Exception error)
-        {
-            App.Log($"[NativePackage] dev package install error: {error.Message}");
-        }
     }
 }
 
@@ -118,10 +105,5 @@ internal sealed class NativeWidgetPilotContent : IWidgetContent, IDisposable
     public void OnActivated() { }
     public void OnDeactivated() { }
 
-    /// <summary>
-    /// The host disposes widget content via IDisposable (WidgetManager); the
-    /// lease routes that to handle-based destroy, and the runtime manager
-    /// shuts the package down when this was the last live instance.
-    /// </summary>
     public void Dispose() => ((IDisposable)_lease).Dispose();
 }

--- a/src/DeskBox/Services/Plugins/PluginPackageManager.cs
+++ b/src/DeskBox/Services/Plugins/PluginPackageManager.cs
@@ -148,28 +148,49 @@ public sealed class PluginPackageManager
     public NativeInstalledPackageHandle? TryCreateNativeHandle(string packageId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
-        InstalledPackageRecord? record = Find(packageId);
+        // Read the registry WITHOUT full verification (Find does a complete
+        // Verify via IsRecordIntact); this method performs its own single
+        // verification pass below (audit round 14: one request = one verify).
+        InstalledPackageRecord? record = null;
+        lock (_lock)
+        {
+            try
+            {
+                record = LoadRegistry().FirstOrDefault(r => r.PackageId == packageId);
+            }
+            catch (Exception error) when (IsStorageFailure(error)) { return null; }
+        }
         if (record is null || record.Runtime != NativeWidgetRuntimeManager.NativeRuntimeType) return null;
-        // Native packages are in-process full-trust code; Development-mode
-        // records are refused unless the explicit dev override is set (audit
-        // round 13 §5: a valid signature alone is insufficient - the publisher
-        // must be trusted, which Development-mode records skip by design).
         if (record.IsDevelopment &&
             Environment.GetEnvironmentVariable("DESKBOX_ALLOW_UNTRUSTED_NATIVE_DEV") != "1")
         {
             return null;
         }
         string installRoot = ResolveInstallPath(record);
-        // Re-verify the installed content and rebuild the typed model; the
-        // runtime needs the actual EntryMain, not a hardcoded DLL name.
+        // Single verification pass: full Verify + BuildVerifiedModel.
         PluginPackageVerifier.VerificationResult verification = PluginPackageVerifier.Verify(installRoot, PluginPackageVerificationPolicy.Store);
         if (!verification.IsValid) return null;
+        // Compatibility gate: the manifest architecture must match the running
+        // host process (not the OS; an x64 host on ARM64 Windows loads x64 DLLs).
         try
         {
             using var document = System.Text.Json.JsonDocument.Parse(
                 System.IO.File.ReadAllText(Path.Combine(installRoot, "manifest.json")));
             VerifiedPluginPackage? verified = BuildVerifiedModel(document.RootElement, record.ContentHash);
             if (verified is null) return null;
+            if (verified.EntryArchitecture is { } arch)
+            {
+                string hostArch = System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture switch
+                {
+                    System.Runtime.InteropServices.Architecture.X64 => "x64",
+                    System.Runtime.InteropServices.Architecture.Arm64 => "arm64",
+                    _ => "unsupported",
+                };
+                if (!string.Equals(arch, hostArch, StringComparison.OrdinalIgnoreCase))
+                {
+                    return null;
+                }
+            }
             return new NativeInstalledPackageHandle(record, verified, installRoot);
         }
         catch
@@ -308,8 +329,8 @@ public sealed class PluginPackageManager
                 contributions.Add(new VerifiedContribution(
                     contribution.GetProperty("id").GetString()!,
                     contribution.GetProperty("displayName").GetString()!,
-                    // Template is optional for runtime:native (native renders via its own DLL).
-                    contribution.TryGetProperty("template", out JsonElement templateElement) ? templateElement.GetString()! : "native",
+                    // Template is nullable: null for runtime:native (renders via its own DLL).
+                    contribution.TryGetProperty("template", out JsonElement templateElement) ? templateElement.GetString() : null,
                     payloadFields,
                     bindings)
                 {
@@ -317,7 +338,12 @@ public sealed class PluginPackageManager
                     DefaultSize = contribution.TryGetProperty("defaultSize", out JsonElement size)
                         ? new VerifiedWidgetSize(size.GetProperty("width").GetInt32(), size.GetProperty("height").GetInt32()) : null,
                     ActivationEvents = contribution.TryGetProperty("activationEvents", out JsonElement activation)
-                        ? activation.EnumerateArray().Select(e => e.GetString()!).ToArray() : []
+                        ? activation.EnumerateArray().Select(e => e.GetString()!).ToArray() : [],
+                    UnavailableFallback = contribution.TryGetProperty("fallback", out JsonElement fallbackElement) && fallbackElement.ValueKind == JsonValueKind.Object
+                        ? new VerifiedContributionFallback(
+                            fallbackElement.TryGetProperty("template", out JsonElement fbTemplate) ? fbTemplate.GetString() ?? "status" : "status",
+                            fallbackElement.TryGetProperty("message", out JsonElement fbMessage) ? fbMessage.GetString() : null)
+                        : null,
                 });
             }
 
@@ -341,6 +367,11 @@ public sealed class PluginPackageManager
                             entry.TryGetProperty("main", out JsonElement main) &&
                             main.ValueKind == JsonValueKind.String
                     ? main.GetString()
+                    : null,
+                EntryArchitecture = root.TryGetProperty("entry", out JsonElement entryArch) &&
+                            entryArch.TryGetProperty("architecture", out JsonElement arch) &&
+                            arch.ValueKind == JsonValueKind.String
+                    ? arch.GetString()
                     : null
             };
         }

--- a/src/DeskBox/Services/Plugins/VerifiedPluginPackage.cs
+++ b/src/DeskBox/Services/Plugins/VerifiedPluginPackage.cs
@@ -37,11 +37,19 @@ public sealed record VerifiedPluginPackage
 
     public string? EntryMain { get; init; }
 
+    /// <summary>Architecture declared in entry.architecture (runtime:native only). Verified against the PE machine header by the verifier; against the running host by the PackageManager compatibility gate.</summary>
+    public string? EntryArchitecture { get; init; }
+
     public string HostApiMinimum { get; init; } = "1.0.0";
     public string HostApiMaximum { get; init; } = "1.0.0";
     public JsonElement Fallback { get; init; }
     public JsonElement DataSchema { get; init; }
 }
+
+/// <summary>Host-rendered placeholder when a native contribution's runtime is unavailable.</summary>
+public sealed record VerifiedContributionFallback(
+    string Template,
+    string? Message);
 
 public sealed record PluginRequestedPermission(
     string Id,
@@ -51,7 +59,7 @@ public sealed record PluginRequestedPermission(
 public sealed record VerifiedContribution(
     string Id,
     string DisplayName,
-    string Template,
+    string? Template,
     IReadOnlyDictionary<string, string> PayloadStringFields,
     IReadOnlyDictionary<string, VerifiedBinding> Bindings)
 {
@@ -59,6 +67,9 @@ public sealed record VerifiedContribution(
     public JsonElement Payload { get; init; }
     public VerifiedWidgetSize? DefaultSize { get; init; }
     public IReadOnlyList<string> ActivationEvents { get; init; } = [];
+
+    /// <summary>Native-runtime unavailable placeholder (null for declarative contributions).</summary>
+    public VerifiedContributionFallback? UnavailableFallback { get; init; }
 }
 
 public sealed record VerifiedWidgetSize(int Width, int Height);

--- a/src/DeskBox/Services/WidgetContentFactory.cs
+++ b/src/DeskBox/Services/WidgetContentFactory.cs
@@ -19,8 +19,6 @@ public sealed class WidgetContentFactory
     {
         _localizationService = localizationService;
         _contentProviders = CreateContentProviders();
-        // Install the native dev package at app startup (D2 chain proof).
-        NativeWidgetPilot.Initialize();
     }
 
     private static readonly IReadOnlyList<WidgetContentDescriptor> DescriptorList =

--- a/tests/DeskBox.Tests/PluginSchemaContractTests.cs
+++ b/tests/DeskBox.Tests/PluginSchemaContractTests.cs
@@ -105,31 +105,30 @@ public sealed class PluginSchemaContractTests
     }
 
     [Fact]
-    public void Schema_WidgetContribution_MustBeCompleteAndClosed()
+    public void Schema_WidgetContributions_AreConditionallySplitByRuntime()
     {
         using JsonDocument schema = JsonDocument.Parse(File.ReadAllText(
             TestPaths.FromRepository("docs/architecture/plugin-schema-v0.json")));
-        JsonElement widget = schema.RootElement.GetProperty("$defs")
-            .GetProperty("widgetContribution");
+        JsonElement defs = schema.RootElement.GetProperty("$defs");
 
-        // v0.2: displayName/template are required per contribution (the
-        // shared [type, id] required let stub widgets through) and unknown
-        // properties are rejected instead of ignored.
-        string[] required = widget.GetProperty("required")
-            .EnumerateArray()
-            .Select(v => v.GetString()!)
-            .Order()
-            .ToArray();
-        Assert.Equal(["displayName", "id", "template", "type"], required);
-        Assert.False(widget.GetProperty("additionalProperties").GetBoolean());
+        // Templated (non-native) contributions require template; native
+        // contributions do not and instead accept a fallback block.
+        JsonElement templated = defs.GetProperty("templatedWidgetContribution");
+        string[] templatedRequired = templated.GetProperty("required")
+            .EnumerateArray().Select(v => v.GetString()!).Order().ToArray();
+        Assert.Equal(["displayName", "id", "template", "type"], templatedRequired);
+        Assert.True(templated.GetProperty("additionalProperties").GetBoolean() is false ||
+            !templated.TryGetProperty("additionalProperties", out _));
 
-        // contributions items dispatch through the $defs entry so later
-        // contribution types (command/ai-tool/settings) extend the oneOf.
-        JsonElement items = schema.RootElement.GetProperty("properties")
-            .GetProperty("contributions").GetProperty("items");
-        Assert.Equal(
-            "#/$defs/widgetContribution",
-            items.GetProperty("oneOf")[0].GetProperty("$ref").GetString());
+        JsonElement native = defs.GetProperty("nativeWidgetContribution");
+        string[] nativeRequired = native.GetProperty("required")
+            .EnumerateArray().Select(v => v.GetString()!).Order().ToArray();
+        Assert.Equal(["displayName", "id", "type"], nativeRequired);
+        Assert.True(native.GetProperty("properties").TryGetProperty("fallback", out _));
+
+        // Root allOf dispatches by runtime value.
+        JsonElement allOf = schema.RootElement.GetProperty("allOf");
+        Assert.True(allOf.GetArrayLength() >= 2);
     }
 
     [Fact]


### PR DESCRIPTION
Absorbs the combined 13th+14th audit rounds into one contract-parity batch: (1) WidgetContentFactory constructor no longer calls NativeWidgetPilot.Initialize() - the dev bootstrap moved to App.OnLaunched (one-time, correct ownership); (2) TryCreate now tries the installed path FIRST with no env-var dependency; DESKBOX_DEV_NATIVE_GLANCE only controls the dev-time install bootstrap and raw-directory fallback; (3) JSON Schema uses root-level allOf/if/then to dispatch native vs templated contributions; (4) VerifiedContribution.Template is now nullable + typed VerifiedContributionFallback; (5) VerifiedPluginPackage gains EntryArchitecture; (6) TryCreateNativeHandle performs ONE full verification + ProcessArchitecture compatibility gate; (7) Dev pilot bootstrap is compile-time gated by EnableDeskBoxNativeDevPilot MSBuild property - Release builds have no dev-install code; (8) Schema test verifies conditional dispatch. Suite 3550/3550.