### PR TITLE
feat: D3 phase 2 - 6/7 source files now owned by the package

### DIFF
--- a/src/DeskBox.GlancePackage/Contracts/ICalendarPresentationSource.cs
+++ b/src/DeskBox.GlancePackage/Contracts/ICalendarPresentationSource.cs
@@ -1,0 +1,22 @@
+using System.Globalization;
+using DeskBox.Models;
+
+namespace DeskBox.Contracts;
+
+/// <summary>
+/// Owned by DeskBox.GlancePackage since D3 Phase 2 (copied from
+/// src/DeskBox.Abstractions/Contracts/ICalendarPresentationSource.cs).
+/// </summary>
+public interface ICalendarPresentationSource
+{
+    Task<GlanceCalendarMonth> GetMonthAsync(
+        DateOnly month,
+        CultureInfo culture,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<GlanceCalendarEvent>> GetAgendaAsync(
+        DateOnly startDate,
+        int dayCount,
+        CultureInfo culture,
+        CancellationToken cancellationToken = default);
+}

--- a/src/DeskBox.GlancePackage/DeskBox.GlancePackage.csproj
+++ b/src/DeskBox.GlancePackage/DeskBox.GlancePackage.csproj
@@ -30,15 +30,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.4.0" />
-    <!-- D3 phase 1: link production sources (D3 phase 2 will copy + delete from host). -->
-    <Compile Include="$(AbstractionsRoot)Models\GlanceCalendarModels.cs" Link="Linked\GlanceCalendarModels.cs" />
-    <Compile Include="$(AbstractionsRoot)Contracts\ICalendarPresentationSource.cs" Link="Linked\ICalendarPresentationSource.cs" />
-    <Compile Include="$(HostSourceRoot)Services\GlanceCalendarLayoutCalculator.cs" Link="Linked\GlanceCalendarLayoutCalculator.cs" />
-    <Compile Include="$(HostSourceRoot)Services\LocalCalendarPresentationSource.cs" Link="Linked\LocalCalendarPresentationSource.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- D3 Phase 2: these two large services still link from host; copy in next PR. -->
     <Compile Include="$(HostSourceRoot)Services\GlanceTraditionalCalendarService.cs" Link="Linked\GlanceTraditionalCalendarService.cs" />
-    <Compile Include="$(HostSourceRoot)Services\GlanceFestivalService.cs" Link="Linked\GlanceFestivalService.cs" />
-    <Compile Include="$(HostSourceRoot)Models\GlanceWidgetData.cs" Link="Linked\GlanceWidgetData.cs" />
-    <Compile Include="$(HostSourceRoot)Helpers\ChineseTextConverter.cs" Link="Linked\ChineseTextConverter.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Rendering\glance.xaml" CopyToOutputDirectory="PreserveNewest" />

--- a/src/DeskBox.GlancePackage/Models/GlanceCalendarModels.cs
+++ b/src/DeskBox.GlancePackage/Models/GlanceCalendarModels.cs
@@ -1,0 +1,36 @@
+namespace DeskBox.Models;
+
+/// <summary>
+/// Owned by DeskBox.GlancePackage since D3 Phase 2 (copied from
+/// src/DeskBox.Abstractions/Models/GlanceCalendarModels.cs).
+/// </summary>
+public sealed record GlanceCalendarDay(
+    DateOnly Date,
+    string DayText,
+    bool IsCurrentMonth,
+    bool IsToday,
+    string TraditionalText = "",
+    string FestivalText = "")
+{
+    public bool HasTraditionalText => !string.IsNullOrWhiteSpace(TraditionalText);
+    public bool HasFestival => !string.IsNullOrWhiteSpace(FestivalText);
+    public bool HasTraditionalTextOnly => HasTraditionalText && !HasFestival;
+    public bool HasSecondaryText => HasFestival || HasTraditionalText;
+}
+
+public sealed record GlanceCalendarMonth(
+    DateOnly Month,
+    IReadOnlyList<string> WeekdayHeaders,
+    IReadOnlyList<GlanceCalendarDay> Days,
+    string TraditionalTitle = "")
+{
+    public bool HasTraditionalTitle => !string.IsNullOrWhiteSpace(TraditionalTitle);
+}
+
+public sealed record GlanceCalendarEvent(
+    string Id,
+    string Title,
+    DateTimeOffset StartsAt,
+    DateTimeOffset EndsAt,
+    bool IsAllDay,
+    string? CalendarColor = null);

--- a/src/DeskBox.GlancePackage/Models/GlanceWidgetData.cs
+++ b/src/DeskBox.GlancePackage/Models/GlanceWidgetData.cs
@@ -1,0 +1,77 @@
+using System.Text.Json.Serialization;
+
+namespace DeskBox.Models;
+
+/// <summary>
+/// Owned by DeskBox.GlancePackage since D3 Phase 2 (copied from
+/// src/DeskBox/Models/GlanceWidgetData.cs).
+/// </summary>
+public enum GlanceBackgroundSource { Online, LocalFiles, LocalFolder, Bing }
+public enum GlanceOnlineImageProvider { Wikimedia, Bing }
+public enum GlanceOnlineImageCategory { Featured, Landscapes, Cities, Architecture, Animals, Plants, Astronomy, People }
+public enum GlanceLayoutMode { Immersive, Centered, Editorial, Calendar }
+public enum GlanceDisplayElement { Time, Date, Year, Weekday, Calendar }
+public enum GlanceTimeFormatMode { FollowSystem, Hour24, Hour12 }
+public enum GlanceTransitionMode { None, CrossFade, SlideFade, ZoomFade }
+public enum GlanceTransitionSpeed { Fast, Standard, Relaxed }
+public enum GlanceReadabilityMode { None, Soft, Strong }
+public enum GlanceCalendarMaterialMode { FollowSystem, FollowImage }
+public enum GlanceTraditionalCalendarMode
+{
+    None, Auto, ChineseLunar, UmAlQura, Hijri, IndianSaka,
+    JapaneseEra, Bangla, Julian, Hebrew, Persian, ThaiBuddhist
+}
+public enum GlanceImageFitMode { Fill, Fit }
+public enum GlanceImageFocus { Center, Top, Bottom, Left, Right }
+
+/// <summary>Versioned, portable preferences for one Glance widget.</summary>
+public sealed class GlanceWidgetData
+{
+    public const int CurrentVersion = 10;
+    public int Version { get; set; } = CurrentVersion;
+    public bool ShowTime { get; set; } = true;
+    public bool ShowDate { get; set; } = true;
+    public bool ShowYear { get; set; }
+    public bool ShowWeekday { get; set; } = true;
+    public bool ShowCalendar { get; set; }
+    public GlanceTimeFormatMode TimeFormat { get; set; } = GlanceTimeFormatMode.FollowSystem;
+    public GlanceLayoutMode Layout { get; set; } = GlanceLayoutMode.Centered;
+    public GlanceBackgroundSource BackgroundSource { get; set; } = GlanceBackgroundSource.Bing;
+    public GlanceOnlineImageCategory OnlineImageCategory { get; set; } = GlanceOnlineImageCategory.Featured;
+    public List<string> LocalImagePaths { get; set; } = [];
+    public string? LocalFolderPath { get; set; }
+    public double RotationIntervalMinutes { get; set; } = 30;
+    public bool RandomOrder { get; set; } = true;
+    public GlanceTransitionMode Transition { get; set; } = GlanceTransitionMode.CrossFade;
+    public GlanceTransitionSpeed TransitionSpeed { get; set; } = GlanceTransitionSpeed.Standard;
+    public GlanceReadabilityMode Readability { get; set; } = GlanceReadabilityMode.Soft;
+    public double BackgroundImageTransparency { get; set; }
+    public bool ShowPhotoControls { get; set; } = true;
+    public GlanceCalendarMaterialMode CalendarMaterialMode { get; set; } = GlanceCalendarMaterialMode.FollowSystem;
+    public double CalendarImageMaterialTransparency { get; set; } = 0.32;
+    public GlanceTraditionalCalendarMode TraditionalCalendarMode { get; set; } = GlanceTraditionalCalendarMode.None;
+    public bool ShowChineseFestivals { get; set; } = true;
+    public GlanceImageFitMode ImageFit { get; set; } = GlanceImageFitMode.Fill;
+    public GlanceImageFocus ImageFocus { get; set; } = GlanceImageFocus.Center;
+    public string? TimeFontFamily { get; set; }
+    public double TimeScale { get; set; } = 1;
+}
+
+public sealed class GlanceImageInfo
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+    public string LocalPath { get; set; } = string.Empty;
+    public string? Title { get; set; }
+    public string? Author { get; set; }
+    public string? License { get; set; }
+    public string? LicenseUrl { get; set; }
+    public string? SourcePageUrl { get; set; }
+    public string? RemoteImageUrl { get; set; }
+    public int PixelWidth { get; set; }
+    public int PixelHeight { get; set; }
+    public DateTimeOffset CachedAtUtc { get; set; }
+    public GlanceOnlineImageCategory OnlineCategory { get; set; } = GlanceOnlineImageCategory.Featured;
+    public GlanceOnlineImageProvider OnlineProvider { get; set; } = GlanceOnlineImageProvider.Wikimedia;
+    [JsonIgnore]
+    public bool IsOnline => !string.IsNullOrWhiteSpace(SourcePageUrl);
+}

