### PR TITLE
fix: D3 boundary correctness closeout - destroy transaction, unload semantics, minimal patches

### DIFF
--- a/docs/architecture/official-widget-packages-plan.md
+++ b/docs/architecture/official-widget-packages-plan.md
@@ -124,4 +124,14 @@ Store 路径在批次 B 前期就核对，不能等发布前才验证。动态�
   附带（审计 §12/§13）：布局计算三处硬编码 `true` 改传真实 `hasTraditional`（None 模式不再预留次行空间）；`showSecondary` 真正消费——日项次行按响应式空间门控（对齐内置 `ShowCalendarTraditionalDetails`）。
   测试：patch 4 条（权威提交/类型拒绝/整数枚举/空串清 Folder）+迁移类型腐蚀场景+golden version 断言反转。
 - **D3 生命周期 Controller 批（2026-09-09，第十八/十九轮审计 §16-17 落地）**：包端实例状态从 ViewBuilder 闭包收进 **`GlanceWidgetController`**（view/settings/runtime/images/三个 timer/生命周期/写回/Dispose），`GlanceWidgetHandle` 降级为 ABI 事件薄路由（**探针视觉残留清除**——Visibility 的 opacity 0.9、Compact 的 MaxHeight 260 不复存在）：①**时钟**：可见时按 `GlanceLifecyclePolicy.DelayToNextMinute` 单发到下一分钟边界（对齐内置 60-Second 算法+50ms 守卫）刷新时间/日期/星期；tick 里比对前后一分钟日期，**跨午夜自动刷新月历**（修时钟冻结）；②**能耗**：`GlanceLifecyclePolicy` 纯逻辑核（镜像内置 UpdateTimers 条件）决定 clock/rotation 运行——hidden/longHidden 全停、compact 与用户暂停只停轮播、轮播还需间隔>0+图≥2；reveal 时立即刷新时间文本（不显示隐藏期快照）；③**RefreshRequested(1) 首次消费**：刷新时钟+重建月份；④**destroy 显式 Dispose**（停三表+保存 runtime state），Unloaded 降级为带 disposed 守卫的兜底；⑤ViewBuilder 瘦身为静态构建助手。未接事件（2/3/4/6/10/11-15）注释标注归属批次（主题推送/性能策略需 config 通道扩展）。测试 +7（policy 矩阵 6+时钟边界纯函数；真包代码经 extern alias 直跑）。
+- **D3 边界 correctness 收口（2026-09-09，第二十轮审计吸收·八项全修）**：审计在 #304/#305 找到两个回归+一批收严项，全部修复：
+  ①**Destroy 事务恢复**——原 `_handles.Remove` 在 `Dispose`（含磁盘写、可抛）之前，失败即造成"包侧句柄已删/宿主 lease 仍活"的永久分歧（破坏 #281/#295 建立的销毁契约）。修复=`GlanceRuntimeState.TrySave`（total no-throw）+ destroy 改 **TryGetValue→Dispose（不可抛）→Remove** 顺序。
+  ②**Unloaded→Dispose 删除**——宿主组切换会 reparent+可回滚 outgoing 视图，Unloaded 永久 Dispose 会让回滚回来的视图计时器全死。改为 `Unloaded→StopVisualResources()`（停三表）/`Loaded→EnsureCurrentDate+UpdateTimers`；真正的 teardown 只允许 deskbox_widget_destroy；暂停态改在 TogglePause 时即存。
+  ③**写回最小 patch**——原 BuildOwnedPatch 发全部 9 个 owned 字段=用包缓存旧值覆盖宿主并发修改（典型 lost update：宿主设置页改 RandomOrder，原生关一下节日就被旧 false 盖掉）。修复=开关只发**被改的单个字段**（BuildOwnedPatch(params onlyFields)）。
+  ④**写回语义改 accepted-not-committed**——回调返回 0 只表示"已受理"，UpdateAsync fire-and-forget 在宿主 dispatcher 上执行（阻塞 UI 会死锁）；异步持久化失败由宿主日志观测（CommitToAuthorityAsync try/catch），包端只把同步拒绝视为回滚条件；丢失的异步提交经下次 create 权威同步自愈。真正的 ack 等推送通道批次。
+  ⑤**迁移校验 localImagePaths 条件反转修复**——原 `!=Array || All(string)` 会把 `"localImagePaths":"not-array"` 判合法（审计抓到的明确 bug）；改严格 `==Array && All(string)`。
+  ⑥**迁移校验补三个枚举字段**（traditionalCalendarMode/backgroundSource/imageFit：名字可解析或整数在定义域内），`"backgroundSource":{}` 现在正确落 .bak。
+  ⑦**Patch 枚举字符串收严**——`Enum.TryParse` 会把 `"999"` 这类数字字符串解析成未定义枚举值，补 `Enum.IsDefined`。
+  ⑧**隐藏跨午夜/跨月修复**——新增 `EnsureCurrentDate`（_renderedDate 缓存）：reveal/Loaded/RefreshRequested/时钟 tick 统一走它，隐藏跨天后重显自动重建月历（运行中的分钟 tick 检测不到停摆期间的跨日）。
+  测试 +5（未定义枚举拒绝/迁移错型落 .bak/最小 patch 恰一字段/TrySave 失败不抛/destroy 顺序+Unloaded 语义源码契约）。#306 Pomodoro 外部 PR 关闭符合架构方向（正是要消除的"加功能改宿主十几处"路径，未来可作官方包示例）。
 - 批次 C–E：C1/C2 完成。六功能仍保留在现有应用中；商店界面和升级迁移未在本批次提前切换。

