### PR TITLE
feat: all four glance layouts reach the native package

### DIFF
--- a/src/DeskBox.GlancePackage/Rendering/GlanceDataFile.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceDataFile.cs
@@ -52,6 +52,7 @@ internal static class GlanceDataFile
             if (TryBool(raw, "showWeekday", out bool showWeekday)) settings.ShowWeekday = showWeekday;
             if (TryBool(raw, "showCalendar", out bool showCalendar)) settings.ShowCalendar = showCalendar;
             if (TryEnum<GlanceTimeFormatMode>(raw, "timeFormat", out var timeFormat)) settings.TimeFormat = timeFormat;
+            if (TryEnum<GlanceLayoutMode>(raw, "layout", out var layout)) settings.Layout = layout;
             return new GlanceData(settings, raw);
         }
         catch
@@ -173,6 +174,7 @@ internal static class GlanceDataFile
         if (skip?.Contains("showWeekday") != true && only?.Contains("showWeekday") != false) writer.WriteBoolean("showWeekday", settings.ShowWeekday);
         if (skip?.Contains("showCalendar") != true && only?.Contains("showCalendar") != false) writer.WriteBoolean("showCalendar", settings.ShowCalendar);
         if (skip?.Contains("timeFormat") != true && only?.Contains("timeFormat") != false) writer.WriteString("timeFormat", settings.TimeFormat.ToString());
+        if (skip?.Contains("layout") != true && only?.Contains("layout") != false) writer.WriteString("layout", settings.Layout.ToString());
     }
 
     private static bool TryBool(JsonElement root, string property, out bool value)

--- a/src/DeskBox.GlancePackage/Rendering/GlanceDisplayPolicy.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceDisplayPolicy.cs
@@ -22,15 +22,38 @@ internal static class GlanceDisplayPolicy
         showCalendar && availableWidth >= 300 && availableHeight >= 280;
 
     /// <summary>
+    /// Built-in layout resolution: Centered/Editorial map to themselves; the
+    /// Calendar layout degrades to Immersive (background + non-calendar
+    /// foreground) when the calendar is off or below the responsive floor.
+    /// </summary>
+    public static NativeLayout ResolveLayout(GlanceLayoutMode mode, bool showCalendarEffective) => mode switch
+    {
+        GlanceLayoutMode.Centered => NativeLayout.Centered,
+        GlanceLayoutMode.Editorial => NativeLayout.Editorial,
+        GlanceLayoutMode.Calendar => showCalendarEffective ? NativeLayout.Calendar : NativeLayout.Immersive,
+        _ => NativeLayout.Immersive,
+    };
+
+    /// <summary>Built-in TimeFontSize (TimeScale stays at 1 until the
+    /// font/scale settings batch).</summary>
+    public static double TimeFontSize(double availableWidth, double availableHeight) =>
+        RoundToHalf(Math.Clamp(Math.Min(availableWidth * 0.18, availableHeight * 0.28), 38, 78));
+
+    private static double RoundToHalf(double value) => Math.Round(value * 2) / 2;
+
+    /// <summary>
     /// Built-in UpdateClockTimer cadence: a time display needs per-minute
     /// ticks; date/weekday/calendar-only needs one tick per midnight;