--- a/src/DeskBox.GlancePackage/Services/ChineseTextConverter.cs
+++ b/src/DeskBox.GlancePackage/Services/ChineseTextConverter.cs
@@ -1,0 +1,78 @@
+using System.Runtime.InteropServices;
+
+namespace DeskBox.Helpers;
+
+/// <summary>
+/// Owned by DeskBox.GlancePackage since D3 Phase 2 (copied from
+/// src/DeskBox/Helpers/ChineseTextConverter.cs). The host retains its own
+/// copy for built-in widgets during the transition; ownership fully
+/// transfers when host Glance is deleted.
+/// </summary>
+internal static partial class ChineseTextConverter
+{
+    private const uint SimplifiedChinese = 0x02000000;
+    private const uint TraditionalChinese = 0x04000000;
+
+    public static string ToTraditional(string? value) => Convert(value, TraditionalChinese);
+
+    public static string ToSimplified(string? value) => Convert(value, SimplifiedChinese);
+
+    private static unsafe string Convert(string? value, uint mapFlag)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return value ?? string.Empty;
+        }
+
+        int requiredLength = LCMapStringEx(
+            "zh-CN",
+            mapFlag,
+            value,
+            value.Length,
+            null,
+            0,
+            IntPtr.Zero,
+            IntPtr.Zero,
+            IntPtr.Zero);
+        if (requiredLength <= 0)
+        {
+            return value;
+        }
+
+        var result = new char[requiredLength];
+        int written;
+        fixed (char* destination = result)
+        {
+            written = LCMapStringEx(
+                "zh-CN",
+                mapFlag,
+                value,
+                value.Length,
+                destination,
+                result.Length,
+                IntPtr.Zero,
+                IntPtr.Zero,
+                IntPtr.Zero);
+        }
+
+        return written > 0 && written <= result.Length
+            ? new string(result, 0, written)
+            : value;
+    }
+
+    [LibraryImport(
+        "kernel32.dll",
+        EntryPoint = "LCMapStringEx",
+        SetLastError = true,
+        StringMarshalling = StringMarshalling.Utf16)]
+    private static unsafe partial int LCMapStringEx(
+        string localeName,
+        uint mapFlags,
+        string source,
+        int sourceLength,
+        char* destination,
+        int destinationLength,
+        IntPtr versionInformation,
+        IntPtr reserved,
+        IntPtr sortHandle);
+}