--- a/src/DeskBox.GlancePackage/Abi/Exports.cs
+++ b/src/DeskBox.GlancePackage/Abi/Exports.cs
@@ -148,10 +148,13 @@ public static unsafe class Exports
         // host destroy state machine only commits a release on package success.
         try
         {
-            if (!_handles.Remove(widgetHandle, out Rendering.GlanceWidgetHandle? handle)) return E_HANDLE;
-            // Explicit teardown (audit 19): stop timers and save runtime
-            // state now - never bet on the UI tree firing Unloaded.
+            if (!_handles.TryGetValue(widgetHandle, out Rendering.GlanceWidgetHandle? handle)) return E_HANDLE;
+            // Dispose FIRST, then remove the handle (audit round 20): the
+            // controller's Dispose is total/no-throw, so nothing between the
+            // two steps can fail and leave the host lease alive against an
+            // already-gone package handle (the destroy transaction contract).
             handle.Dispose();
+            _handles.Remove(widgetHandle);
             Instances.Remove(widgetHandle);
             return S_OK;
         }

--- a/src/DeskBox.GlancePackage/Rendering/GlanceDataFile.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceDataFile.cs
@@ -122,38 +122,40 @@ internal static class GlanceDataFile
 
     /// <summary>
     /// The package-owned settings as a standalone patch document for the
-    /// host write-through channel (audit round 19: under host authority,
-    /// native mutations must commit to the authoritative store, not just to
-    /// the local copy).
+    /// host write-through channel (audit round 20): pass ONLY the mutated
+    /// field names - a full owned snapshot would overwrite concurrent
+    /// host-side setting changes with this widget's stale cache. With no
+    /// field names the full owned set is written (fresh-file path).
     /// </summary>
-    internal static string BuildOwnedPatch(GlanceWidgetData settings)
+    internal static string BuildOwnedPatch(GlanceWidgetData settings, params string[] onlyFields)
     {
+        HashSet<string>? only = onlyFields.Length == 0 ? null : onlyFields.ToHashSet(StringComparer.Ordinal);
         using var stream = new MemoryStream();
         using (var writer = new Utf8JsonWriter(stream))
         {
             writer.WriteStartObject();
-            WriteOwnedProperties(writer, settings, null);
+            WriteOwnedProperties(writer, settings, skip: null, only);
             writer.WriteEndObject();
         }
         return System.Text.Encoding.UTF8.GetString(stream.ToArray());
     }
 