-    /// nothing that displays time or dates needs no clock at all.
+    /// nothing that displays time or dates needs no clock at all. Uses the
+    /// RAW showCalendar setting (the built-in does not apply the responsive
+    /// floor here - a floored-off calendar still displays dates elsewhere
+    /// or may come back on resize).
     /// </summary>
     public static ClockCadence ComputeClockCadence(
-        bool showTime, bool showDate, bool showWeekday, bool showCalendarEffective,
+        bool showTime, bool showDate, bool showWeekday, bool showCalendar,
         GlanceTraditionalCalendarMode traditionalMode)
     {
-        bool needsCalendarClock = showDate || showWeekday || showCalendarEffective ||
+        bool needsCalendarClock = showDate || showWeekday || showCalendar ||
                                   traditionalMode != GlanceTraditionalCalendarMode.None;
         if (!showTime && !needsCalendarClock)
         {
@@ -158,4 +181,13 @@ internal enum ClockCadence
     None,
     PerMinute,
     PerMidnight,
+}
+
+/// <summary>The four built-in glance layouts (native resolution).</summary>
+internal enum NativeLayout
+{
+    Immersive,
+    Centered,
+    Editorial,
+    Calendar,
 }

--- a/src/DeskBox.GlancePackage/Rendering/GlanceMonthPipeline.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceMonthPipeline.cs
@@ -52,6 +52,12 @@ internal static class GlanceMonthPipeline
     {
         DateTime now = DateTime.Now;
         double compactFontSize = Math.Round(Math.Clamp(Math.Min(availableWidth * 0.078, availableHeight * 0.095), 22, 28) * 2) / 2;
+        // Built-in layout resolution: Calendar degrades to Immersive when the
+        // calendar is off or below the responsive floor.
+        bool calendarEffective = GlanceDisplayPolicy.ShowCalendarEffective(
+            settings.ShowCalendar, availableWidth, availableHeight);
+        NativeLayout layout = GlanceDisplayPolicy.ResolveLayout(settings.Layout, calendarEffective);
+        bool foreground = settings.ShowTime || settings.ShowDate || settings.ShowWeekday || calendarEffective;
         return new GlancePresentation
         {
             TimeText = GlanceDisplayPolicy.FormatTimeText(now, settings.TimeFormat, culture),
@@ -61,6 +67,7 @@ internal static class GlanceMonthPipeline
             CompactCalendarDateText = GlanceDisplayPolicy.FormatCompactCalendarDateText(now, culture),
             TraditionalCalendarTitle = month.TraditionalTitle,
             TimeFontFamily = new FontFamily("XamlAutoFontFamily"),
+            TimeFontSize = GlanceDisplayPolicy.TimeFontSize(availableWidth, availableHeight),
             CompactTimeFontSize = compactFontSize,
             CalendarCompactTimeFontSize = compactFontSize,
             CalendarPanelHeight = panelHeight,
@@ -70,14 +77,16 @@ internal static class GlanceMonthPipeline
             PlayIconVisibility = Visibility.Collapsed,
             PauseIconVisibility = Visibility.Visible,
             // Built-in display toggles gate each element; the calendar
-            // surface additionally carries the responsive floor.
+            // surface follows the resolved layout.
             TimeVisibility = settings.ShowTime ? Visibility.Visible : Visibility.Collapsed,
             DateVisibility = settings.ShowDate ? Visibility.Visible : Visibility.Collapsed,
             WeekdayVisibility = settings.ShowWeekday ? Visibility.Visible : Visibility.Collapsed,
-            CalendarHeaderVisibility = isCompact ? Visibility.Visible : Visibility.Collapsed,
-            CalendarSurfaceVisibility = GlanceDisplayPolicy.ShowCalendarEffective(
-                settings.ShowCalendar, availableWidth, availableHeight)
-                ? Visibility.Visible : Visibility.Collapsed,
+            CalendarHeaderVisibility = isCompact && layout == NativeLayout.Calendar ? Visibility.Visible : Visibility.Collapsed,
+            CalendarSurfaceVisibility = layout == NativeLayout.Calendar ? Visibility.Visible : Visibility.Collapsed,
+            ForegroundVisibility = foreground ? Visibility.Visible : Visibility.Collapsed,
+            ImmersiveVisibility = foreground && layout == NativeLayout.Immersive ? Visibility.Visible : Visibility.Collapsed,
+            CenteredVisibility = foreground && layout == NativeLayout.Centered ? Visibility.Visible : Visibility.Collapsed,
+            EditorialVisibility = foreground && layout == NativeLayout.Editorial ? Visibility.Visible : Visibility.Collapsed,
         };
     }
 }
