### PR TITLE
feat: display-element toggles and time format reach the native glance

### DIFF
--- a/src/DeskBox.GlancePackage/Rendering/GlanceDataFile.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceDataFile.cs
@@ -44,6 +44,14 @@ internal static class GlanceDataFile
             if (TryString(raw, "localFolderPath", out string? folder) && !string.IsNullOrWhiteSpace(folder)) settings.LocalFolderPath = folder;
             if (TryEnum<GlanceImageFitMode>(raw, "imageFit", out var fit)) settings.ImageFit = fit;
             if (TryBool(raw, "showPhotoControls", out bool controls)) settings.ShowPhotoControls = controls;
+            // Display-element toggles + time format (parity batch: built-in
+            // UpdateClockTimer/visibility semantics consume these).
+            if (TryBool(raw, "showTime", out bool showTime)) settings.ShowTime = showTime;
+            if (TryBool(raw, "showDate", out bool showDate)) settings.ShowDate = showDate;
+            if (TryBool(raw, "showYear", out bool showYear)) settings.ShowYear = showYear;
+            if (TryBool(raw, "showWeekday", out bool showWeekday)) settings.ShowWeekday = showWeekday;
+            if (TryBool(raw, "showCalendar", out bool showCalendar)) settings.ShowCalendar = showCalendar;
+            if (TryEnum<GlanceTimeFormatMode>(raw, "timeFormat", out var timeFormat)) settings.TimeFormat = timeFormat;
             return new GlanceData(settings, raw);
         }
         catch
@@ -156,6 +164,15 @@ internal static class GlanceDataFile
         if (skip?.Contains("localFolderPath") != true && only?.Contains("localFolderPath") != false) writer.WriteString("localFolderPath", settings.LocalFolderPath);
         if (skip?.Contains("imageFit") != true && only?.Contains("imageFit") != false) writer.WriteString("imageFit", settings.ImageFit.ToString());
         if (skip?.Contains("showPhotoControls") != true && only?.Contains("showPhotoControls") != false) writer.WriteBoolean("showPhotoControls", settings.ShowPhotoControls);
+        // Display-element toggles: the package never mutates these (host
+        // settings UI owns them pre-cutover), but they ride the typed
+        // round-trip so a full-cache save preserves them exactly.
+        if (skip?.Contains("showTime") != true && only?.Contains("showTime") != false) writer.WriteBoolean("showTime", settings.ShowTime);
+        if (skip?.Contains("showDate") != true && only?.Contains("showDate") != false) writer.WriteBoolean("showDate", settings.ShowDate);
+        if (skip?.Contains("showYear") != true && only?.Contains("showYear") != false) writer.WriteBoolean("showYear", settings.ShowYear);
+        if (skip?.Contains("showWeekday") != true && only?.Contains("showWeekday") != false) writer.WriteBoolean("showWeekday", settings.ShowWeekday);
+        if (skip?.Contains("showCalendar") != true && only?.Contains("showCalendar") != false) writer.WriteBoolean("showCalendar", settings.ShowCalendar);
+        if (skip?.Contains("timeFormat") != true && only?.Contains("timeFormat") != false) writer.WriteString("timeFormat", settings.TimeFormat.ToString());
     }
 
     private static bool TryBool(JsonElement root, string property, out bool value)

