### PR TITLE
fix: day decoration reads today/culture per call

### DIFF
--- a/src/DeskBox.GlancePackage/Rendering/GlanceViewBuilder.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceViewBuilder.cs
@@ -97,9 +97,8 @@ internal static class GlanceViewBuilder
         background.Opacity = 1;
     }
 
-    internal static void SubscribeDayDecoration(CalendarView calendarView, CalendarDecorationState decoration, CultureInfo culture)
+    internal static void SubscribeDayDecoration(CalendarView calendarView, CalendarDecorationState decoration)
     {
-        DateOnly today = DateOnly.FromDateTime(DateTime.Today);
         calendarView.CalendarViewDayItemChanging += (_, args) =>
         {
             CalendarViewDayItem item = args.Item;
@@ -118,10 +117,15 @@ internal static class GlanceViewBuilder
             bool hasSecondaryText = !string.IsNullOrWhiteSpace(secondaryText);
             bool isFestival = hasSecondaryText && day?.HasFestival == true;
             bool isCurrentMonth = day?.IsCurrentMonth ?? date.Month == decoration.Month.Month.Month;
+            // Regression pass: "today" and the culture are read PER CALL, not
+            // captured - a captured snapshot left the yesterday highlight
+            // marked as today after any midnight rollover, and kept the old
+            // locale's digit shaping after a live language switch.
+            DateOnly today = DateOnly.FromDateTime(DateTime.Today);
             item.MinHeight = decoration.DayItemHeight;
             item.Height = decoration.DayItemHeight;
             item.Tag = new GlanceDayDecoration(
-                day?.DayText ?? date.Day.ToString(culture),
+                day?.DayText ?? date.Day.ToString(decoration.Culture),
                 secondaryText,
                 hasSecondaryText ? Visibility.Visible : Visibility.Collapsed,
                 date == today ? Visibility.Visible : Visibility.Collapsed,
@@ -135,17 +139,19 @@ internal static class GlanceViewBuilder
 
 /// <summary>Mutable decoration state shared with the day-item callback.</summary>
 internal sealed class CalendarDecorationState(
-    GlanceCalendarMonth month, double dayItemHeight, bool showTraditional, bool showFestivals, bool showSecondary)
+    GlanceCalendarMonth month, double dayItemHeight, bool showTraditional, bool showFestivals, bool showSecondary,
+    CultureInfo culture)
 {
     public GlanceCalendarMonth Month = month;
     public double DayItemHeight = dayItemHeight;
     public bool ShowTraditional = showTraditional;
     public bool ShowFestivals = showFestivals;
     public bool ShowSecondary = showSecondary;
+    public CultureInfo Culture = culture;
 
-    public void Update(GlanceCalendarMonth rebuilt, double itemHeight, bool traditional, bool festivals, bool secondary)
+    public void Update(GlanceCalendarMonth rebuilt, double itemHeight, bool traditional, bool festivals, bool secondary, CultureInfo culture)
     {
-        Month = rebuilt; DayItemHeight = itemHeight; ShowTraditional = traditional; ShowFestivals = festivals; ShowSecondary = secondary;
+        Month = rebuilt; DayItemHeight = itemHeight; ShowTraditional = traditional; ShowFestivals = festivals; ShowSecondary = secondary; Culture = culture;
     }
 }
 

--- a/src/DeskBox.GlancePackage/Rendering/GlanceWidgetController.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceWidgetController.cs
@@ -88,8 +88,8 @@ internal sealed class GlanceWidgetController : IDisposable
         _content.DataContext = GlanceMonthPipeline.CreatePresentation(_month, _isCompact, _panelHeight, _panelWidth, _culture, _width, _height);
 
         var calendarView = _content.FindName("NativeCalendarView").As<CalendarView>();
-        _decoration = new CalendarDecorationState(_month, dayItemHeight, showTraditional, showFestivals, showSecondary);
-        GlanceViewBuilder.SubscribeDayDecoration(calendarView, _decoration, _culture);
+        _decoration = new CalendarDecorationState(_month, dayItemHeight, showTraditional, showFestivals, showSecondary, _culture);
+        GlanceViewBuilder.SubscribeDayDecoration(calendarView, _decoration);
 
         _images = GlanceViewBuilder.LoadImages(Settings, packageRoot);
         _imageStretch = Settings.ImageFit == GlanceImageFitMode.Fit ? Stretch.Uniform : Stretch.UniformToFill;
@@ -359,7 +359,7 @@ internal sealed class GlanceWidgetController : IDisposable
     {
         (_month, _isCompact, _panelHeight, _panelWidth, double itemHeight, bool secondary, GlanceTraditionalCalendarMode mode) =
             GlanceMonthPipeline.Build(Settings.ShowChineseFestivals, Settings.TraditionalCalendarMode, _culture, _width, _height);
-        _decoration.Update(_month, itemHeight, mode != GlanceTraditionalCalendarMode.None, Settings.ShowChineseFestivals, secondary);
+        _decoration.Update(_month, itemHeight, mode != GlanceTraditionalCalendarMode.None, Settings.ShowChineseFestivals, secondary, _culture);
         _renderedDate = DateOnly.FromDateTime(DateTime.Today);
         UpdateClockText();
     }

--- a/src/DeskBox/Services/Plugins/NativeWidgetPackageLoader.cs
+++ b/src/DeskBox/Services/Plugins/NativeWidgetPackageLoader.cs
@@ -454,19 +454,17 @@ internal sealed class NativeWidgetLease : IDisposable
 
     internal Microsoft.UI.Xaml.FrameworkElement View { get; private set; } = null!;
     private string _instanceId = null!;
-    private string _instanceDataRoot = null!;
 
     internal NativePackageSession Session => _session;
 
     internal static NativeWidgetLease Create(
         NativePackageSession session, nint handle, Microsoft.UI.Xaml.FrameworkElement view,
-        string instanceId, string instanceDataRoot) => new()
+        string instanceId) => new()
     {
         _session = session,
         _handle = handle,
         View = view,
         _instanceId = instanceId,
-        _instanceDataRoot = instanceDataRoot,
     };
 
     /// <summary>
@@ -478,7 +476,11 @@ internal sealed class NativeWidgetLease : IDisposable
     internal bool TryRelease()
     {
         if (_released) return false;
-        if (!_session.DestroyWidget(_handle)) return false;
+        if (!_session.DestroyWidget(_handle))
+        {
+            App.LogVerbose($"[NativePackage] destroy retry pending for instance {_instanceId}");
+            return false;
+        }
         _released = true;
         return true;
     }
@@ -637,7 +639,7 @@ internal sealed unsafe class NativePackageSession
         }
         // Ownership for the generic write-through routing (audit 20 §18).
         PackageInstanceRegistry.Register(Identity.PackageId, instanceId);
