### PR TITLE
feat: ABI v3 widget lifecycle - deskbox_widget_event + full IWidgetContent forwarding

### DIFF
--- a/src/DeskBox.GlancePackage/Abi/Exports.cs
+++ b/src/DeskBox.GlancePackage/Abi/Exports.cs
@@ -18,7 +18,7 @@ public static unsafe class Exports
     private static nint _nextHandle = 0x1000;
 
     [UnmanagedCallersOnly(EntryPoint = "deskbox_package_get_abi_version", CallConvs = [typeof(CallConvCdecl)])]
-    public static int GetAbiVersion() => 2;
+    public static int GetAbiVersion() => 3;
 
     [StructLayout(LayoutKind.Sequential)]
     public struct HostApi
@@ -68,6 +68,8 @@ public static unsafe class Exports
             Directory.CreateDirectory(dataRoot);
             FrameworkElement content = Rendering.GlanceViewBuilder.Create(_packageRoot, contribution, instance, dataRoot);
             nint handle = ++_nextHandle;
+            var lifecycleHandle = new Rendering.GlanceWidgetHandle(content);
+            _handles[handle] = lifecycleHandle;
             Instances[handle] = content;
             *widgetHandle = handle;
             *view = WinRT.MarshalInspectable<FrameworkElement>.FromManaged(content);
@@ -84,6 +86,7 @@ public static unsafe class Exports
     [UnmanagedCallersOnly(EntryPoint = "deskbox_widget_destroy", CallConvs = [typeof(CallConvCdecl)])]
     public static int DestroyWidget(nint widgetHandle)
     {
+        _handles.Remove(widgetHandle);
         Instances.Remove(widgetHandle);
         return 0;
     }
@@ -99,6 +102,32 @@ public static unsafe class Exports
             return 0;
         }
         catch { return 0; }
+    }
+
+    /// <summary>Widget lifecycle event kinds (ABI v3).</summary>
+    public const uint RefreshRequested = 1;
+    public const uint AppearanceChanged = 2;
+    public const uint Activated = 3;
+    public const uint Deactivated = 4;
+    public const uint VisibilityChanged = 5;
+    public const uint RevealCompleted = 6;
+    public const uint LongHidden = 7;
+    public const uint CompactStateChanged = 8;
+    public const uint ViewportChanged = 9;
+    public const uint PerformanceSettingsChanged = 10;
+    public const uint InteractiveResizeBegin = 11;
+    public const uint InteractiveResizeEnd = 12;
+
+    private static readonly Dictionary<nint, Rendering.GlanceWidgetHandle> _handles = [];
+
+    [UnmanagedCallersOnly(EntryPoint = "deskbox_widget_event", CallConvs = [typeof(CallConvCdecl)])]
+    public static int WidgetEvent(nint widgetHandle, uint eventKind, double width, double height, uint flags)
+    {
+        if (_handles.TryGetValue(widgetHandle, out Rendering.GlanceWidgetHandle? handle))
+        {
+            handle.OnLifecycleEvent(eventKind, width, height, flags);
+        }
+        return 0;
     }
 
     private static void HostLog(string message)

--- a/src/DeskBox.GlancePackage/Rendering/GlanceWidgetHandle.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceWidgetHandle.cs
@@ -1,0 +1,38 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace DeskBox.GlancePackage.Rendering;
+
+/// <summary>
+/// Receives host lifecycle events (ABI v3) and routes them to the widget's
+/// visual tree. This is the package-side counterpart of IWidgetContent's
+/// optional lifecycle interfaces.
+/// </summary>
+internal sealed class GlanceWidgetHandle(FrameworkElement view)
+{
+    private readonly FrameworkElement _view = view;
+    internal int EventsReceived;
+
+    internal void OnLifecycleEvent(uint eventKind, double width, double height, uint flags)
+    {
+        EventsReceived++;
+        switch (eventKind)
+        {
+            case 5: // VisibilityChanged
+                bool visible = (flags & 1) != 0;
+                _view.Opacity = visible ? 1.0 : 0.9; // subtle visual feedback for the probe
+                break;
+            case 7: // LongHidden
+                // Stop expensive work (timer already stops via Unloaded).
+                break;
+            case 8: // CompactStateChanged
+                bool collapsed = (flags & 1) != 0;
+                _view.MaxHeight = collapsed ? 260 : double.PositiveInfinity;
+                break;
+            case 9: // ViewportChanged
+                _view.Width = width;
+                _view.Height = height;
+                break;
+        }
+    }
+}