--- a/src/DeskBox.GlancePackage/Rendering/GlanceDisplayPolicy.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceDisplayPolicy.cs
@@ -1,0 +1,161 @@
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using DeskBox.Models;
+
+namespace DeskBox.GlancePackage.Rendering;
+
+/// <summary>
+/// Pure display composition rules ported VERBATIM from the built-in
+/// GlanceWidgetViewModel (FormatTimeText / RemoveAmPmDesignator /
+/// FormatDateText / FormatCompactCalendarDateText / ShowCalendar) so the
+/// native widget renders byte-identical strings. Keep in lockstep with the
+/// host view model when either side changes.
+/// </summary>
+internal static class GlanceDisplayPolicy
+{
+    /// <summary>
+    /// Built-in ShowCalendar: the user setting gated by the responsive floor
+    /// below which the calendar surface does not fit.
+    /// </summary>
+    public static bool ShowCalendarEffective(bool showCalendar, double availableWidth, double availableHeight) =>
+        showCalendar && availableWidth >= 300 && availableHeight >= 280;
+
+    /// <summary>
+    /// Built-in UpdateClockTimer cadence: a time display needs per-minute
+    /// ticks; date/weekday/calendar-only needs one tick per midnight;
+    /// nothing that displays time or dates needs no clock at all.
+    /// </summary>
+    public static ClockCadence ComputeClockCadence(
+        bool showTime, bool showDate, bool showWeekday, bool showCalendarEffective,
+        GlanceTraditionalCalendarMode traditionalMode)
+    {
+        bool needsCalendarClock = showDate || showWeekday || showCalendarEffective ||
+                                  traditionalMode != GlanceTraditionalCalendarMode.None;
+        if (!showTime && !needsCalendarClock)
+        {
+            return ClockCadence.None;
+        }
+        return showTime ? ClockCadence.PerMinute : ClockCadence.PerMidnight;
+    }
+
+    /// <summary>Delay until the cadence's next boundary (minute or midnight,
+    /// +100 ms past-midnight guard mirroring the built-in).</summary>
+    public static TimeSpan DelayToBoundary(ClockCadence cadence, DateTime now) =>
+        cadence switch
+        {
+            ClockCadence.PerMidnight => now.Date.AddDays(1).AddMilliseconds(100) - now,
+            _ => DelayToNextMinute(now),
+        };
+
+    /// <summary>One-shot interval to the next minute boundary (+50 ms guard
+    /// so the tick lands just past the boundary, mirroring the built-in cadence).</summary>
+    public static TimeSpan DelayToNextMinute(DateTime now)
+    {
+        double remainingMs = 60_000 - (now.Second * 1000) - now.Millisecond;
+        return TimeSpan.FromMilliseconds(Math.Max(1, remainingMs) + 50);
+    }
+
+    public static string FormatTimeText(
+        DateTime date,
+        GlanceTimeFormatMode mode,
+        CultureInfo displayCulture,
+        CultureInfo? systemCulture = null)
+    {
+        CultureInfo timeCulture = mode == GlanceTimeFormatMode.FollowSystem
+            ? systemCulture ?? CultureInfo.CurrentCulture
+            : displayCulture;
+        string pattern = mode switch
+        {
+            GlanceTimeFormatMode.FollowSystem => RemoveAmPmDesignator(
+                timeCulture.DateTimeFormat.ShortTimePattern),
+            GlanceTimeFormatMode.Hour24 => "HH:mm",
+            GlanceTimeFormatMode.Hour12 => "h:mm",
+            _ => RemoveAmPmDesignator(
+                CultureInfo.CurrentCulture.DateTimeFormat.ShortTimePattern)
+        };
+        return date.ToString(pattern, timeCulture);
+    }
+
+    /// <summary>Strips AM/PM designator tokens from a time pattern while
+    /// respecting quoted literals and backslash escapes (built-in algorithm).</summary>
+    private static string RemoveAmPmDesignator(string pattern)
+    {
+        StringBuilder result = new(pattern.Length);
+        for (int index = 0; index < pattern.Length; index++)
+        {
+            char current = pattern[index];
+            if (current is '\'' or '"')
+            {
+                char quote = current;
+                result.Append(current);
+                while (++index < pattern.Length)
+                {
+                    result.Append(pattern[index]);
+                    if (pattern[index] == quote)
+                    {
+                        break;
+                    }
+                }
+                continue;
+            }
+
+            if (current == '\\' && index + 1 < pattern.Length)
+            {
+                result.Append(current);
+                result.Append(pattern[++index]);
+                continue;
+            }
+
+            if (current == 't')
+            {
+                while (index + 1 < pattern.Length && pattern[index + 1] == 't')
+                {
+                    index++;
+                }
+                continue;
+            }
+
+            result.Append(current);
+        }
+
+        return result.ToString().Trim();
+    }
+
+    public static string FormatDateText(DateTime date, CultureInfo culture, bool includeYear)
+    {
+        if (!includeYear)
+        {
+            return date.ToString("M", culture);
+        }
+
+        // LongDatePattern already carries the locale's natural year/month/day
+        // order. Remove its weekday token because weekday is an independent
+        // Glance display option.
+        string pattern = Regex.Replace(
+            culture.DateTimeFormat.LongDatePattern,
+            @"(?<!d)d{3,4}(?!d)",
+            string.Empty,
+            RegexOptions.CultureInvariant);
+        pattern = pattern.Trim().Trim(',', '，', '،').Trim();
+        return date.ToString(pattern, culture);
+    }
+
+    public static string FormatCompactCalendarDateText(DateTime date, CultureInfo culture)
+    {
+        string day = date.Day.ToString(culture);
+        return culture.TwoLetterISOLanguageName switch
+        {
+            "zh" or "ja" => $"{day}日",
+            "ko" => $"{day}일",
+            _ => day
+        };
+    }
+}
+
+internal enum ClockCadence
+{
+    None,
+    PerMinute,
+    PerMidnight,
+}