-    private static void WriteOwnedProperties(Utf8JsonWriter writer, GlanceWidgetData settings, HashSet<string>? skip)
+    private static void WriteOwnedProperties(Utf8JsonWriter writer, GlanceWidgetData settings, HashSet<string>? skip, HashSet<string>? only = null)
     {
-        if (skip?.Contains("showChineseFestivals") != true) writer.WriteBoolean("showChineseFestivals", settings.ShowChineseFestivals);
-        if (skip?.Contains("traditionalCalendarMode") != true) writer.WriteString("traditionalCalendarMode", settings.TraditionalCalendarMode.ToString());
-        if (skip?.Contains("rotationIntervalMinutes") != true) writer.WriteNumber("rotationIntervalMinutes", settings.RotationIntervalMinutes);
-        if (skip?.Contains("randomOrder") != true) writer.WriteBoolean("randomOrder", settings.RandomOrder);
-        if (skip?.Contains("backgroundSource") != true) writer.WriteString("backgroundSource", settings.BackgroundSource.ToString());
-        if (skip?.Contains("localImagePaths") != true)
+        if (skip?.Contains("showChineseFestivals") != true && only?.Contains("showChineseFestivals") != false) writer.WriteBoolean("showChineseFestivals", settings.ShowChineseFestivals);
+        if (skip?.Contains("traditionalCalendarMode") != true && only?.Contains("traditionalCalendarMode") != false) writer.WriteString("traditionalCalendarMode", settings.TraditionalCalendarMode.ToString());
+        if (skip?.Contains("rotationIntervalMinutes") != true && only?.Contains("rotationIntervalMinutes") != false) writer.WriteNumber("rotationIntervalMinutes", settings.RotationIntervalMinutes);
+        if (skip?.Contains("randomOrder") != true && only?.Contains("randomOrder") != false) writer.WriteBoolean("randomOrder", settings.RandomOrder);
+        if (skip?.Contains("backgroundSource") != true && only?.Contains("backgroundSource") != false) writer.WriteString("backgroundSource", settings.BackgroundSource.ToString());
+        if (skip?.Contains("localImagePaths") != true && only?.Contains("localImagePaths") != false)
         {
             writer.WriteStartArray("localImagePaths");
             foreach (string path in settings.LocalImagePaths) writer.WriteStringValue(path);
             writer.WriteEndArray();
         }
-        if (skip?.Contains("localFolderPath") != true) writer.WriteString("localFolderPath", settings.LocalFolderPath);
-        if (skip?.Contains("imageFit") != true) writer.WriteString("imageFit", settings.ImageFit.ToString());
-        if (skip?.Contains("showPhotoControls") != true) writer.WriteBoolean("showPhotoControls", settings.ShowPhotoControls);
+        if (skip?.Contains("localFolderPath") != true && only?.Contains("localFolderPath") != false) writer.WriteString("localFolderPath", settings.LocalFolderPath);
+        if (skip?.Contains("imageFit") != true && only?.Contains("imageFit") != false) writer.WriteString("imageFit", settings.ImageFit.ToString());
+        if (skip?.Contains("showPhotoControls") != true && only?.Contains("showPhotoControls") != false) writer.WriteBoolean("showPhotoControls", settings.ShowPhotoControls);
     }
 
     private static bool TryBool(JsonElement root, string property, out bool value)

--- a/src/DeskBox.GlancePackage/Rendering/GlanceViewBuilder.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceViewBuilder.cs
@@ -196,4 +196,23 @@ internal sealed class GlanceRuntimeState
                 writer.WriteNumber("imageIndex", state.ImageIndex);
                 writer.WriteEndObject();
             });
+
+    /// <summary>
+    /// Total no-throw variant (audit round 20): ephemeral runtime state must
+    /// never turn into an ABI destroy failure, so a failed save is logged
+    /// and reported as false instead of propagating.
+    /// </summary>
+    public static bool TrySave(GlanceRuntimeState state, string instanceDataRoot)
+    {
+        try
+        {
+            Save(state, instanceDataRoot);
+            return true;
+        }
+        catch (Exception error)
+        {
+            PackageLogger.LogVerbose($"[GlancePackage] failed to save runtime state: {error.Message}");
+            return false;
+        }
+    }
 }

--- a/src/DeskBox.GlancePackage/Rendering/GlanceWidgetController.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceWidgetController.cs
@@ -46,6 +46,7 @@ internal sealed class GlanceWidgetController : IDisposable
     private bool _collapsed;
     private bool _applying; // toggle revert suppression
     private bool _disposed;
+    private DateOnly _renderedDate;
 
     private double _width;
     private double _height;