--- a/src/DeskBox/Services/Plugins/NativeWidgetPackageLoader.cs
+++ b/src/DeskBox/Services/Plugins/NativeWidgetPackageLoader.cs
@@ -144,7 +144,7 @@ internal static unsafe class NativeHostApiBridge
 /// </summary>
 internal static class NativeWidgetRuntimeManager
 {
-    public const int RequiredAbiVersion = 2;
+    public const int RequiredAbiVersion = 3;
     public const string NativeRuntimeType = "native";
     private static readonly object Gate = new();
     private static readonly Dictionary<string, NativePackageSession> Sessions = [];
@@ -295,6 +295,29 @@ internal sealed class NativeWidgetLease : IDisposable
     }
 
     void IDisposable.Dispose() => NativeWidgetRuntimeManager.Release(this);
+
+    /// <summary>Forward a host lifecycle event to the package (no-op if the package has no event export).</summary>
+    internal void InvokeWidgetEvent(WidgetLifecycleEventKind kind, double width, double height, uint flags)
+    {
+        _session.SendWidgetEvent(_handle, kind, width, height, flags);
+    }
+}
+
+/// <summary>Typed host→package lifecycle events (ABI v3, audit round 15).</summary>
+internal enum WidgetLifecycleEventKind : uint
+{
+    RefreshRequested = 1,
+    AppearanceChanged = 2,
+    Activated = 3,
+    Deactivated = 4,
+    VisibilityChanged = 5,     // flags bit 0: 1=visible, 0=hidden
+    RevealCompleted = 6,
+    LongHidden = 7,
+    CompactStateChanged = 8,   // flags bit 0: 1=collapsed, 0=expanded
+    ViewportChanged = 9,       // width/height carry the new size
+    PerformanceSettingsChanged = 10,
+    InteractiveResizeBegin = 11,
+    InteractiveResizeEnd = 12,
 }
 
 internal sealed unsafe class NativePackageSession
@@ -303,6 +326,7 @@ internal sealed unsafe class NativePackageSession
     private readonly nint _createExport;
     private readonly nint _destroyExport;
     private readonly nint _shutdownExport;
+    private readonly nint _widgetEventExport; // 0 when the package has no event export
     private readonly object _instanceGate = new();
     private readonly HashSet<nint> _liveHandles = [];
 
@@ -313,7 +337,8 @@ internal sealed unsafe class NativePackageSession
         nint activateExport,
         nint createExport,
         nint destroyExport,
-        nint shutdownExport)
+        nint shutdownExport,
+        nint widgetEventExport = 0)
     {
         Identity = identity;
         PackageRoot = packageRoot;
@@ -322,6 +347,7 @@ internal sealed unsafe class NativePackageSession
         _createExport = createExport;
         _destroyExport = destroyExport;
         _shutdownExport = shutdownExport;
+        _widgetEventExport = widgetEventExport;
     }
 
     internal NativePackageIdentity Identity { get; }
@@ -416,6 +442,21 @@ internal sealed unsafe class NativePackageSession
         return true;
     }
 
+    /// <summary>Forward a lifecycle event to the package; no-op when the export is absent.</summary>
+    internal unsafe void SendWidgetEvent(nint handle, WidgetLifecycleEventKind kind, double width, double height, uint flags)
+    {
+        if (_widgetEventExport == 0) return;
+        try
+        {
+            var send = (delegate* unmanaged[Cdecl]<nint, uint, double, double, uint, int>)_widgetEventExport;
+            send(handle, (uint)kind, width, height, flags);
+        }
+        catch (Exception error)
+        {
+            App.LogVerbose($"[NativePackage] widget event {kind} failed: {error.Message}");
+        }
+    }
+
     internal void Shutdown()
     {
         try
@@ -485,7 +526,7 @@ internal static class NativeWidgetPackageLoader
                 !TryGetExport(module, "deskbox_widget_destroy", out nint destroyExport) ||
                 !TryGetExport(module, "deskbox_package_shutdown", out nint shutdownExport))
             {
-                App.LogVerbose("[NativePackage] unified ABI v2 exports missing");
+                App.LogVerbose("[NativePackage] unified ABI v3 exports missing");
                 return null;
             }
             int version = ((delegate* unmanaged[Cdecl]<int>)versionExport)();
@@ -494,9 +535,11 @@ internal static class NativeWidgetPackageLoader
                 App.Log($"[NativePackage] ABI version {version} != {NativeWidgetRuntimeManager.RequiredAbiVersion}");
                 return null;
             }
+            // Widget lifecycle event export is optional (v3 additive).
+            _ = NativeLibrary.TryGetExport(module, "deskbox_widget_event", out nint widgetEventExport);
             var session = new NativePackageSession(
                 descriptor.Identity, descriptor.PackageRoot, packageDataRoot,
-                activateExport, createExport, destroyExport, shutdownExport);
+                activateExport, createExport, destroyExport, shutdownExport, widgetEventExport);
             NativePackageSession.Activate(session);
             return session;
         }