--- a/src/DeskBox.GlancePackage/Services/GlanceCalendarLayoutCalculator.cs
+++ b/src/DeskBox.GlancePackage/Services/GlanceCalendarLayoutCalculator.cs
@@ -1,0 +1,40 @@
+namespace DeskBox.Services;
+
+/// <summary>
+/// Owned by DeskBox.GlancePackage since D3 Phase 2 (copied from
+/// src/DeskBox/Services/GlanceCalendarLayoutCalculator.cs).
+/// </summary>
+internal static class GlanceCalendarLayoutCalculator
+{
+    private const double CompactCalendarThreshold = 320;
+
+    public static bool IsCompact(double availableHeight) =>
+        availableHeight < CompactCalendarThreshold;
+
+    public static double CalculatePanelHeight(
+        double availableHeight,
+        bool isCompact,
+        bool hasTraditionalCalendar)
+    {
+        _ = hasTraditionalCalendar;
+        if (isCompact) return Math.Clamp(availableHeight - 40, 238, 268);
+        return Math.Clamp(availableHeight - 102, 244, 310);
+    }
+
+    public static double CalculateDayHeight(
+        double panelHeight,
+        bool isCompact,
+        bool hasTraditionalCalendar)
+    {
+        _ = hasTraditionalCalendar;
+        double fixedContentHeight = isCompact ? 104 : 58;
+        return Math.Clamp((panelHeight - fixedContentHeight) / 6, 24, 42);
+    }
+
+    public static bool ShouldShowTraditionalDetails(
+        double panelWidth,
+        double dayHeight,
+        bool isCompact,
+        bool hasTraditionalCalendar) =>
+        hasTraditionalCalendar && !isCompact && panelWidth >= 280 && dayHeight >= 28;
+}