@@ -90,13 +99,18 @@ internal static class GlanceMonthPipeline
     nameof(CalendarPanelMaxWidth),
     nameof(CalendarPanelWidth),
     nameof(CalendarSurfaceVisibility),
+    nameof(CenteredVisibility),
     nameof(CompactCalendarDateText),
     nameof(CompactTimeFontSize),
     nameof(DateText),
     nameof(DateVisibility),
+    nameof(EditorialVisibility),
+    nameof(ForegroundVisibility),
+    nameof(ImmersiveVisibility),
     nameof(PauseIconVisibility),
     nameof(PlayIconVisibility),
     nameof(TimeFontFamily),
+    nameof(TimeFontSize),
     nameof(TimeText),
     nameof(TimeVisibility),
     nameof(TraditionalCalendarTitle),
@@ -111,6 +125,7 @@ public sealed partial class GlancePresentation
     public string CompactCalendarDateText { get; init; } = "";
     public string TraditionalCalendarTitle { get; init; } = "";
     public FontFamily TimeFontFamily { get; init; } = new("XamlAutoFontFamily");
+    public double TimeFontSize { get; init; }
     public double CompactTimeFontSize { get; init; }
     public double CalendarCompactTimeFontSize { get; init; }
     public double CalendarPanelHeight { get; init; }
@@ -122,6 +137,10 @@ public sealed partial class GlancePresentation
     public Visibility WeekdayVisibility { get; init; }
     public Visibility CalendarHeaderVisibility { get; init; }
     public Visibility CalendarSurfaceVisibility { get; init; }
+    public Visibility ForegroundVisibility { get; init; }
+    public Visibility ImmersiveVisibility { get; init; }
+    public Visibility CenteredVisibility { get; init; }
+    public Visibility EditorialVisibility { get; init; }
     public Visibility PlayIconVisibility { get; set; }
     public Visibility PauseIconVisibility { get; set; }
 }

--- a/src/DeskBox.GlancePackage/Rendering/GlanceWidgetController.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceWidgetController.cs
@@ -274,7 +274,9 @@ internal sealed class GlanceWidgetController : IDisposable
     private ClockCadence CurrentClockCadence() =>
         GlanceDisplayPolicy.ComputeClockCadence(
             Settings.ShowTime, Settings.ShowDate, Settings.ShowWeekday,
-            GlanceDisplayPolicy.ShowCalendarEffective(Settings.ShowCalendar, _width, _height),
+            // Raw setting (built-in parity): the responsive floor only gates
+            // the surface, not the clock's midnight obligation.
+            Settings.ShowCalendar,
             Settings.TraditionalCalendarMode);
 
     private void UpdateTimers()

--- a/src/DeskBox.GlancePackage/Rendering/glance.xaml
+++ b/src/DeskBox.GlancePackage/Rendering/glance.xaml
@@ -38,7 +38,72 @@
         IsHitTestVisible="False"
         Opacity="0.42" />
 