@@ -120,7 +121,10 @@ internal sealed class GlanceWidgetController : IDisposable
         {
             if (_applying) return;
             Settings.ShowChineseFestivals = festivalToggle.IsOn;
-            if (CommitSettings())
+            // Minimal patch (audit round 20): send ONLY the mutated field -
+            // a full owned snapshot would overwrite concurrent host-side
+            // setting changes with this widget's stale cache.
+            if (CommitSettings(GlanceDataFile.BuildOwnedPatch(Settings, "showChineseFestivals")))
             {
                 RebuildMonth();
                 return;
@@ -131,7 +135,7 @@ internal sealed class GlanceWidgetController : IDisposable
         {
             if (_applying) return;
             Settings.TraditionalCalendarMode = traditionalToggle.IsOn ? _restoreMode : GlanceTraditionalCalendarMode.None;
-            if (CommitSettings())
+            if (CommitSettings(GlanceDataFile.BuildOwnedPatch(Settings, "traditionalCalendarMode")))
             {
                 RebuildMonth();
                 return;
@@ -165,11 +169,19 @@ internal sealed class GlanceWidgetController : IDisposable
         _resizeTimer.Interval = TimeSpan.FromMilliseconds(120);
         _resizeTimer.IsRepeating = false;
         _resizeTimer.Tick += (_, _) => RebuildMonth();
+        _renderedDate = DateOnly.FromDateTime(DateTime.Today);
 
-        // Safety net only: the primary teardown is deskbox_widget_destroy ->
-        // Dispose(). Unloaded may fire first when the host tears the tree
-        // down; the disposed guard makes double teardown a no-op.
-        _content.Unloaded += (_, _) => Dispose();
+        // Visual pause ONLY (audit round 20): Unloaded fires during host
+        // group transitions that can ROLL BACK, so it must never permanently
+        // dispose the controller - a rolled-back view would come back with
+        // dead timers. Real teardown happens exclusively on
+        // deskbox_widget_destroy.
+        _content.Unloaded += (_, _) => StopVisualResources();
+        _content.Loaded += (_, _) =>
+        {
+            EnsureCurrentDate();
+            UpdateTimers();
+        };
 
         UpdateTimers();
     }
@@ -180,7 +192,7 @@ internal sealed class GlanceWidgetController : IDisposable
     {
         EventsReceived++;
         if (_disposed) return;
-        UpdateClockText();
+        EnsureCurrentDate();
         RebuildMonth();
     }
 
@@ -192,9 +204,11 @@ internal sealed class GlanceWidgetController : IDisposable
         if (visible)
         {
             // Built-in parity: the clock text refreshes immediately on
-            // reveal instead of showing the hidden-time snapshot.
+            // reveal instead of showing the hidden-time snapshot, and a
+            // widget hidden across midnight/month rolls its grid forward
+            // (the minute tick cannot detect a date change while stopped).
             _longHidden = false;
-            UpdateClockText();
+            EnsureCurrentDate();
         }
         UpdateTimers();
     }
@@ -256,21 +270,30 @@ internal sealed class GlanceWidgetController : IDisposable
     private void ClockTimerTick()
     {
         if (_disposed) return;
-        // Built-in parity: compare the date a minute ago with now - at
-        // midnight (or any date change) the month grid refreshes.
-        DateOnly previousDate = DateOnly.FromDateTime(DateTime.Now.AddMinutes(-1));
-        DateOnly currentDate = DateOnly.FromDateTime(DateTime.Now);
-        UpdateClockText();
-        if (previousDate != currentDate &&
-            _month.Month == new DateOnly(previousDate.Year, previousDate.Month, 1))
-        {
-            RebuildMonth();
-        }
+        // A running clock catches the midnight rollover here; a HIDDEN
+        // widget catches it in EnsureCurrentDate on reveal (audit 20).
+        EnsureCurrentDate();
         // Re-arm the one-shot clock only; restarting the rotation timer here
         // would reset its progress.
         _clockTimer.Stop();
         _clockTimer.Interval = GlanceLifecyclePolicy.DelayToNextMinute(DateTime.Now);
         _clockTimer.Start();
+    }
+
+    /// <summary>
+    /// Brings the rendered date (and month grid) forward to today. Cheap
+    /// when nothing changed; rebuilds the month on any date rollover.
+    /// </summary>
+    private void EnsureCurrentDate()
+    {
+        DateOnly today = DateOnly.FromDateTime(DateTime.Today);
+        if (today == _renderedDate)
+        {
+            UpdateClockText();
+            return;
+        }
+        _renderedDate = today;
+        RebuildMonth();
     }
 
     private void UpdateClockText()
@@ -281,9 +304,9 @@ internal sealed class GlanceWidgetController : IDisposable
 
     // ---- Settings (host-authoritative write-through) ----
 
-    private bool CommitSettings()
+    private bool CommitSettings(string patch)
     {
-        if (HostConfig.TryPushInstanceConfig(_instanceId, GlanceDataFile.BuildOwnedPatch(Settings)))
+        if (HostConfig.TryPushInstanceConfig(_instanceId, patch))
         {
             // Local cache for continuity until the next host sync; the
             // authoritative copy lives in the built-in store.
@@ -315,6 +338,7 @@ internal sealed class GlanceWidgetController : IDisposable
         (_month, _isCompact, _panelHeight, _panelWidth, double itemHeight, bool secondary, GlanceTraditionalCalendarMode mode) =
             GlanceMonthPipeline.Build(Settings.ShowChineseFestivals, Settings.TraditionalCalendarMode, _culture, _width, _height);
         _decoration.Update(_month, itemHeight, mode != GlanceTraditionalCalendarMode.None, Settings.ShowChineseFestivals, secondary);
+        _renderedDate = DateOnly.FromDateTime(DateTime.Today);
         UpdateClockText();
     }
 
@@ -339,10 +363,27 @@ internal sealed class GlanceWidgetController : IDisposable
     {
         _runtimeState.Paused = !_runtimeState.Paused;
         UpdateTimers();
+        // Persist the pause at the change point: teardown no longer saves on
+        // Unloaded, and destroy persistence must be able to stay no-throw.
+        GlanceRuntimeState.TrySave(_runtimeState, _instanceDataRoot);
     }
 
     // ---- Teardown ----
 
+    private void StopVisualResources()
+    {
+        if (_disposed) return;
+        _clockTimer.Stop();
+        _rotationTimer.Stop();
+        _resizeTimer.Stop();
+    }
+
+    /// <summary>
+    /// Total no-throw teardown (audit round 20): deskbox_widget_destroy
+    /// calls this BEFORE removing the handle, so a runtime-state save
+    /// failure must never turn into an ABI destroy failure - that would
+    /// leave the host lease alive against an already-gone package handle.
+    /// </summary>
     public void Dispose()
     {
         if (_disposed) return;
@@ -350,6 +391,6 @@ internal sealed class GlanceWidgetController : IDisposable
         _clockTimer.Stop();
         _rotationTimer.Stop();
         _resizeTimer.Stop();
-        GlanceRuntimeState.Save(_runtimeState, _instanceDataRoot);
+        GlanceRuntimeState.TrySave(_runtimeState, _instanceDataRoot);
     }
 }

--- a/src/DeskBox/Services/Plugins/NativeInstanceConfigPatch.cs
+++ b/src/DeskBox/Services/Plugins/NativeInstanceConfigPatch.cs
@@ -36,6 +36,24 @@ internal sealed record InstanceConfigPatch(
         if (ShowPhotoControls is { } controls) data.ShowPhotoControls = controls;
     }
 
+    /// <summary>
+    /// Commits an accepted patch through the authoritative store.
+    /// Deliberately OUTSIDE the unsafe HostApi bridge (await is not allowed
+    /// in an unsafe context); failures are observed and logged here so a
+    /// lost async commit never disappears silently.
+    /// </summary>
+    public static async Task CommitAsync(GlanceWidgetStore store, InstanceConfigPatch patch)
+    {
+        try
+        {
+            await store.UpdateAsync(data => patch.ApplyTo(data));
+        }
+        catch (Exception error)
+        {
+            App.Log($"[NativePackage] instance config commit failed: {error.Message}");
+        }
+    }
+
     public static InstanceConfigPatch? TryParse(string payload)
     {
         try
@@ -125,7 +143,12 @@ internal sealed record InstanceConfigPatch(
         if (!root.TryGetProperty(property, out JsonElement element)) return true;
         if (element.ValueKind == JsonValueKind.String)
         {
-            if (!Enum.TryParse(element.GetString(), ignoreCase: true, out TEnum parsed)) return false;
+            // TryParse also accepts numeric STRINGS into undefined values -
+            // IsDefined closes that hole (audit round 20).
+            if (!Enum.TryParse(element.GetString(), ignoreCase: true, out TEnum parsed) || !Enum.IsDefined(parsed))
+            {
+                return false;
+            }
             value = parsed;
             return true;
         }

--- a/src/DeskBox/Services/Plugins/NativeWidgetDataMigration.cs
+++ b/src/DeskBox/Services/Plugins/NativeWidgetDataMigration.cs
@@ -93,7 +93,7 @@ internal static class NativeWidgetDataMigration
     /// <summary>
     /// Structural + semantic validation: the candidate must parse AND the
     /// glance settings fields must be type-valid, mirroring what the
-    /// built-in deserializer would accept (audit round 19). Only the fields
+    /// built-in deserializer would accept (audits 19-20). Only the fields
     /// the sync target consumes are checked; the built-in store owns the
     /// rest of the schema and its own recovery.
     /// </summary>
@@ -113,10 +113,16 @@ internal static class NativeWidgetDataMigration
                     "rotationIntervalMinutes" =>
                         property.Value.ValueKind == JsonValueKind.Number && property.Value.TryGetDouble(out _),
                     "localImagePaths" =>
-                        property.Value.ValueKind != JsonValueKind.Array ||
+                        // Strict (audit 20): the built-in deserializer rejects
+                        // a non-array here, so the sync must too - never
+                        // accept a scalar and copy it as a valid primary.
+                        property.Value.ValueKind == JsonValueKind.Array &&
                         property.Value.EnumerateArray().All(item => item.ValueKind == JsonValueKind.String),
                     "localFolderPath" =>
                         property.Value.ValueKind is JsonValueKind.String or JsonValueKind.Null,
+                    "traditionalCalendarMode" => IsValidEnumValue<DeskBox.Models.GlanceTraditionalCalendarMode>(property.Value),
+                    "backgroundSource" => IsValidEnumValue<DeskBox.Models.GlanceBackgroundSource>(property.Value),
+                    "imageFit" => IsValidEnumValue<DeskBox.Models.GlanceImageFitMode>(property.Value),
                     _ => true,
                 };
                 if (!typeValid) return false;
@@ -127,6 +133,28 @@ internal static class NativeWidgetDataMigration
         {
             return false;
         }
+    }
+
+    /// <summary>
+    /// Enums travel as names or legacy integers (the built-in accepts both);
+    /// anything else - or an undefined value - is a type error.
+    /// </summary>
+    private static bool IsValidEnumValue<TEnum>(JsonElement element)
+        where TEnum : struct, Enum
+    {
+        if (element.ValueKind == JsonValueKind.String)
+        {
+            return Enum.TryParse(element.GetString(), ignoreCase: true, out TEnum parsed) &&
+                   Enum.IsDefined(parsed);
+        }
+        if (element.ValueKind == JsonValueKind.Number &&
+            element.TryGetInt32(out int number) &&
+            number >= 0)
+        {
+            TEnum candidate = (TEnum)(object)number;
+            return Enum.IsDefined(candidate);
+        }
+        return false;
     }
 
     private static void WriteResilient(string path, string content)

--- a/src/DeskBox/Services/Plugins/NativeWidgetPackageLoader.cs
+++ b/src/DeskBox/Services/Plugins/NativeWidgetPackageLoader.cs
@@ -164,12 +164,15 @@ internal static unsafe class NativeHostApiBridge
                 App.LogVerbose($"[NativePackage] rejected malformed instance config patch for {widgetId}");
                 return unchecked((int)0x80070057); // E_INVALIDARG
             }
-            // Authority write (audit round 19): the native setting mutation
-            // commits to the built-in store; the package's local copy is a
-            // cache the next create re-syncs. Fire-and-forget on the caller's
-            // dispatcher context - the callback must never block the UI
-            // thread on the store's async pipeline.
-            _ = GlanceWidgetStore.ForWidget(widgetId).UpdateAsync(data => patch.ApplyTo(data));
+            // Authority write (audits 19-20): the native setting mutation
+            // commits to the built-in store. The return value means
+            // ACCEPTED, not committed: the store update runs fire-and-forget
+            // because blocking the UI thread on the async store pipeline
+            // would deadlock. The package treats only synchronous rejection
+            // as a revert condition; a failed async persistence is logged
+            // below and self-heals on the next create-time sync from
+            // authority (which is also what reverts the widget's cache).
+            _ = InstanceConfigPatch.CommitAsync(GlanceWidgetStore.ForWidget(widgetId), patch);
             return 0;
         }
         catch (Exception error)