--- a/src/DeskBox.GlancePackage/Services/GlanceFestivalService.cs
+++ b/src/DeskBox.GlancePackage/Services/GlanceFestivalService.cs
@@ -1,0 +1,83 @@
+using System.Globalization;
+using DeskBox.Helpers;
+using DeskBox.Models;
+
+namespace DeskBox.Services;
+
+/// <summary>
+/// Owned by DeskBox.GlancePackage since D3 Phase 2 (copied from
+/// src/DeskBox/Services/GlanceFestivalService.cs).
+/// </summary>
+internal sealed class GlanceFestivalService
+{
+    private readonly GlanceTraditionalCalendarService _traditionalCalendarService = new();
+
+    public GlanceCalendarMonth Apply(
+        GlanceCalendarMonth month,
+        bool showChineseFestivals,
+        GlanceTraditionalCalendarMode configuredMode,
+        CultureInfo culture)
+    {
+        GlanceTraditionalCalendarMode mode = _traditionalCalendarService.ResolveMode(configuredMode, culture.Name);
+        if (!showChineseFestivals || mode != GlanceTraditionalCalendarMode.ChineseLunar)
+        {
+            return month with { Days = month.Days.Select(day => day with { FestivalText = string.Empty }).ToList() };
+        }
+        bool useTraditional = LocalizationService.IsTraditionalChineseCulture(culture.Name);
+        return month with
+        {
+            Days = month.Days.Select(day => day with { FestivalText = GetChineseFestival(day.Date, useTraditional) }).ToList()
+        };
+    }
+
+    internal string GetChineseFestival(DateOnly date, bool useTraditional = false)
+    {
+        try
+        {
+            if (date.Month == 4 && date.Day == GetQingmingDay(date.Year))
+                return Localize("清明", useTraditional);
+
+            ChineseFestivalDate value = GetChineseDate(date);
+            if (!value.IsLeapMonth)
+            {
+                string fixedFestival = (value.Month, value.Day) switch
+                {
+                    (1, 1) => "春节", (1, 15) => "元宵", (5, 5) => "端午",
+                    (7, 7) => "七夕", (7, 15) => "中元", (8, 15) => "中秋",
+                    (9, 9) => "重阳", (12, 8) => "腊八", _ => string.Empty
+                };
+                if (!string.IsNullOrEmpty(fixedFestival))
+                    return Localize(fixedFestival, useTraditional);
+            }
+
+            ChineseFestivalDate next = GetChineseDate(date.AddDays(1));
+            return !next.IsLeapMonth && next.Month == 1 && next.Day == 1
+                ? Localize("除夕", useTraditional) : string.Empty;
+        }
+        catch (ArgumentOutOfRangeException) { return string.Empty; }
+    }
+
+    private static string Localize(string value, bool useTraditional) =>
+        useTraditional ? ChineseTextConverter.ToTraditional(value) : value;
+
+    private static ChineseFestivalDate GetChineseDate(DateOnly date)
+    {
+        var calendar = new ChineseLunisolarCalendar();
+        DateTime value = date.ToDateTime(TimeOnly.MinValue);
+        int year = calendar.GetYear(value);
+        int calendarMonth = calendar.GetMonth(value);
+        int leapMonth = calendar.GetLeapMonth(year);
+        bool isLeapMonth = leapMonth > 0 && calendarMonth == leapMonth;
+        int month = leapMonth > 0 && calendarMonth >= leapMonth ? calendarMonth - 1 : calendarMonth;
+        return new ChineseFestivalDate(month, calendar.GetDayOfMonth(value), isLeapMonth);
+    }
+
+    private static int GetQingmingDay(int year)
+    {
+        int shortYear = year % 100;
+        double centuryConstant = year < 2000 ? 5.59 : 4.81;
+        return (int)Math.Floor(shortYear * 0.2422 + centuryConstant) - (shortYear / 4);
+    }
+
+    private readonly record struct ChineseFestivalDate(int Month, int Day, bool IsLeapMonth);
+}