-    <Grid x:Name="CalendarLayoutRoot" Padding="20,22,20,18">
+    <Grid
+        x:Name="ImageForegroundThemeScope"
+        Padding="20,22,20,18"
+        Visibility="{Binding ForegroundVisibility}">
+        <StackPanel
+            x:Name="ImmersiveLayoutRoot"
+            HorizontalAlignment="Left"
+            VerticalAlignment="Bottom"
+            Spacing="-2"
+            Visibility="{Binding ImmersiveVisibility}">
+            <TextBlock
+                FontFamily="{Binding TimeFontFamily}"
+                FontSize="{Binding TimeFontSize}"
+                FontWeight="SemiBold"
+                Foreground="{StaticResource TextFillColorPrimaryBrush}"
+                IsTextSelectionEnabled="False"
+                Text="{Binding TimeText}"
+                Typography.NumeralAlignment="Tabular"
+                Visibility="{Binding TimeVisibility}" />
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock FontSize="14" FontWeight="SemiBold" Foreground="{StaticResource TextFillColorPrimaryBrush}" Text="{Binding DateText}" Typography.NumeralAlignment="Tabular" Visibility="{Binding DateVisibility}" />
+                <TextBlock FontSize="14" Foreground="{StaticResource TextFillColorSecondaryBrush}" Text="{Binding WeekdayText}" Visibility="{Binding WeekdayVisibility}" />
+            </StackPanel>
+        </StackPanel>
+
+        <StackPanel
+            x:Name="CenteredLayoutRoot"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Spacing="2"
+            Visibility="{Binding CenteredVisibility}">
+            <TextBlock
+                HorizontalAlignment="Center"
+                FontFamily="{Binding TimeFontFamily}"
+                FontSize="{Binding TimeFontSize}"
+                FontWeight="SemiBold"
+                Foreground="{StaticResource TextFillColorPrimaryBrush}"
+                IsTextSelectionEnabled="False"
+                Text="{Binding TimeText}"
+                Typography.NumeralAlignment="Tabular"
+                Visibility="{Binding TimeVisibility}" />
+            <StackPanel HorizontalAlignment="Center" Orientation="Horizontal" Spacing="8">
+                <TextBlock FontSize="14" FontWeight="SemiBold" Foreground="{StaticResource TextFillColorPrimaryBrush}" Text="{Binding DateText}" Typography.NumeralAlignment="Tabular" Visibility="{Binding DateVisibility}" />
+                <TextBlock FontSize="14" Foreground="{StaticResource TextFillColorSecondaryBrush}" Text="{Binding WeekdayText}" Visibility="{Binding WeekdayVisibility}" />
+            </StackPanel>
+        </StackPanel>
+
+        <Grid x:Name="EditorialLayoutRoot" Visibility="{Binding EditorialVisibility}">
+            <StackPanel HorizontalAlignment="Left" VerticalAlignment="Top" Spacing="2">
+                <TextBlock FontSize="16" FontWeight="SemiBold" Foreground="{StaticResource TextFillColorPrimaryBrush}" Text="{Binding DateText}" Visibility="{Binding DateVisibility}" />
+                <TextBlock FontSize="13" Foreground="{StaticResource TextFillColorSecondaryBrush}" Text="{Binding WeekdayText}" Visibility="{Binding WeekdayVisibility}" />
+            </StackPanel>
+            <TextBlock
+                HorizontalAlignment="Right"
+                VerticalAlignment="Bottom"
+                FontFamily="{Binding TimeFontFamily}"
+                FontSize="{Binding CompactTimeFontSize}"
+                FontWeight="SemiBold"
+                Foreground="{StaticResource TextFillColorPrimaryBrush}"
+                Text="{Binding TimeText}"
+                Typography.NumeralAlignment="Tabular"
+                Visibility="{Binding TimeVisibility}" />
+        </Grid>
+    </Grid>
+
+    <Grid x:Name="CalendarLayoutRoot" Padding="20,22,20,18" Visibility="{Binding CalendarSurfaceVisibility}">
                 <Border
                     x:Name="CalendarGlassSurface"
                     Visibility="{Binding CalendarSurfaceVisibility}"

--- a/src/DeskBox/Services/GlanceInstanceMigration.cs
+++ b/src/DeskBox/Services/GlanceInstanceMigration.cs
@@ -91,6 +91,7 @@ internal sealed class GlanceInstanceMigration : ILegacyInstanceMigration
                     "backgroundSource" => IsValidEnumValue<GlanceBackgroundSource>(property.Value),
                     "imageFit" => IsValidEnumValue<GlanceImageFitMode>(property.Value),
                     "timeFormat" => IsValidEnumValue<GlanceTimeFormatMode>(property.Value),