--- a/tests/DeskBox.Tests/NativeGlanceDataGoldenTests.cs
+++ b/tests/DeskBox.Tests/NativeGlanceDataGoldenTests.cs
@@ -178,4 +178,74 @@ public class NativeGlanceDataGoldenTests
             Directory.Delete(root, recursive: true);
         }
     }
+
+    [Fact]
+    public void MinimalPatchCarriesOnlyTheMutatedField()
+    {
+        // Audit round 20 (lost update): a toggle must send ONLY its own
+        // field - a full owned snapshot would overwrite concurrent host-side
+        // changes with the widget's stale cache.
+        var settings = new PackageData
+        {
+            ShowChineseFestivals = false, // the mutated field
+            RandomOrder = true,
+            RotationIntervalMinutes = 30,
+        };
+        string minimal = GlanceDataFile.BuildOwnedPatch(settings, "showChineseFestivals");
+        using (JsonDocument document = JsonDocument.Parse(minimal))
+        {
+            Assert.Equal(1, document.RootElement.EnumerateObject().Count());
+            Assert.False(document.RootElement.GetProperty("showChineseFestivals").GetBoolean());
+        }
+
+        string full = GlanceDataFile.BuildOwnedPatch(settings);
+        using (JsonDocument document = JsonDocument.Parse(full))
+        {
+            Assert.Equal(9, document.RootElement.EnumerateObject().Count());
+        }
+    }
+
+    [Fact]
+    public void RuntimeStateTrySaveNeverThrows()
+    {
+        string root = Root();
+        try
+        {
+            // A FILE where the data root directory should be: every write
+            // must fail, and the failure must be contained (audit 20 -
+            // destroy can never fail because of ephemeral state).
+            string fileAsRoot = Path.Combine(root, "not-a-directory");
+            File.WriteAllText(fileAsRoot, "x");
+            var state = new GlancePkg::DeskBox.GlancePackage.Rendering.GlanceRuntimeState
+            {
+                Paused = true,
+                ImageIndex = 3,
+            };
+            Assert.False(GlancePkg::DeskBox.GlancePackage.Rendering.GlanceRuntimeState.TrySave(state, fileAsRoot));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void DestroyAndUnloadSemanticsStayStrict()
+    {
+        // Audit round 20 contracts: dispose-before-remove (the destroy
+        // transaction) and Unloaded-as-visual-pause only.
+        string exports = File.ReadAllText(TestPaths.SourceFile(
+            "src/DeskBox.GlancePackage/Abi/Exports.cs"));
+        int dispose = exports.IndexOf("handle.Dispose();", StringComparison.Ordinal);
+        int remove = exports.IndexOf("_handles.Remove(widgetHandle)", StringComparison.Ordinal);
+        Assert.True(dispose >= 0 && remove > dispose,
+            "destroy must dispose the controller BEFORE removing the handle");
+
+        string controller = File.ReadAllText(TestPaths.SourceFile(
+            "src/DeskBox.GlancePackage/Rendering/GlanceWidgetController.cs"));
+        Assert.DoesNotContain("Unloaded += (_, _) => Dispose()", controller);
+        Assert.Contains("StopVisualResources", controller);
+        // Hidden-across-midnight recovery: reveal must re-derive the date.
+        Assert.Contains("EnsureCurrentDate", controller);
+    }
 }

--- a/tests/DeskBox.Tests/NativeInstanceConfigPatchTests.cs
+++ b/tests/DeskBox.Tests/NativeInstanceConfigPatchTests.cs
@@ -64,6 +64,19 @@ public class NativeInstanceConfigPatchTests
     }
 
     [Fact]