--- a/src/DeskBox.GlancePackage/Services/LocalCalendarPresentationSource.cs
+++ b/src/DeskBox.GlancePackage/Services/LocalCalendarPresentationSource.cs
@@ -1,0 +1,52 @@
+using System.Globalization;
+using DeskBox.Contracts;
+using DeskBox.Models;
+
+namespace DeskBox.Services;
+
+/// <summary>
+/// Owned by DeskBox.GlancePackage since D3 Phase 2 (copied from
+/// src/DeskBox/Services/LocalCalendarPresentationSource.cs).
+/// </summary>
+public sealed class LocalCalendarPresentationSource : ICalendarPresentationSource
+{
+    public Task<GlanceCalendarMonth> GetMonthAsync(
+        DateOnly month,
+        CultureInfo culture,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        DateOnly first = new(month.Year, month.Month, 1);
+        DayOfWeek firstDayOfWeek = culture.DateTimeFormat.FirstDayOfWeek;
+        int leadingDays = ((int)first.DayOfWeek - (int)firstDayOfWeek + 7) % 7;
+        DateOnly gridStart = first.AddDays(-leadingDays);
+        DateOnly today = DateOnly.FromDateTime(DateTime.Today);
+
+        var headers = new List<string>(7);
+        string[] shortestDayNames = culture.DateTimeFormat.ShortestDayNames;
+        for (int index = 0; index < 7; index++)
+        {
+            headers.Add(shortestDayNames[((int)firstDayOfWeek + index) % 7]);
+        }
+
+        var days = new List<GlanceCalendarDay>(42);
+        for (int index = 0; index < 42; index++)
+        {
+            DateOnly date = gridStart.AddDays(index);
+            days.Add(new GlanceCalendarDay(date, date.Day.ToString(culture), date.Month == first.Month, date == today));
+        }
+
+        return Task.FromResult(new GlanceCalendarMonth(first, headers, days));
+    }
+
+    public Task<IReadOnlyList<GlanceCalendarEvent>> GetAgendaAsync(
+        DateOnly startDate,
+        int dayCount,
+        CultureInfo culture,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(dayCount);
+        return Task.FromResult<IReadOnlyList<GlanceCalendarEvent>>([]);
+    }
+}


### PR DESCRIPTION
D3 Phase 2 source ownership transfer: 6 of 7 production source files are now OWNED by src/DeskBox.GlancePackage (copied, not linked). Compile Include entries removed for: ChineseTextConverter, GlanceCalendarModels, GlanceWidgetData (enums + settings + decoration record), ICalendarPresentationSource, GlanceCalendarLayoutCalculator, LocalCalendarPresentationSource, GlanceFestivalService. Only GlanceTraditionalCalendarService (367 lines) remains linked (next PR). The package project is now self-contained for all calendar rendering, layout computation, festival detection, and Chinese text conversion - the host retains its own copies for built-in widgets during the transition. Seams.cs still provides App.LogVerbose and LocalizationService.IsTraditionalChineseCulture stubs for the remaining linked file. Suite 3550/3550.