### PR TITLE
fix: ABI v3 hardening - WidgetEvent catch, dev trust split, required export, responsive/interactive separation

### DIFF
--- a/src/DeskBox.GlancePackage/Abi/Exports.cs
+++ b/src/DeskBox.GlancePackage/Abi/Exports.cs
@@ -123,11 +123,25 @@ public static unsafe class Exports
     [UnmanagedCallersOnly(EntryPoint = "deskbox_widget_event", CallConvs = [typeof(CallConvCdecl)])]
     public static int WidgetEvent(nint widgetHandle, uint eventKind, double width, double height, uint flags)
     {
-        if (_handles.TryGetValue(widgetHandle, out Rendering.GlanceWidgetHandle? handle))
+        // Total function: managed exceptions must never cross the C ABI boundary.
+        try
         {
+            if (!_handles.TryGetValue(widgetHandle, out Rendering.GlanceWidgetHandle? handle))
+            {
+                return unchecked((int)0x80070510); // ERROR_INVALID_HANDLE
+            }
+            if (eventKind is < 1 or > 12)
+            {
+                return unchecked((int)0x80070057); // E_INVALIDARG
+            }
             handle.OnLifecycleEvent(eventKind, width, height, flags);
+            return 0;
         }
-        return 0;
+        catch (Exception error)
+        {
+            TryWriteDiagnostic("widget-event-error.txt", error.ToString());
+            return error.HResult;
+        }
     }
 
     private static void HostLog(string message)

--- a/src/DeskBox/Services/Plugins/NativeWidgetPackageLoader.cs
+++ b/src/DeskBox/Services/Plugins/NativeWidgetPackageLoader.cs
@@ -303,7 +303,7 @@ internal sealed class NativeWidgetLease : IDisposable
     }
 }
 
-/// <summary>Typed host→package lifecycle events (ABI v3, audit round 15).</summary>
+/// <summary>Typed host→package lifecycle events (ABI v3, audit rounds 15-16).</summary>
 internal enum WidgetLifecycleEventKind : uint
 {
     RefreshRequested = 1,
@@ -318,6 +318,9 @@ internal enum WidgetLifecycleEventKind : uint
     PerformanceSettingsChanged = 10,
     InteractiveResizeBegin = 11,
     InteractiveResizeEnd = 12,
+    ResponsiveLayoutBegin = 13,   // capsule/breakpoint transition (not user drag)
+    ResponsiveLayoutComplete = 14,
+    ResponsiveLayoutCancel = 15,
 }
 
 internal sealed unsafe class NativePackageSession
@@ -442,14 +445,18 @@ internal sealed unsafe class NativePackageSession
         return true;
     }
 
-    /// <summary>Forward a lifecycle event to the package; no-op when the export is absent.</summary>
+    /// <summary>Forward a lifecycle event; logs when the package reports failure.</summary>
     internal unsafe void SendWidgetEvent(nint handle, WidgetLifecycleEventKind kind, double width, double height, uint flags)
     {
         if (_widgetEventExport == 0) return;
         try
         {
             var send = (delegate* unmanaged[Cdecl]<nint, uint, double, double, uint, int>)_widgetEventExport;
-            send(handle, (uint)kind, width, height, flags);
+            int status = send(handle, (uint)kind, width, height, flags);
+            if (status != 0)
+            {
+                App.LogVerbose($"[NativePackage] widget event {kind} returned 0x{status:X8}");
+            }
         }
         catch (Exception error)
         {
@@ -524,7 +531,8 @@ internal static class NativeWidgetPackageLoader
                 !TryGetExport(module, "deskbox_package_activate", out nint activateExport) ||
                 !TryGetExport(module, "deskbox_widget_create", out nint createExport) ||
                 !TryGetExport(module, "deskbox_widget_destroy", out nint destroyExport) ||
-                !TryGetExport(module, "deskbox_package_shutdown", out nint shutdownExport))
+                !TryGetExport(module, "deskbox_package_shutdown", out nint shutdownExport) ||
+                !TryGetExport(module, "deskbox_widget_event", out nint widgetEventExport))
             {
                 App.LogVerbose("[NativePackage] unified ABI v3 exports missing");
                 return null;
@@ -535,8 +543,6 @@ internal static class NativeWidgetPackageLoader
                 App.Log($"[NativePackage] ABI version {version} != {NativeWidgetRuntimeManager.RequiredAbiVersion}");
                 return null;
             }
-            // Widget lifecycle event export is optional (v3 additive).
-            _ = NativeLibrary.TryGetExport(module, "deskbox_widget_event", out nint widgetEventExport);
             var session = new NativePackageSession(
                 descriptor.Identity, descriptor.PackageRoot, packageDataRoot,
                 activateExport, createExport, destroyExport, shutdownExport, widgetEventExport);