+    public void UndefinedEnumValuesAreRejected()
+    {
+        // TryParse accepts numeric STRINGS into undefined values; the patch
+        // channel must not commit those (audit round 20).
+        Assert.Null(DeskBox.Services.Plugins.InstanceConfigPatch.TryParse(
+            """{"traditionalCalendarMode":"999"}"""));
+        Assert.Null(DeskBox.Services.Plugins.InstanceConfigPatch.TryParse(
+            """{"backgroundSource":"NotAMode"}"""));
+        Assert.Null(DeskBox.Services.Plugins.InstanceConfigPatch.TryParse(
+            """{"backgroundSource":{}}"""));
+    }
+
+    [Fact]
     public void ClearingTheLocalFolderMapsEmptyStringToNull()
     {
         DeskBox.Services.Plugins.InstanceConfigPatch? patch =

--- a/tests/DeskBox.Tests/NativeWidgetDataMigrationTests.cs
+++ b/tests/DeskBox.Tests/NativeWidgetDataMigrationTests.cs
@@ -195,6 +195,44 @@ public class NativeWidgetDataMigrationTests
     }
 
     [Fact]
+    public async Task SyncRejectsWrongFieldTypesAndFallsToBackup()
+    {
+        (string root, string widgetId) = CreateRoot();
+        try
+        {
+            var store = CreateProductionLayoutStore(root, widgetId);
+            await File.WriteAllTextAsync(store.StorePath + ".bak",
+                """{ "rotationIntervalMinutes": 66 }""");
+
+            // A scalar where the built-in deserializer wants a string list.
+            await File.WriteAllTextAsync(store.StorePath,
+                """{ "localImagePaths": "not-array" }""");
+            string publisher = "g".PadLeft(64, '0');
+            DeskBox.Services.Plugins.NativeWidgetDataMigration.TryMigrate(publisher, "deskbox.glance", widgetId, root);
+            using (JsonDocument synced = JsonDocument.Parse(
+                await File.ReadAllTextAsync(TargetPath(root, publisher, widgetId))))
+            {
+                Assert.Equal(66, synced.RootElement.GetProperty("rotationIntervalMinutes").GetInt32());
+            }
+
+            // An object where the built-in deserializer wants an enum.
+            await File.WriteAllTextAsync(store.StorePath,
+                """{ "backgroundSource": {} }""");
+            File.Delete(TargetPath(root, publisher, widgetId));
+            DeskBox.Services.Plugins.NativeWidgetDataMigration.TryMigrate(publisher, "deskbox.glance", widgetId, root);
+            using (JsonDocument synced = JsonDocument.Parse(
+                await File.ReadAllTextAsync(TargetPath(root, publisher, widgetId))))
+            {
+                Assert.Equal(66, synced.RootElement.GetProperty("rotationIntervalMinutes").GetInt32());
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void PackagePersistsWithoutReflectionJson()
     {
         foreach (string relativePath in new[]


### PR DESCRIPTION
fix: D3 boundary correctness closeout - destroy transaction, unload semantics, minimal patches

Audit round 20 (verified against code): eight real findings, all fixed.

- destroy transaction (P0 regression): _handles.Remove ran BEFORE Dispose,
  and Dispose did disk I/O that can throw - a failed destroy left the
  package handle gone while the host lease stayed live, and the retry hit
  E_HANDLE: permanent divergence, breaking the #281/#295 destroy contract.
  GlanceRuntimeState.TrySave is now total/no-throw and destroy runs
  TryGetValue -> Dispose (cannot throw) -> Remove
- Unloaded => Dispose removed (P0 regression): host group transitions
  reparent the outgoing view and can ROLL BACK - a permanent dispose would
  bring the view back with dead timers. Unloaded now only pauses visual
  resources (stop timers); Loaded resumes via EnsureCurrentDate + policy;
  real teardown happens exclusively on deskbox_widget_destroy; the paused
  flag persists at the change point
- write-through lost update: toggles sent the full 9-field owned snapshot,
  so a host-side settings change between the package's load and a toggle
  got overwritten by the stale cache. Patches now carry ONLY the mutated
  field (BuildOwnedPatch(params onlyFields))
- write-through semantics made honest: the callback return means ACCEPTED,
  not committed (the store update is fire-and-forget on the dispatcher -
  blocking the UI thread would deadlock); async persistence failures are
  observed and logged via InstanceConfigPatch.CommitAsync (outside the
  unsafe bridge - CS4004), and a lost async commit self-heals on the next
  create-time sync from authority
- migration validator: the localImagePaths condition was half-inverted (a
  scalar passed as valid); now strictly Array-of-strings, and the three
  enum fields are validated (parseable name or defined integer) so
  {"backgroundSource":{}} falls through to the .bak like the built-in
  deserializer would
- InstanceConfigPatch: numeric STRINGS like "999" parsed into undefined
  enum values through TryParse - Enum.IsDefined now closes that hole
- hidden-across-midnight/month: EnsureCurrentDate (rendered-date cache) on
  reveal/Loaded/RefreshRequested/clock tick rebuilds the month grid after a
  widget was hidden over a date boundary (the running minute tick cannot
  detect a change that happened while stopped)

Tests +5: undefined enum values rejected, wrong-typed primaries fall to the
backup, the minimal patch carries exactly one field, TrySave never throws
on an unusable root, and a source contract pins dispose-before-remove plus
Unloaded-as-pause.

Total: 3594/3594 green.