-        return NativeWidgetLease.Create(this, handle, view, instanceId, instanceDataRoot);
+        return NativeWidgetLease.Create(this, handle, view, instanceId);
     }
 
     /// <summary>Destroys by handle; returns true only when the package confirms success.

--- a/tests/DeskBox.Tests/NativeWidgetLifecycleAbiTests.cs
+++ b/tests/DeskBox.Tests/NativeWidgetLifecycleAbiTests.cs
@@ -46,7 +46,7 @@ public class NativeWidgetLifecycleAbiTests
             destroyExport: Marshal.GetFunctionPointerForDelegate(DestroyStub),
             shutdownExport: Marshal.GetFunctionPointerForDelegate(ShutdownStub),
             widgetEventExport: Marshal.GetFunctionPointerForDelegate(WidgetEventStub));
-        NativeWidgetLease lease = NativeWidgetLease.Create(session, 0x1234, null!, "instance-1", "/tmp/instance");
+        NativeWidgetLease lease = NativeWidgetLease.Create(session, 0x1234, null!, "instance-1");
         return new NativeWidgetPilotContent(new DeskBox.Models.WidgetConfig(), lease);
     }
 


### PR DESCRIPTION
fix: day decoration reads today/culture per call - midnight and locale staleness

Regression pass over the newest lifecycle code found a parity bug present
since the first native glance build: the day-item decoration callback
captured "today" and the CultureInfo at subscription time. After any
midnight rollover the yesterday highlight kept rendering as "today" (the
#305 clock rebuild refreshed month data but not the closure's snapshot),
and after a live language switch day digits kept the previous locale's
shaping.

- CalendarDecorationState carries Culture; Update refreshes it on every
  rebuild (locale push path included)
- the callback reads DateTime.Today per call, so today/tomorrow highlights
  follow real midnight without any rebuild dependency
- NativeWidgetLease: removed the unused instanceDataRoot field and put
  instanceId to work in the destroy-retry diagnostic log

Tests: 3599/3599 green.