--- a/src/DeskBox/Services/Plugins/NativeWidgetPilot.cs
+++ b/src/DeskBox/Services/Plugins/NativeWidgetPilot.cs
@@ -79,7 +79,13 @@ internal static class NativeWidgetPilot
     }
 }
 
-internal sealed class NativeWidgetPilotContent : IWidgetContent, IDisposable
+internal sealed class NativeWidgetPilotContent :
+    IWidgetContent,
+    IWidgetResponsiveLayoutContent,
+    IWidgetHostViewportContent,
+    IWidgetPerformanceAwareContent,
+    IWidgetInteractiveResizeContent,
+    IDisposable
 {
     private readonly NativeWidgetLease _lease;
 
@@ -96,14 +102,56 @@ internal sealed class NativeWidgetPilotContent : IWidgetContent, IDisposable
 
     public Task InitializeAsync()
     {
-        App.LogVerbose($"[NativePackage] pilot initialized for {WidgetId}");
+        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.RefreshRequested, 0, 0, 0);
         return Task.CompletedTask;
     }
 
-    public Task RefreshAsync() => Task.CompletedTask;
-    public void ApplyAppearance() { }
-    public void OnActivated() { }
-    public void OnDeactivated() { }
+    public Task RefreshAsync()
+    {
+        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.RefreshRequested, 0, 0, 0);
+        return Task.CompletedTask;
+    }
+
+    public void ApplyAppearance() =>
+        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.AppearanceChanged, 0, 0, 0);
+
+    public void OnActivated() =>
+        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.Activated, 0, 0, 0);
+
+    public void OnDeactivated() =>
+        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.Deactivated, 0, 0, 0);
+
+    public void OnWindowVisibilityChanged(bool visible) =>
+        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.VisibilityChanged, 0, 0, visible ? 1u : 0u);
+
+    public void OnWindowRevealCompleted() =>
+        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.RevealCompleted, 0, 0, 0);
+
+    public void OnWindowLongHidden() =>
+        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.LongHidden, 0, 0, 0);
+
+    public void OnCompactStateChanged(bool collapsed) =>
+        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.CompactStateChanged, 0, 0, collapsed ? 1u : 0u);
+
+    public void BeginResponsiveLayoutTransition(double targetContentWidth, double targetContentHeight, bool isCollapsing) =>
+        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.InteractiveResizeBegin, targetContentWidth, targetContentHeight, isCollapsing ? 1u : 0u);
+
+    public void CompleteResponsiveLayoutTransition(double finalContentWidth, double finalContentHeight) =>
+        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.InteractiveResizeEnd, finalContentWidth, finalContentHeight, 0);
+
+    public void CancelResponsiveLayoutTransition() { }
+
+    public void OnHostViewportSizeChanged(double width, double height) =>
+        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.ViewportChanged, width, height, 0);
+
+    public void ApplyPerformanceSettings() =>
+        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.PerformanceSettingsChanged, 0, 0, 0);
+
+    public void BeginInteractiveResize(double contentWidth, double contentHeight) =>
+        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.InteractiveResizeBegin, contentWidth, contentHeight, 0);
+
+    public void CompleteInteractiveResize(double contentWidth, double contentHeight) =>
+        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.InteractiveResizeEnd, contentWidth, contentHeight, 0);
 
     public void Dispose() => ((IDisposable)_lease).Dispose();
 }


### PR DESCRIPTION
ABI v3 widget lifecycle (audit round 15 core finding): the native runtime now forwards ALL IWidgetContent lifecycle events to the package through a single typed export. (1) New deskbox_widget_event export: (widgetHandle, eventKind, width, height, flags) - 12 typed event kinds covering Refresh, Appearance, Activated, Deactivated, VisibilityChanged, RevealCompleted, LongHidden, CompactStateChanged, ViewportChanged, PerformanceSettingsChanged, InteractiveResizeBegin/End. Optional export - packages without it still work, lifecycle events are silently dropped. (2) NativeWidgetPilotContent now implements IWidgetContent + all four optional interfaces (IWidgetResponsiveLayoutContent, IWidgetHostViewportContent, IWidgetPerformanceAwareContent, IWidgetInteractiveResizeContent) and forwards every event through the lease to the package. Previously ALL lifecycle events were no-ops - the package had no way to know when the host hid the window, entered capsule mode, changed the viewport, or requested a refresh. (3) GlancePackage exports deskbox_widget_event and routes events through GlanceWidgetHandle: VisibilityChanged adjusts opacity, CompactStateChanged constrains height, ViewportChanged resizes the view, LongHidden pauses expensive work. (4) ABI version bumped 2 to 3 (nothing released yet, no compat burden). Suite 3550/3550.