--- a/src/DeskBox.GlancePackage/Rendering/GlanceLifecyclePolicy.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceLifecyclePolicy.cs
@@ -8,29 +8,26 @@ namespace DeskBox.GlancePackage.Rendering;
 /// </summary>
 internal static class GlanceLifecyclePolicy
 {
-    internal readonly record struct Activity(bool ClockRunning, bool RotationRunning);
+    internal readonly record struct Activity(ClockCadence Cadence, bool RotationRunning);
 
+    /// <summary>
+    /// Cadence comes from GlanceDisplayPolicy.ComputeClockCadence (the
+    /// display-settings half of the decision); this gate applies the
+    /// energy half - hidden/long-hidden stops everything, compact and user
+    /// pause stop only the image rotation.
+    /// </summary>
     internal static Activity Compute(
         bool visible,
         bool longHidden,
         bool collapsed,
         bool paused,
+        ClockCadence cadence,
         bool rotationConfigured,
         bool multipleImages)
     {
         bool active = visible && !longHidden;
         return new Activity(
-            ClockRunning: active,
+            Cadence: active ? cadence : ClockCadence.None,
             RotationRunning: active && !collapsed && !paused && rotationConfigured && multipleImages);
-    }
-
-    /// <summary>
-    /// One-shot interval to the next minute boundary (+50 ms guard so the
-    /// tick lands just past the boundary, mirroring the built-in cadence).
-    /// </summary>
-    internal static TimeSpan DelayToNextMinute(DateTime now)
-    {
-        double remainingMs = 60_000 - (now.Second * 1000) - now.Millisecond;
-        return TimeSpan.FromMilliseconds(Math.Max(1, remainingMs) + 50);
     }
 }

--- a/src/DeskBox.GlancePackage/Rendering/GlanceMonthPipeline.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceMonthPipeline.cs
@@ -48,18 +48,17 @@ internal static class GlanceMonthPipeline
 
     public static GlancePresentation CreatePresentation(
         GlanceCalendarMonth month, bool isCompact, double panelHeight, double panelWidth,
-        CultureInfo culture, double availableWidth, double availableHeight)
+        GlanceWidgetData settings, CultureInfo culture, double availableWidth, double availableHeight)
     {
         DateTime now = DateTime.Now;
         double compactFontSize = Math.Round(Math.Clamp(Math.Min(availableWidth * 0.078, availableHeight * 0.095), 22, 28) * 2) / 2;
         return new GlancePresentation
         {
-            TimeText = now.ToString("HH:mm", culture),
-            // "M" is the culture-aware month-day pattern (Chinese locales
-            // render their native month-day form); never hard-code one
-            // locale's literal format here.
-            DateText = now.ToString("M", culture),
-            WeekdayText = culture.DateTimeFormat.GetDayName(now.DayOfWeek),
+            TimeText = GlanceDisplayPolicy.FormatTimeText(now, settings.TimeFormat, culture),
+            // Culture-aware month-day (or long-date-with-year) pattern.
+            DateText = GlanceDisplayPolicy.FormatDateText(now, culture, settings.ShowYear),
+            WeekdayText = now.ToString("dddd", culture),
+            CompactCalendarDateText = GlanceDisplayPolicy.FormatCompactCalendarDateText(now, culture),
             TraditionalCalendarTitle = month.TraditionalTitle,
             TimeFontFamily = new FontFamily("XamlAutoFontFamily"),
             CompactTimeFontSize = compactFontSize,
@@ -70,6 +69,15 @@ internal static class GlanceMonthPipeline
             CalendarCornerRadius = new CornerRadius(12),
             PlayIconVisibility = Visibility.Collapsed,
             PauseIconVisibility = Visibility.Visible,
+            // Built-in display toggles gate each element; the calendar
+            // surface additionally carries the responsive floor.
+            TimeVisibility = settings.ShowTime ? Visibility.Visible : Visibility.Collapsed,
+            DateVisibility = settings.ShowDate ? Visibility.Visible : Visibility.Collapsed,
+            WeekdayVisibility = settings.ShowWeekday ? Visibility.Visible : Visibility.Collapsed,
+            CalendarHeaderVisibility = isCompact ? Visibility.Visible : Visibility.Collapsed,
+            CalendarSurfaceVisibility = GlanceDisplayPolicy.ShowCalendarEffective(
+                settings.ShowCalendar, availableWidth, availableHeight)
+                ? Visibility.Visible : Visibility.Collapsed,
         };
     }
 }
