### PR TITLE
fix: migration validator learns the display-element and time-format fields

### DIFF
--- a/src/DeskBox/Services/GlanceInstanceMigration.cs
+++ b/src/DeskBox/Services/GlanceInstanceMigration.cs
@@ -75,7 +75,8 @@ internal sealed class GlanceInstanceMigration : ILegacyInstanceMigration
             {
                 bool typeValid = property.Name switch
                 {
-                    "showChineseFestivals" or "randomOrder" or "showPhotoControls" =>
+                    "showChineseFestivals" or "randomOrder" or "showPhotoControls" or
+                    "showTime" or "showDate" or "showYear" or "showWeekday" or "showCalendar" =>
                         property.Value.ValueKind is JsonValueKind.True or JsonValueKind.False,
                     "rotationIntervalMinutes" =>
                         property.Value.ValueKind == JsonValueKind.Number && property.Value.TryGetDouble(out _),
@@ -89,6 +90,7 @@ internal sealed class GlanceInstanceMigration : ILegacyInstanceMigration
                     "traditionalCalendarMode" => IsValidEnumValue<GlanceTraditionalCalendarMode>(property.Value),
                     "backgroundSource" => IsValidEnumValue<GlanceBackgroundSource>(property.Value),
                     "imageFit" => IsValidEnumValue<GlanceImageFitMode>(property.Value),
+                    "timeFormat" => IsValidEnumValue<GlanceTimeFormatMode>(property.Value),
                     _ => true,
                 };
                 if (!typeValid) return false;


### PR DESCRIPTION
fix: migration validator learns the display-element and time-format fields

Follow-up to the display parity batch: the GlanceInstanceMigration
semantic validator (synced-file field type checks) did not get the six
new fields - showTime/showDate/showYear/showWeekday/showCalendar as
bools and timeFormat as a defined enum. A synced file carrying, say,
"showTime": "yes" would have passed validation and been copied even
though the built-in deserializer rejects it, breaking the
validator-matches-built-in contract. Unknown-to-the-package fields stay
tolerated on purpose; these are known fields.
