### PR TITLE
fix: audit 15 P0 - schema allOf conflict, publisher trust, identity binding

### DIFF
--- a/docs/architecture/plugin-schema-v0.json
+++ b/docs/architecture/plugin-schema-v0.json
@@ -208,6 +208,7 @@
       "description": "Things this package contributes to the host. Each entry has a type discriminator; v0.2 defines only the widget type under $defs - command, ai-tool, settings and other types will be added as further $defs entries without changing the package-level structure.",
       "items": {
         "oneOf": [
+          { "$ref": "#/$defs/nativeWidgetContribution" },
           { "$ref": "#/$defs/templatedWidgetContribution" }
         ]
       }

--- a/src/DeskBox/Services/Plugins/PluginPackageManager.cs
+++ b/src/DeskBox/Services/Plugins/PluginPackageManager.cs
@@ -148,9 +148,9 @@ public sealed class PluginPackageManager
     public NativeInstalledPackageHandle? TryCreateNativeHandle(string packageId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
-        // Read the registry WITHOUT full verification (Find does a complete
-        // Verify via IsRecordIntact); this method performs its own single
-        // verification pass below (audit round 14: one request = one verify).
+        // Read the registry without full verification (single-verify pattern,
+        // audit round 14). Publisher trust and identity binding are checked
+        // AFTER verification below (audit round 15 P0).
         InstalledPackageRecord? record = null;
         lock (_lock)
         {
@@ -166,18 +166,34 @@ public sealed class PluginPackageManager
         {
             return null;
         }
+        // Publisher authorization (audit round 15 P0: in-process full-trust
+        // native code must never be activated on signature validity alone).
+        if (!record.IsDevelopment && !_trustedPublishers.Contains(record.PublisherFingerprint)) return null;
         string installRoot = ResolveInstallPath(record);
-        // Single verification pass: full Verify + BuildVerifiedModel.
+        // Single verification pass with the ACTUAL content hash from disk.
         PluginPackageVerifier.VerificationResult verification = PluginPackageVerifier.Verify(installRoot, PluginPackageVerificationPolicy.Store);
         if (!verification.IsValid) return null;
-        // Compatibility gate: the manifest architecture must match the running
-        // host process (not the OS; an x64 host on ARM64 Windows loads x64 DLLs).
         try
         {
+            // Use the actual verified content hash, not the registry value
+            // (audit round 15 P0: registry hash may be stale or tampered).
+            string actualContentHash = PluginPackageVerifier.Sha256HexFile(
+                Path.Combine(installRoot, "package.integrity"));
             using var document = System.Text.Json.JsonDocument.Parse(
                 System.IO.File.ReadAllText(Path.Combine(installRoot, "manifest.json")));
-            VerifiedPluginPackage? verified = BuildVerifiedModel(document.RootElement, record.ContentHash);
+            VerifiedPluginPackage? verified = BuildVerifiedModel(document.RootElement, actualContentHash);
             if (verified is null) return null;
+            // Identity binding: the verified package must match the registry
+            // record on all identity dimensions (audit round 15 P0).
+            if (!string.Equals(verified.PackageId, record.PackageId, StringComparison.Ordinal) ||
+                !string.Equals(verified.PublisherFingerprint, record.PublisherFingerprint, StringComparison.Ordinal) ||
+                !string.Equals(verified.Version, record.Version, StringComparison.Ordinal) ||
+                !string.Equals(verified.Runtime, record.Runtime, StringComparison.Ordinal) ||
+                !string.Equals(verified.ContentHash, record.ContentHash, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+            // Compatibility gate: architecture must match the running host process.
             if (verified.EntryArchitecture is { } arch)
             {
                 string hostArch = System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture switch


### PR DESCRIPTION
Round-15 audit P0 fixes (3 items): (1) JSON Schema allOf conflict resolved - base contributions.items now accepts both nativeWidgetContribution and templatedWidgetContribution via oneOf, with the allOf conditionals narrowing to the correct type by runtime. Previously the base forced templated (template required) while allOf native forced forbidden = no valid native contribution. (2) Publisher authorization restored in TryCreateNativeHandle - the single-verify rewrite in #290 accidentally dropped the _trustedPublishers.Contains() check that was in Find->IsRecordIntact. In-process full-trust native code now requires the publisher to be in the trusted set. (3) Identity binding restored - BuildVerifiedModel now uses the ACTUAL verified content hash from disk (Sha256HexFile of package.integrity) instead of the registry record hash, and all five identity dimensions (PackageId, PublisherFingerprint, Version, Runtime, ContentHash) are compared between the registry record and the verified package before a handle is issued. Suite 3550/3550.