@@ -77,23 +85,30 @@ internal static class GlanceMonthPipeline
 [WinRT.GeneratedBindableCustomProperty([
     nameof(CalendarCompactTimeFontSize),
     nameof(CalendarCornerRadius),
+    nameof(CalendarHeaderVisibility),
     nameof(CalendarPanelHeight),
     nameof(CalendarPanelMaxWidth),
     nameof(CalendarPanelWidth),
+    nameof(CalendarSurfaceVisibility),
+    nameof(CompactCalendarDateText),
     nameof(CompactTimeFontSize),
     nameof(DateText),
+    nameof(DateVisibility),
     nameof(PauseIconVisibility),
     nameof(PlayIconVisibility),
     nameof(TimeFontFamily),
     nameof(TimeText),
+    nameof(TimeVisibility),
     nameof(TraditionalCalendarTitle),
-    nameof(WeekdayText)
+    nameof(WeekdayText),
+    nameof(WeekdayVisibility)
 ], [])]
 public sealed partial class GlancePresentation
 {
     public string TimeText { get; init; } = "";
     public string DateText { get; init; } = "";
     public string WeekdayText { get; init; } = "";
+    public string CompactCalendarDateText { get; init; } = "";
     public string TraditionalCalendarTitle { get; init; } = "";
     public FontFamily TimeFontFamily { get; init; } = new("XamlAutoFontFamily");
     public double CompactTimeFontSize { get; init; }
@@ -102,6 +117,11 @@ public sealed partial class GlancePresentation
     public double CalendarPanelWidth { get; init; }
     public double CalendarPanelMaxWidth { get; init; }
     public CornerRadius CalendarCornerRadius { get; init; }
+    public Visibility TimeVisibility { get; init; }
+    public Visibility DateVisibility { get; init; }
+    public Visibility WeekdayVisibility { get; init; }
+    public Visibility CalendarHeaderVisibility { get; init; }
+    public Visibility CalendarSurfaceVisibility { get; init; }
     public Visibility PlayIconVisibility { get; set; }
     public Visibility PauseIconVisibility { get; set; }
 }

--- a/src/DeskBox.GlancePackage/Rendering/GlanceWidgetController.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceWidgetController.cs
@@ -85,7 +85,7 @@ internal sealed class GlanceWidgetController : IDisposable
 
         _content = (FrameworkElement)XamlReader.Load(
             File.ReadAllText(Path.Combine(packageRoot, "glance.xaml")));
-        _content.DataContext = GlanceMonthPipeline.CreatePresentation(_month, _isCompact, _panelHeight, _panelWidth, _culture, _width, _height);
+        _content.DataContext = GlanceMonthPipeline.CreatePresentation(_month, _isCompact, _panelHeight, _panelWidth, Settings, _culture, _width, _height);
 
         var calendarView = _content.FindName("NativeCalendarView").As<CalendarView>();
         _decoration = new CalendarDecorationState(_month, dayItemHeight, showTraditional, showFestivals, showSecondary, _culture);
@@ -266,17 +266,29 @@ internal sealed class GlanceWidgetController : IDisposable
 
     // ---- Timers ----
 
+    /// <summary>
+    /// Built-in UpdateClockTimer cadence: a time display ticks per minute;
+    /// date/weekday/calendar/traditional-only ticks once per midnight;
+    /// nothing that displays time or dates needs no clock.
+    /// </summary>
+    private ClockCadence CurrentClockCadence() =>
+        GlanceDisplayPolicy.ComputeClockCadence(
+            Settings.ShowTime, Settings.ShowDate, Settings.ShowWeekday,
+            GlanceDisplayPolicy.ShowCalendarEffective(Settings.ShowCalendar, _width, _height),
+            Settings.TraditionalCalendarMode);
+
     private void UpdateTimers()
     {
         if (_disposed) return;
+        ClockCadence cadence = CurrentClockCadence();
         GlanceLifecyclePolicy.Activity activity = GlanceLifecyclePolicy.Compute(
             _visible, _longHidden, _collapsed, _runtimeState.Paused,
-            Settings.RotationIntervalMinutes > 0, _images.Length > 1);
+            cadence, Settings.RotationIntervalMinutes > 0, _images.Length > 1);
 
         _clockTimer.Stop();
-        if (activity.ClockRunning)
+        if (activity.Cadence != ClockCadence.None)
         {
-            _clockTimer.Interval = GlanceLifecyclePolicy.DelayToNextMinute(DateTime.Now);
+            _clockTimer.Interval = GlanceDisplayPolicy.DelayToBoundary(activity.Cadence, DateTime.Now);
             _clockTimer.Start();
         }
 
@@ -297,9 +309,13 @@ internal sealed class GlanceWidgetController : IDisposable
         EnsureCurrentDate();
         // Re-arm the one-shot clock only; restarting the rotation timer here
         // would reset its progress.