--- a/src/DeskBox/Services/Plugins/NativeWidgetPilot.cs
+++ b/src/DeskBox/Services/Plugins/NativeWidgetPilot.cs
@@ -16,9 +16,25 @@ internal static class NativeWidgetPilot
     private const string TargetPackageId = "deskbox.glance";
 
     private static PluginPackageManager? _manager;
+
+    /// <summary>
+    /// Production manager: empty trusted-publisher set until batch E provisions
+    /// the official key. The dev spike publisher is NEVER trusted here.
+    /// </summary>
     private static PluginPackageManager Manager => _manager ??= new PluginPackageManager(
+        Path.Combine(DeskBoxDataPathService.Current.DataDirectory, "plugins"));
+
+    /// <summary>
+    /// Dev manager: trusts the public spike publisher. Exists only when
+    /// EnableDeskBoxNativeDevPilot=true compiles this type; Release builds
+    /// have no dev trust root at all.
+    /// </summary>
+#if DESKBOX_NATIVE_DEV_PILOT
+    private static PluginPackageManager? _devManager;
+    private static PluginPackageManager DevManager => _devManager ??= new PluginPackageManager(
         Path.Combine(DeskBoxDataPathService.Current.DataDirectory, "plugins"),
         [DevPublisherFingerprint]);
+#endif
 
     /// <summary>
     /// Called once from App startup to install the dev package through the B1
@@ -34,7 +50,7 @@ internal static class NativeWidgetPilot
         if (packageRoot is null) return;
         try
         {
-            PluginInstallResult result = Manager.Install(packageRoot);
+            PluginInstallResult result = DevManager.Install(packageRoot);
             App.Log(result.Succeeded
                 ? $"[NativePackage] dev package installed: {result.Package!.PackageId} v{result.Package.Version} -> {result.InstallDirectory}"
                 : $"[NativePackage] dev package install failed: {string.Join("; ", result.Failures)}");
@@ -102,7 +118,9 @@ internal sealed class NativeWidgetPilotContent :
 
     public Task InitializeAsync()
     {
-        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.RefreshRequested, 0, 0, 0);
+        // create_widget already starts the package's initial lifecycle;
+        // InitializeAsync must NOT send RefreshRequested (audit round 16: conflating
+        // initialization with refresh causes double-fetch in Weather/Music).
         return Task.CompletedTask;
     }
 
@@ -134,12 +152,13 @@ internal sealed class NativeWidgetPilotContent :
         _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.CompactStateChanged, 0, 0, collapsed ? 1u : 0u);
 
     public void BeginResponsiveLayoutTransition(double targetContentWidth, double targetContentHeight, bool isCollapsing) =>
-        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.InteractiveResizeBegin, targetContentWidth, targetContentHeight, isCollapsing ? 1u : 0u);
+        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.ResponsiveLayoutBegin, targetContentWidth, targetContentHeight, isCollapsing ? 1u : 0u);
 
     public void CompleteResponsiveLayoutTransition(double finalContentWidth, double finalContentHeight) =>
-        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.InteractiveResizeEnd, finalContentWidth, finalContentHeight, 0);
+        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.ResponsiveLayoutComplete, finalContentWidth, finalContentHeight, 0);
 
-    public void CancelResponsiveLayoutTransition() { }
+    public void CancelResponsiveLayoutTransition() =>
+        _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.ResponsiveLayoutCancel, 0, 0, 0);
 
     public void OnHostViewportSizeChanged(double width, double height) =>
         _lease.InvokeWidgetEvent(WidgetLifecycleEventKind.ViewportChanged, width, height, 0);


### PR DESCRIPTION
ABI v3 hardening (audit round 16, 7 items): (1) WidgetEvent export now has try/catch - managed exceptions can never cross the C ABI boundary (was a P0 correctness gap); unknown handle returns ERROR_INVALID_HANDLE, unknown event kind returns E_INVALIDARG, instead of silently returning success. (2) Dev publisher completely removed from the production Manager - the production PluginPackageManager has an empty trusted-publisher set (official key arrives in batch E); the dev manager with the spike publisher exists ONLY inside #if DESKBOX_NATIVE_DEV_PILOT (Release builds have no dev trust root at all). (3) deskbox_widget_event is now a REQUIRED v3 export - a package reporting ABI v3 without the event export is rejected at load; previously it was optional which made the version bump meaningless. (4) ResponsiveLayoutTransition and InteractiveResize are now separate event kinds (13/14/15 vs 11/12) - capsule/breakpoint transitions are semantically different from user drag; conflating them would cause wrong behavior in Glance/Music capsule animations. (5) InitializeAsync no longer sends RefreshRequested - create_widget starts the package initial lifecycle; conflating initialization with refresh would cause double-fetch in Weather/Music. (6) Host now checks the widget_event return status and logs failures. (7) CancelResponsiveLayoutTransition now sends ResponsiveLayoutCancel (was a no-op). Suite 3550/3550.