### PR TITLE
fix: pause/play affordance follows runtime state

### DIFF
--- a/src/DeskBox.GlancePackage/Rendering/GlanceWidgetController.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceWidgetController.cs
@@ -338,8 +338,13 @@ internal sealed class GlanceWidgetController : IDisposable
 
     private void UpdateClockText()
     {
-        _content.DataContext = GlanceMonthPipeline.CreatePresentation(
+        var presentation = GlanceMonthPipeline.CreatePresentation(
             _month, _isCompact, _panelHeight, _panelWidth, Settings, _culture, _width, _height);
+        // Built-in parity: the action-bar affordance follows the runtime
+        // pause state - paused shows the play triangle to resume.
+        presentation.PlayIconVisibility = _runtimeState.Paused ? Visibility.Visible : Visibility.Collapsed;
+        presentation.PauseIconVisibility = _runtimeState.Paused ? Visibility.Collapsed : Visibility.Visible;
+        _content.DataContext = presentation;
     }
 
     // ---- Settings (host-authoritative write-through) ----
@@ -403,6 +408,7 @@ internal sealed class GlanceWidgetController : IDisposable
     {
         _runtimeState.Paused = !_runtimeState.Paused;
         UpdateTimers();
+        UpdateClockText();
         // Persist the pause at the change point: teardown no longer saves on
         // Unloaded, and destroy persistence must be able to stay no-throw.
         GlanceRuntimeState.TrySave(_runtimeState, _instanceDataRoot);

--- a/src/DeskBox/Services/GlanceWidgetStore.cs
+++ b/src/DeskBox/Services/GlanceWidgetStore.cs
@@ -297,8 +297,8 @@ public sealed class GlanceWidgetStore
                new GlanceWidgetData();
     }
 
-    // Internal for NativeGlanceDataMigration: the migration must resolve the
-    // exact store path the built-in widget uses.
+    // Internal for GlanceInstanceMigration (the official-package legacy
+    // adapter): it must resolve the exact store path the built-in widget uses.
     internal static string GetSafeWidgetFileName(string widgetId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(widgetId);


### PR DESCRIPTION
fix: pause/play affordance follows runtime state; stale comment swept

Regression sweep for superseded code: PinnedYear/Month, the duplicated
DelayToNextMinute, GlanceViewBuilder.Create, and the old migration class
name are all fully gone; the only leftovers were one stale comment and a
real parity gap.

- the action-bar button now swaps pause/play with the runtime pause
  state (built-in parity: paused shows the play triangle to resume);
  previously the icon stayed on "pause" even while paused, and any
  presentation rebuild silently reset it
- GlanceWidgetStore comment updated to the current adapter class name

Tests: 3609/3609 green.