+        ClockCadence cadence = CurrentClockCadence();
         _clockTimer.Stop();
-        _clockTimer.Interval = GlanceLifecyclePolicy.DelayToNextMinute(DateTime.Now);
-        _clockTimer.Start();
+        if (cadence != ClockCadence.None)
+        {
+            _clockTimer.Interval = GlanceDisplayPolicy.DelayToBoundary(cadence, DateTime.Now);
+            _clockTimer.Start();
+        }
     }
 
     /// <summary>
@@ -321,7 +337,7 @@ internal sealed class GlanceWidgetController : IDisposable
     private void UpdateClockText()
     {
         _content.DataContext = GlanceMonthPipeline.CreatePresentation(
-            _month, _isCompact, _panelHeight, _panelWidth, _culture, _width, _height);
+            _month, _isCompact, _panelHeight, _panelWidth, Settings, _culture, _width, _height);
     }
 
     // ---- Settings (host-authoritative write-through) ----

--- a/src/DeskBox.GlancePackage/Rendering/glance.xaml
+++ b/src/DeskBox.GlancePackage/Rendering/glance.xaml
@@ -39,8 +39,9 @@
         Opacity="0.42" />
 
     <Grid x:Name="CalendarLayoutRoot" Padding="20,22,20,18">
-        <Border
-            x:Name="CalendarGlassSurface"
+                <Border
+                    x:Name="CalendarGlassSurface"
+                    Visibility="{Binding CalendarSurfaceVisibility}"
             Height="{Binding CalendarPanelHeight}"
             HorizontalAlignment="Center"
             Margin="-6,0,-6,0"
@@ -59,8 +60,12 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
-                    <Grid Grid.Row="0" Height="27" Margin="13,7,6,0" Visibility="Collapsed">
-                        <TextBlock x:Name="CompactTimeText" Margin="0,5,0,-5" HorizontalAlignment="Left" FontSize="22" FontWeight="SemiBold" Foreground="{StaticResource TextFillColorPrimaryBrush}" LineHeight="26" LineStackingStrategy="BlockLineHeight" Text="{Binding TimeText}" Typography.NumeralAlignment="Tabular" />
+                    <Grid Grid.Row="0" Height="27" Margin="13,7,6,0" Visibility="{Binding CalendarHeaderVisibility}">
+                        <TextBlock x:Name="CompactTimeText" Margin="0,5,0,-5" HorizontalAlignment="Left" FontSize="22" FontWeight="SemiBold" Foreground="{StaticResource TextFillColorPrimaryBrush}" LineHeight="26" LineStackingStrategy="BlockLineHeight" Text="{Binding TimeText}" Typography.NumeralAlignment="Tabular" Visibility="{Binding TimeVisibility}" />
+                        <StackPanel Margin="0,5,0,-5" HorizontalAlignment="Right" VerticalAlignment="Top">
+                            <TextBlock HorizontalAlignment="Right" FontSize="10" FontWeight="SemiBold" Foreground="{StaticResource TextFillColorPrimaryBrush}" LineHeight="12" LineStackingStrategy="BlockLineHeight" Text="{Binding CompactCalendarDateText}" Typography.NumeralAlignment="Tabular" Visibility="{Binding DateVisibility}" />
+                            <TextBlock HorizontalAlignment="Right" FontSize="9.5" Foreground="{StaticResource TextFillColorSecondaryBrush}" LineHeight="11" LineStackingStrategy="BlockLineHeight" Text="{Binding WeekdayText}" Visibility="{Binding WeekdayVisibility}" />
+                        </StackPanel>
                     </Grid>
                     <Grid Grid.Row="1">
                         <CalendarView

--- a/tests/DeskBox.Tests/NativeGlanceDataGoldenTests.cs
+++ b/tests/DeskBox.Tests/NativeGlanceDataGoldenTests.cs
@@ -232,7 +232,8 @@ public class NativeGlanceDataGoldenTests
         string full = GlanceDataFile.BuildOwnedPatch(settings);
         using (JsonDocument document = JsonDocument.Parse(full))
         {
-            Assert.Equal(9, document.RootElement.EnumerateObject().Count());
+            // 9 interaction fields + 6 display-element/time-format fields.
+            Assert.Equal(15, document.RootElement.EnumerateObject().Count());
         }
     }
 