+                    "layout" => IsValidEnumValue<GlanceLayoutMode>(property.Value),
                     _ => true,
                 };
                 if (!typeValid) return false;

--- a/tests/DeskBox.Tests/NativeGlanceDataGoldenTests.cs
+++ b/tests/DeskBox.Tests/NativeGlanceDataGoldenTests.cs
@@ -45,8 +45,7 @@ public class NativeGlanceDataGoldenTests
                   "showChineseFestivals": true,
                   "rotationIntervalMinutes": 30
                 }
-                """);
-            GlanceData? loaded = GlanceDataFile.Load(root);
+                """);            GlanceData? loaded = GlanceDataFile.Load(root);
             Assert.NotNull(loaded);
 
             // The user flips one package-owned toggle and the rotation.
@@ -232,8 +231,8 @@ public class NativeGlanceDataGoldenTests
         string full = GlanceDataFile.BuildOwnedPatch(settings);
         using (JsonDocument document = JsonDocument.Parse(full))
         {
-            // 9 interaction fields + 6 display-element/time-format fields.
-            Assert.Equal(15, document.RootElement.EnumerateObject().Count());
+            // 9 interaction fields + 6 display/time fields + layout.
+            Assert.Equal(16, document.RootElement.EnumerateObject().Count());
         }
     }
 

--- a/tests/DeskBox.Tests/NativeGlanceDisplayPolicyTests.cs
+++ b/tests/DeskBox.Tests/NativeGlanceDisplayPolicyTests.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 namespace DeskBox.Tests;
 
 using Display = GlancePkg::DeskBox.GlancePackage.Rendering.GlanceDisplayPolicy;
+using NativeLayout = GlancePkg::DeskBox.GlancePackage.Rendering.NativeLayout;
 using GlanceTimeFormatMode = GlancePkg::DeskBox.Models.GlanceTimeFormatMode;
 
 /// <summary>
@@ -59,6 +60,34 @@ public class NativeGlanceDisplayPolicyTests
         Assert.Equal("9日", Display.FormatCompactCalendarDateText(Sample, Zh));
         Assert.Equal("9日", Display.FormatCompactCalendarDateText(Sample, CultureInfo.GetCultureInfo("ja-JP")));
         Assert.Equal("9", Display.FormatCompactCalendarDateText(Sample, En));
+    }
+
+    [Fact]
+    public void LayoutResolutionMatchesBuiltIn()
+    {
+        var immersive = GlancePkg::DeskBox.Models.GlanceLayoutMode.Immersive;
+        var centered = GlancePkg::DeskBox.Models.GlanceLayoutMode.Centered;
+        var editorial = GlancePkg::DeskBox.Models.GlanceLayoutMode.Editorial;
+        var calendar = GlancePkg::DeskBox.Models.GlanceLayoutMode.Calendar;
+
+        Assert.Equal(NativeLayout.Immersive, Display.ResolveLayout(immersive, showCalendarEffective: true));
+        Assert.Equal(NativeLayout.Centered, Display.ResolveLayout(centered, showCalendarEffective: false));
+        Assert.Equal(NativeLayout.Editorial, Display.ResolveLayout(editorial, showCalendarEffective: false));
+        // Calendar degrades to Immersive when the calendar is off or below
+        // the responsive floor.
+        Assert.Equal(NativeLayout.Calendar, Display.ResolveLayout(calendar, showCalendarEffective: true));
+        Assert.Equal(NativeLayout.Immersive, Display.ResolveLayout(calendar, showCalendarEffective: false));
+    }
+
+    [Fact]
+    public void TimeFontSizeClampsToTheBuiltInRange()
+    {
+        // 440x560: min(79.2, 156.8) -> clamp 78.
+        Assert.Equal(78, Display.TimeFontSize(440, 560));
+        // Tiny surface: clamps at the 38 floor.
+        Assert.Equal(38, Display.TimeFontSize(120, 120));
+        // Mid-size: min(0.18w, 0.28h) rounded to the half-step.
+        Assert.Equal(45.5, Display.TimeFontSize(253, 162.5));
     }
 
     [Fact]