--- a/tests/DeskBox.Tests/NativeGlanceDisplayPolicyTests.cs
+++ b/tests/DeskBox.Tests/NativeGlanceDisplayPolicyTests.cs
@@ -1,0 +1,74 @@
+extern alias GlancePkg;
+
+using System.Globalization;
+
+namespace DeskBox.Tests;
+
+using Display = GlancePkg::DeskBox.GlancePackage.Rendering.GlanceDisplayPolicy;
+using GlanceTimeFormatMode = GlancePkg::DeskBox.Models.GlanceTimeFormatMode;
+
+/// <summary>
+/// Display composition parity (behavior parity batch 1): the ported
+/// FormatTimeText / FormatDateText / FormatCompactCalendarDateText must
+/// produce the same strings as the built-in view model for the same inputs.
+/// </summary>
+public class NativeGlanceDisplayPolicyTests
+{
+    private static readonly DateTime Sample = new(2026, 9, 9, 15, 5, 0); // 3:05 PM
+    private static readonly CultureInfo En = CultureInfo.GetCultureInfo("en-US");
+    private static readonly CultureInfo Zh = CultureInfo.GetCultureInfo("zh-CN");
+
+    [Fact]
+    public void Hour24AndHour12UseExplicitPatterns()
+    {
+        Assert.Equal("15:05", Display.FormatTimeText(Sample, GlanceTimeFormatMode.Hour24, En));
+        Assert.Equal("3:05", Display.FormatTimeText(Sample, GlanceTimeFormatMode.Hour12, En));
+    }
+
+    [Fact]
+    public void FollowSystemUsesSystemCultureAndStripsAmPm()
+    {
+        // en-US ShortTimePattern is "h:mm tt"; FollowSystem strips the
+        // AM/PM designator but keeps the system culture's 12-hour numbers.
+        string text = Display.FormatTimeText(
+            Sample, GlanceTimeFormatMode.FollowSystem, Zh, systemCulture: En);
+        Assert.Equal("3:05", text);
+        Assert.DoesNotContain("AM", text, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("PM", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DateTextWithoutYearUsesCultureMonthDay()
+    {
+        string text = Display.FormatDateText(Sample, Zh, includeYear: false);
+        Assert.Equal("9月9日", text);
+    }
+
+    [Fact]
+    public void DateTextWithYearUsesLongDatePatternWithoutWeekday()
+    {
+        string text = Display.FormatDateText(Sample, En, includeYear: true);
+        // en-US LongDatePattern "dddd, MMMM d, yyyy" minus weekday.
+        Assert.Equal("September 9, 2026", text);
+        Assert.DoesNotContain("Wednesday", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CompactDateSuffixFollowsLocale()
+    {
+        Assert.Equal("9日", Display.FormatCompactCalendarDateText(Sample, Zh));
+        Assert.Equal("9日", Display.FormatCompactCalendarDateText(Sample, CultureInfo.GetCultureInfo("ja-JP")));
+        Assert.Equal("9", Display.FormatCompactCalendarDateText(Sample, En));
+    }
+
+    [Fact]
+    public void TwelveHourSurvivesQuotedLiterals()
+    {
+        // A pattern with a quoted literal containing "t" must not lose the
+        // literal - the designator stripper respects quotes.
+        var culture = (CultureInfo)En.Clone();
+        culture.DateTimeFormat.ShortTimePattern = "'at' h:mm tt";
+        string text = Display.FormatTimeText(Sample, GlanceTimeFormatMode.FollowSystem, culture, systemCulture: culture);
+        Assert.Equal("at 3:05", text);
+    }
+}

--- a/tests/DeskBox.Tests/NativeGlanceLifecyclePolicyTests.cs
+++ b/tests/DeskBox.Tests/NativeGlanceLifecyclePolicyTests.cs
@@ -3,76 +3,75 @@ extern alias GlancePkg;
 namespace DeskBox.Tests;
 
 using Policy = GlancePkg::DeskBox.GlancePackage.Rendering.GlanceLifecyclePolicy;
+using Display = GlancePkg::DeskBox.GlancePackage.Rendering.GlanceDisplayPolicy;
+using ClockCadence = GlancePkg::DeskBox.GlancePackage.Rendering.ClockCadence;
+using GlanceTimeFormatMode = GlancePkg::DeskBox.Models.GlanceTimeFormatMode;
 
 /// <summary>
 /// The energy policy behind the native glance lifecycle (audit rounds
 /// 18-19): hidden/long-hidden stops everything, compact and user pause stop
-/// only the image rotation, and the clock re-arms on minute boundaries.
-/// Pure logic, so these run the real package code.
+/// only the image rotation, and the clock cadence (per-minute for a time
+/// display, per-midnight for date/calendar-only, none otherwise) follows the
+/// built-in UpdateClockTimer semantics. Pure logic running the real package
+/// code.
 /// </summary>
 public class NativeGlanceLifecyclePolicyTests
 {
+    private static Policy.Activity Compute(
+        bool visible = true, bool longHidden = false, bool collapsed = false,
+        bool paused = false, ClockCadence cadence = ClockCadence.PerMinute,
+        bool rotationConfigured = true, bool multipleImages = true) =>
+        Policy.Compute(visible, longHidden, collapsed, paused, cadence, rotationConfigured, multipleImages);
+
     [Fact]
     public void VisibleAndIdleRunsEverything()
     {
-        Policy.Activity activity = Policy.Compute(
-            visible: true, longHidden: false, collapsed: false,
-            paused: false, rotationConfigured: true, multipleImages: true);
-        Assert.True(activity.ClockRunning);
+        Policy.Activity activity = Compute();
+        Assert.Equal(ClockCadence.PerMinute, activity.Cadence);
         Assert.True(activity.RotationRunning);
     }
 
     [Fact]
     public void HiddenStopsEverything()
     {
-        Policy.Activity activity = Policy.Compute(
-            visible: false, longHidden: false, collapsed: false,
-            paused: false, rotationConfigured: true, multipleImages: true);
-        Assert.False(activity.ClockRunning);
+        Policy.Activity activity = Compute(visible: false);
+        Assert.Equal(ClockCadence.None, activity.Cadence);
         Assert.False(activity.RotationRunning);
     }
 
     [Fact]
     public void LongHiddenStopsEverythingButClockSurvivesReveal()
     {
-        Policy.Activity hidden = Policy.Compute(
-            visible: true, longHidden: true, collapsed: false,
-            paused: false, rotationConfigured: true, multipleImages: true);
-        Assert.False(hidden.ClockRunning);
+        Policy.Activity hidden = Compute(longHidden: true);
+        Assert.Equal(ClockCadence.None, hidden.Cadence);
         Assert.False(hidden.RotationRunning);
 
         // The controller clears the long-hidden latch on reveal.
-        Policy.Activity revealed = Policy.Compute(
-            visible: true, longHidden: false, collapsed: false,
-            paused: false, rotationConfigured: true, multipleImages: true);
-        Assert.True(revealed.ClockRunning);
+        Policy.Activity revealed = Compute();
+        Assert.Equal(ClockCadence.PerMinute, revealed.Cadence);
     }
 
-    [Theory]
-    [InlineData(true)]  // compact
-    [InlineData(false)] // user pause
-    public void CompactAndPauseStopRotationOnly(bool collapsed)
+    [Fact]
+    public void CompactAndPauseStopRotationOnly()
     {
-        Policy.Activity activity = Policy.Compute(
-            visible: true, longHidden: false, collapsed: collapsed,
-            paused: !collapsed, rotationConfigured: true, multipleImages: true);
-        Assert.True(activity.ClockRunning);
-        Assert.False(activity.RotationRunning);
+        Policy.Activity compact = Compute(collapsed: true);
+        Assert.Equal(ClockCadence.PerMinute, compact.Cadence);
+        Assert.False(compact.RotationRunning);
+
+        Policy.Activity paused = Compute(paused: true);
+        Assert.Equal(ClockCadence.PerMinute, paused.Cadence);
+        Assert.False(paused.RotationRunning);
     }
 
     [Fact]
     public void RotationRequiresConfigurationAndImages()
     {
-        Policy.Activity noInterval = Policy.Compute(
-            visible: true, longHidden: false, collapsed: false,
-            paused: false, rotationConfigured: false, multipleImages: true);
-        Assert.True(noInterval.ClockRunning);
+        Policy.Activity noInterval = Compute(rotationConfigured: false);
+        Assert.Equal(ClockCadence.PerMinute, noInterval.Cadence);
         Assert.False(noInterval.RotationRunning);
 
-        Policy.Activity singleImage = Policy.Compute(
-            visible: true, longHidden: false, collapsed: false,
-            paused: false, rotationConfigured: true, multipleImages: false);
-        Assert.True(singleImage.ClockRunning);
+        Policy.Activity singleImage = Compute(multipleImages: false);
+        Assert.Equal(ClockCadence.PerMinute, singleImage.Cadence);
         Assert.False(singleImage.RotationRunning);
     }
 
@@ -80,12 +79,51 @@ public class NativeGlanceLifecyclePolicyTests
     public void ClockDelayLandsJustPastTheNextMinuteBoundary()
     {
         // 30.5s into the minute -> ~29.55s remaining + 50ms guard.
-        TimeSpan delay = Policy.DelayToNextMinute(new DateTime(2026, 9, 9, 12, 0, 30).AddMilliseconds(500));
+        TimeSpan delay = Display.DelayToNextMinute(new DateTime(2026, 9, 9, 12, 0, 30).AddMilliseconds(500));
         Assert.InRange(delay.TotalMilliseconds, 29_500, 29_650);
 
         // Right at a boundary second=0 the NEXT boundary is a full minute
         // away (+50ms guard) - matching the built-in's (60 - Second) math.
-        TimeSpan boundary = Policy.DelayToNextMinute(new DateTime(2026, 9, 9, 12, 1, 0));
+        TimeSpan boundary = Display.DelayToNextMinute(new DateTime(2026, 9, 9, 12, 1, 0));
         Assert.InRange(boundary.TotalMilliseconds, 60_000, 60_150);
+    }
+
+    [Fact]
+    public void MidnightCadenceDelaysToJustPastMidnight()
+    {
+        // Built-in parity: date/weekday/calendar-only widgets tick once per
+        // day, 100 ms past the next midnight.
+        DateTime now = new(2026, 9, 9, 23, 59, 0);
+        TimeSpan delay = Display.DelayToBoundary(ClockCadence.PerMidnight, now);
+        Assert.InRange(delay.TotalMinutes, 0.9, 1.1);
+    }
+
+    [Fact]
+    public void ClockCadenceFollowsDisplaySettings()
+    {
+        var mode = GlancePkg::DeskBox.Models.GlanceTraditionalCalendarMode.None;
+        Assert.Equal(ClockCadence.None, Display.ComputeClockCadence(
+            showTime: false, showDate: false, showWeekday: false, showCalendarEffective: false, traditionalMode: mode));
+        Assert.Equal(ClockCadence.PerMinute, Display.ComputeClockCadence(
+            showTime: true, showDate: false, showWeekday: false, showCalendarEffective: false, traditionalMode: mode));
+        // Any date-bearing element without a clock ticks once per midnight.
+        Assert.Equal(ClockCadence.PerMidnight, Display.ComputeClockCadence(
+            showTime: false, showDate: true, showWeekday: false, showCalendarEffective: false, traditionalMode: mode));
+        Assert.Equal(ClockCadence.PerMidnight, Display.ComputeClockCadence(
+            showTime: false, showDate: false, showWeekday: false, showCalendarEffective: true, traditionalMode: mode));
+        Assert.Equal(ClockCadence.PerMidnight, Display.ComputeClockCadence(
+            showTime: false, showDate: false, showWeekday: false, showCalendarEffective: false,
+            traditionalMode: GlancePkg::DeskBox.Models.GlanceTraditionalCalendarMode.Hebrew));
+    }
+
+    [Fact]
+    public void ShowCalendarCarriesTheResponsiveFloor()
+    {
+        Assert.True(Display.ShowCalendarEffective(true, 440, 560));
+        Assert.False(Display.ShowCalendarEffective(false, 440, 560));
+        // Built-in floor: width >= 300 and height >= 280.
+        Assert.False(Display.ShowCalendarEffective(true, 299, 560));
+        Assert.False(Display.ShowCalendarEffective(true, 440, 279));
+        Assert.True(Display.ShowCalendarEffective(true, 300, 280));
     }
 }


### PR DESCRIPTION
feat: display-element toggles and time format reach the native glance

Behavior parity batch 1: the five display-element settings (showTime,
showDate, showYear, showWeekday, showCalendar) and timeFormat now drive the
native glance exactly as they drive the built-in widget.

- GlanceDisplayPolicy: verbatim ports of the built-in composition rules -
  FormatTimeText (FollowSystem uses the SYSTEM culture's ShortTimePattern
  with AM/PM designator tokens stripped while respecting quoted literals
  and escapes; Hour24 = HH:mm; Hour12 = h:mm), FormatDateText ("M" without
  year; LongDatePattern minus the weekday token with locale separator
  trimming when the year is shown), FormatCompactCalendarDateText (day +
  ri/��?suffix for zh/ja/ko), and the ShowCalendar responsive floor
  (enabled AND width >= 300 AND height >= 280)
- glance.xaml: the calendar layout header is now live - left time, right
  date/weekday stack, each gated by its display toggle via pre-computed
  presentation visibilities; the glass surface collapses when the
  calendar is off (built-in background-only semantics for the calendar
  layout)
- clock cadence follows the built-in UpdateClockTimer: per-minute with a
  time display, one tick past midnight for date/weekday/calendar/
  traditional-only widgets, no clock when neither is shown
- the six new fields ride the typed lossless round-trip and the migration
  semantic validator accepts them as bools / defined enum values

Tests +8: clock cadence matrix (per-minute / per-midnight / none),
midnight boundary delay, ShowCalendar responsive floor, time-format
outputs for en-US/zh-CN incl. the quoted-literal designator strip, date
composition with and without year, compact date suffix per locale.

Tests: 3607/3607 green.