--- a/tests/DeskBox.Tests/NativeGlanceLifecyclePolicyTests.cs
+++ b/tests/DeskBox.Tests/NativeGlanceLifecyclePolicyTests.cs
@@ -103,16 +103,17 @@ public class NativeGlanceLifecyclePolicyTests
     {
         var mode = GlancePkg::DeskBox.Models.GlanceTraditionalCalendarMode.None;
         Assert.Equal(ClockCadence.None, Display.ComputeClockCadence(
-            showTime: false, showDate: false, showWeekday: false, showCalendarEffective: false, traditionalMode: mode));
+            showTime: false, showDate: false, showWeekday: false, showCalendar: false, traditionalMode: mode));
         Assert.Equal(ClockCadence.PerMinute, Display.ComputeClockCadence(
-            showTime: true, showDate: false, showWeekday: false, showCalendarEffective: false, traditionalMode: mode));
-        // Any date-bearing element without a clock ticks once per midnight.
+            showTime: true, showDate: false, showWeekday: false, showCalendar: false, traditionalMode: mode));
+        // Any date-bearing element without a clock ticks once per midnight
+        // (raw showCalendar setting - the built-in does not floor here).
         Assert.Equal(ClockCadence.PerMidnight, Display.ComputeClockCadence(
-            showTime: false, showDate: true, showWeekday: false, showCalendarEffective: false, traditionalMode: mode));
+            showTime: false, showDate: true, showWeekday: false, showCalendar: false, traditionalMode: mode));
         Assert.Equal(ClockCadence.PerMidnight, Display.ComputeClockCadence(
-            showTime: false, showDate: false, showWeekday: false, showCalendarEffective: true, traditionalMode: mode));
+            showTime: false, showDate: false, showWeekday: false, showCalendar: true, traditionalMode: mode));
         Assert.Equal(ClockCadence.PerMidnight, Display.ComputeClockCadence(
-            showTime: false, showDate: false, showWeekday: false, showCalendarEffective: false,
+            showTime: false, showDate: false, showWeekday: false, showCalendar: false,
             traditionalMode: GlancePkg::DeskBox.Models.GlanceTraditionalCalendarMode.Hebrew));
     }
 


### PR DESCRIPTION
feat: all four glance layouts reach the native package

Behavior parity batch 2: the Layout setting (Immersive/Centered/Editorial/
Calendar) now drives the native glance's composition, matching the
built-in layout roots.

- GlanceDisplayPolicy.ResolveLayout ports the built-in resolution:
  Centered/Editorial map to themselves; Calendar degrades to Immersive
  when the calendar is off or below the responsive floor (width >= 300
  and height >= 280)
- glance.xaml gains the three non-calendar layout roots inside a
  foreground scope gated by IsForegroundVisible semantics (any of
  time/date/weekday/calendar visible): Immersive = time + date/weekday
  bottom-left over the image; Centered = big centered time with the
  date/weekday row under it; Editorial = date/weekday top-left with the
  compact time bottom-right; fonts match the built-in formulas
  (TimeFontSize clamp 38-78 at min(0.18w, 0.28h), rounded to halves)
- the calendar glass surface now collapses whenever the resolved layout
  is not Calendar (previously only on the ShowCalendar toggle), and the
  compact calendar header shows only in the compact calendar presentation
- clock cadence uses the RAW showCalendar setting (built-in parity: the
  responsive floor gates the surface, not the midnight obligation)
- the layout field rides the typed lossless round-trip and the migration
  semantic validator (defined-enum check)

Tests +2 (layout resolution matrix incl. the Calendar-to-Immersive
degradation; TimeFontSize clamp range) and the cadence tests follow the
raw-setting semantics.

Tests: 3609/3609 green.
