### PR TITLE
feat: transition modes, readability, and background transparency in the native glance

### DIFF
--- a/src/DeskBox.GlancePackage/Rendering/GlanceDataFile.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceDataFile.cs
@@ -53,6 +53,10 @@ internal static class GlanceDataFile
             if (TryBool(raw, "showCalendar", out bool showCalendar)) settings.ShowCalendar = showCalendar;
             if (TryEnum<GlanceTimeFormatMode>(raw, "timeFormat", out var timeFormat)) settings.TimeFormat = timeFormat;
             if (TryEnum<GlanceLayoutMode>(raw, "layout", out var layout)) settings.Layout = layout;
+            if (TryEnum<GlanceTransitionMode>(raw, "transition", out var transition)) settings.Transition = transition;
+            if (TryEnum<GlanceTransitionSpeed>(raw, "transitionSpeed", out var speed)) settings.TransitionSpeed = speed;
+            if (TryEnum<GlanceReadabilityMode>(raw, "readability", out var readability)) settings.Readability = readability;
+            if (TryDouble(raw, "backgroundImageTransparency", out double transparency)) settings.BackgroundImageTransparency = transparency;
             return new GlanceData(settings, raw);
         }
         catch
@@ -175,6 +179,10 @@ internal static class GlanceDataFile
         if (skip?.Contains("showCalendar") != true && only?.Contains("showCalendar") != false) writer.WriteBoolean("showCalendar", settings.ShowCalendar);
         if (skip?.Contains("timeFormat") != true && only?.Contains("timeFormat") != false) writer.WriteString("timeFormat", settings.TimeFormat.ToString());
         if (skip?.Contains("layout") != true && only?.Contains("layout") != false) writer.WriteString("layout", settings.Layout.ToString());
+        if (skip?.Contains("transition") != true && only?.Contains("transition") != false) writer.WriteString("transition", settings.Transition.ToString());
+        if (skip?.Contains("transitionSpeed") != true && only?.Contains("transitionSpeed") != false) writer.WriteString("transitionSpeed", settings.TransitionSpeed.ToString());
+        if (skip?.Contains("readability") != true && only?.Contains("readability") != false) writer.WriteString("readability", settings.Readability.ToString());
+        if (skip?.Contains("backgroundImageTransparency") != true && only?.Contains("backgroundImageTransparency") != false) writer.WriteNumber("backgroundImageTransparency", settings.BackgroundImageTransparency);
     }
 
     private static bool TryBool(JsonElement root, string property, out bool value)

--- a/src/DeskBox.GlancePackage/Rendering/GlanceMonthPipeline.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceMonthPipeline.cs
@@ -76,18 +76,26 @@ internal static class GlanceMonthPipeline
             CalendarCornerRadius = new CornerRadius(12),
             PlayIconVisibility = Visibility.Collapsed,
             PauseIconVisibility = Visibility.Visible,
-            // Built-in display toggles gate each element; the calendar
-            // surface follows the resolved layout.
-            TimeVisibility = settings.ShowTime ? Visibility.Visible : Visibility.Collapsed,
-            DateVisibility = settings.ShowDate ? Visibility.Visible : Visibility.Collapsed,
-            WeekdayVisibility = settings.ShowWeekday ? Visibility.Visible : Visibility.Collapsed,
-            CalendarHeaderVisibility = isCompact && layout == NativeLayout.Calendar ? Visibility.Visible : Visibility.Collapsed,
-            CalendarSurfaceVisibility = layout == NativeLayout.Calendar ? Visibility.Visible : Visibility.Collapsed,
-            ForegroundVisibility = foreground ? Visibility.Visible : Visibility.Collapsed,
-            ImmersiveVisibility = foreground && layout == NativeLayout.Immersive ? Visibility.Visible : Visibility.Collapsed,
-            CenteredVisibility = foreground && layout == NativeLayout.Centered ? Visibility.Visible : Visibility.Collapsed,
-            EditorialVisibility = foreground && layout == NativeLayout.Editorial ? Visibility.Visible : Visibility.Collapsed,
-        };
+        // Built-in display toggles gate each element; the calendar
+        // surface follows the resolved layout.
+        TimeVisibility = settings.ShowTime ? Visibility.Visible : Visibility.Collapsed,
+        DateVisibility = settings.ShowDate ? Visibility.Visible : Visibility.Collapsed,
+        WeekdayVisibility = settings.ShowWeekday ? Visibility.Visible : Visibility.Collapsed,
+        CalendarHeaderVisibility = isCompact && layout == NativeLayout.Calendar ? Visibility.Visible : Visibility.Collapsed,
+        CalendarSurfaceVisibility = layout == NativeLayout.Calendar ? Visibility.Visible : Visibility.Collapsed,
+        ForegroundVisibility = foreground ? Visibility.Visible : Visibility.Collapsed,
+        ImmersiveVisibility = foreground && layout == NativeLayout.Immersive ? Visibility.Visible : Visibility.Collapsed,
+        CenteredVisibility = foreground && layout == NativeLayout.Centered ? Visibility.Visible : Visibility.Collapsed,
+        EditorialVisibility = foreground && layout == NativeLayout.Editorial ? Visibility.Visible : Visibility.Collapsed,
+        // Built-in ReadabilityOpacity: strength only counts when the
+        // foreground is visible (background-only shows no darkening).
+        ReadabilityOpacity = foreground ? settings.Readability switch
+        {
+            GlanceReadabilityMode.None => 0,
+            GlanceReadabilityMode.Strong => 0.5,
+            _ => 0.28,
+        } : 0,
+    };
     }
 }
 
@@ -109,6 +117,7 @@ internal static class GlanceMonthPipeline
     nameof(ImmersiveVisibility),
     nameof(PauseIconVisibility),
     nameof(PlayIconVisibility),
+    nameof(ReadabilityOpacity),
     nameof(TimeFontFamily),
     nameof(TimeFontSize),
     nameof(TimeText),
@@ -141,6 +150,7 @@ public sealed partial class GlancePresentation
     public Visibility ImmersiveVisibility { get; init; }
     public Visibility CenteredVisibility { get; init; }
     public Visibility EditorialVisibility { get; init; }
+    public double ReadabilityOpacity { get; init; }
     public Visibility PlayIconVisibility { get; set; }
     public Visibility PauseIconVisibility { get; set; }
 }

--- a/src/DeskBox.GlancePackage/Rendering/GlanceWidgetController.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceWidgetController.cs
@@ -6,6 +6,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Media.Animation;
 using WinRT;
 
 namespace DeskBox.GlancePackage.Rendering;
@@ -33,9 +34,14 @@ internal sealed class GlanceWidgetController : IDisposable
     private readonly CalendarDecorationState _decoration;
     private readonly Border _backgroundA;
     private readonly Border _backgroundB;
+    private readonly Grid _backgroundLayer;
+    private readonly Border _readabilityLayer;
+    private readonly Border _calendarReadabilityLayer;
+    private readonly Border _gradientLayer;
     private readonly string[] _images;
     private readonly Stretch _imageStretch;
     private bool _showingA;
+    private Microsoft.UI.Xaml.Media.Animation.Storyboard? _transitionStoryboard;
 
     private readonly Microsoft.UI.Dispatching.DispatcherQueueTimer _rotationTimer;
     private readonly Microsoft.UI.Dispatching.DispatcherQueueTimer _resizeTimer;
@@ -95,6 +101,10 @@ internal sealed class GlanceWidgetController : IDisposable
         _imageStretch = Settings.ImageFit == GlanceImageFitMode.Fit ? Stretch.Uniform : Stretch.UniformToFill;
         _backgroundA = _content.FindName("BackgroundA").As<Border>();
         _backgroundB = _content.FindName("BackgroundB").As<Border>();
+        _backgroundLayer = _content.FindName("BackgroundImageLayer").As<Grid>();
+        _readabilityLayer = _content.FindName("ReadabilityLayer").As<Border>();
+        _calendarReadabilityLayer = _content.FindName("CalendarReadabilityLayer").As<Border>();
+        _gradientLayer = _content.FindName("NonCalendarGradientLayer").As<Border>();
         if (_images.Length == 0)
         {
             GlanceViewBuilder.ShowGradientFallback(_backgroundA);
@@ -190,6 +200,7 @@ internal sealed class GlanceWidgetController : IDisposable
         };
 
         UpdateTimers();
+        ApplyLayerEffects((GlancePresentation)_content.DataContext);
     }
 
     // ---- Host lifecycle events (ABI v4 kinds routed by GlanceWidgetHandle) ----
@@ -345,6 +356,28 @@ internal sealed class GlanceWidgetController : IDisposable
         presentation.PlayIconVisibility = _runtimeState.Paused ? Visibility.Visible : Visibility.Collapsed;
         presentation.PauseIconVisibility = _runtimeState.Paused ? Visibility.Collapsed : Visibility.Visible;
         _content.DataContext = presentation;
+        ApplyLayerEffects(presentation);
+    }
+
+    /// <summary>
+    /// Built-in parity: the background container carries the user's
+    /// transparency (opacity = 1 - transparency), and the readability
+    /// layers (black for non-calendar foreground, theme fill for the
+    /// calendar surface, bottom gradient) appear only when an image is
+    /// actually visible behind them.
+    /// </summary>
+    private void ApplyLayerEffects(GlancePresentation presentation)
+    {
+        _backgroundLayer.Opacity = 1.0 - Math.Clamp(Settings.BackgroundImageTransparency, 0.0, 1.0);
+        bool hasImage = _images.Length > 0;
+        bool calendar = presentation.CalendarSurfaceVisibility == Visibility.Visible;
+        bool nonCalendarForeground = hasImage &&
+            presentation.ForegroundVisibility == Visibility.Visible && !calendar;
+        _readabilityLayer.Opacity = presentation.ReadabilityOpacity;
+        _readabilityLayer.Visibility = nonCalendarForeground ? Visibility.Visible : Visibility.Collapsed;
+        _gradientLayer.Visibility = nonCalendarForeground ? Visibility.Visible : Visibility.Collapsed;
+        _calendarReadabilityLayer.Opacity = presentation.ReadabilityOpacity;
+        _calendarReadabilityLayer.Visibility = hasImage && calendar ? Visibility.Visible : Visibility.Collapsed;
     }
 
     // ---- Settings (host-authoritative write-through) ----
@@ -396,12 +429,101 @@ internal sealed class GlanceWidgetController : IDisposable
             ImageSource = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(new Uri(_images[_runtimeState.ImageIndex])),
             Stretch = _imageStretch,
         };
-        Border next = _showingA ? _backgroundB : _backgroundA;
-        Border fadeOut = _showingA ? _backgroundA : _backgroundB;
-        next.Background = brush;
-        next.Opacity = 1;
-        fadeOut.Opacity = 0;
-        _showingA = !_showingA;
+        Border incoming = _showingA ? _backgroundB : _backgroundA;
+        Border outgoing = _showingA ? _backgroundA : _backgroundB;
+        RunTransition(incoming, outgoing, brush);
+    }
+
+    /// <summary>
+    /// Verbatim port of the built-in RunTransition: per-mode opacity/slide/
+    /// zoom animation with the speed table (Fast 170 / Standard 300 /
+    /// Relaxed 520 ms, CubicEase EaseOut); instant swap for None or when
+    /// there is no outgoing image.
+    /// </summary>
+    private void RunTransition(Border incoming, Border outgoing, ImageBrush brush)
+    {
+        _transitionStoryboard?.Stop();
+        ResetTransform(incoming);
+        ResetTransform(outgoing);
+
+        bool animate = Settings.Transition != GlanceTransitionMode.None && outgoing.Background is not null;
+        if (!animate)
+        {
+            incoming.Background = brush;
+            incoming.Opacity = 1;
+            outgoing.Opacity = 0;
+            outgoing.Background = null;
+            _showingA = ReferenceEquals(incoming, _backgroundA);
+            return;
+        }
+
+        TimeSpan duration = TimeSpan.FromMilliseconds(Settings.TransitionSpeed switch
+        {
+            GlanceTransitionSpeed.Fast => 170,
+            GlanceTransitionSpeed.Relaxed => 520,
+            _ => 300,
+        });
+        incoming.Background = brush;
+        incoming.Opacity = 0;
+        outgoing.Opacity = 1;
+
+        var storyboard = new Storyboard();
+        AddAnimation(storyboard, incoming, "Opacity", 0, 1, duration);
+        AddAnimation(storyboard, outgoing, "Opacity", 1, 0, duration);
+
+        if (Settings.Transition == GlanceTransitionMode.SlideFade && incoming.RenderTransform is CompositeTransform slide)
+        {
+            slide.TranslateY = 16;
+            AddAnimation(storyboard, slide, "TranslateY", 16, 0, duration);
+        }
+        else if (Settings.Transition == GlanceTransitionMode.ZoomFade && incoming.RenderTransform is CompositeTransform zoom)
+        {
+            zoom.ScaleX = 1.035;
+            zoom.ScaleY = 1.035;
+            AddAnimation(storyboard, zoom, "ScaleX", 1.035, 1, duration);
+            AddAnimation(storyboard, zoom, "ScaleY", 1.035, 1, duration);
+        }
+
+        storyboard.Completed += (_, _) =>
+        {
+            outgoing.Background = null;
+            outgoing.Opacity = 0;
+            ResetTransform(incoming);
+            _showingA = ReferenceEquals(incoming, _backgroundA);
+        };
+        _transitionStoryboard = storyboard;
+        storyboard.Begin();
+    }
+
+    private static void ResetTransform(Border border)
+    {
+        if (border.RenderTransform is CompositeTransform transform)
+        {
+            transform.TranslateX = 0;
+            transform.TranslateY = 0;
+            transform.ScaleX = 1;
+            transform.ScaleY = 1;
+        }
+    }
+
+    private static void AddAnimation(
+        Storyboard storyboard,
+        DependencyObject target,
+        string property,
+        double from,
+        double to,
+        TimeSpan duration)
+    {
+        var animation = new DoubleAnimation
+        {
+            From = from,
+            To = to,
+            Duration = duration,
+            EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut },
+        };
+        Storyboard.SetTarget(animation, target);
+        Storyboard.SetTargetProperty(animation, property);
+        storyboard.Children.Add(animation);
     }
 
     private void TogglePause()
@@ -422,6 +544,7 @@ internal sealed class GlanceWidgetController : IDisposable
         _clockTimer.Stop();
         _rotationTimer.Stop();
         _resizeTimer.Stop();
+        _transitionStoryboard?.Stop();
     }
 
     /// <summary>
@@ -437,6 +560,7 @@ internal sealed class GlanceWidgetController : IDisposable
         _clockTimer.Stop();
         _rotationTimer.Stop();
         _resizeTimer.Stop();
+        _transitionStoryboard?.Stop();
         GlanceRuntimeState.TrySave(_runtimeState, _instanceDataRoot);
     }
 }

--- a/src/DeskBox.GlancePackage/Rendering/glance.xaml
+++ b/src/DeskBox.GlancePackage/Rendering/glance.xaml
@@ -27,16 +27,46 @@
         </ResourceDictionary>
     </Grid.Resources>
 
-    <Grid x:Name="BackgroundImageLayer" IsHitTestVisible="False">
-        <Border x:Name="BackgroundA" Opacity="0" />
-        <Border x:Name="BackgroundB" Opacity="0" />
-    </Grid>
-
-    <Border
-        x:Name="ReadabilityLayer"
-        Background="Black"
-        IsHitTestVisible="False"
-        Opacity="0.42" />
+        <Grid x:Name="BackgroundImageLayer" IsHitTestVisible="False">
+            <Border
+                x:Name="BackgroundA"
+                Opacity="0"
+                RenderTransformOrigin="0.5,0.5">
+                <Border.RenderTransform>
+                    <CompositeTransform />
+                </Border.RenderTransform>
+            </Border>
+            <Border
+                x:Name="BackgroundB"
+                Opacity="0"
+                RenderTransformOrigin="0.5,0.5">
+                <Border.RenderTransform>
+                    <CompositeTransform />
+                </Border.RenderTransform>
+            </Border>
+        </Grid>
+        <Border
+            x:Name="ReadabilityLayer"
+            Background="Black"
+            IsHitTestVisible="False"
+            Opacity="0" />
+        <Border
+            x:Name="CalendarReadabilityLayer"
+            Background="{StaticResource SolidBackgroundFillColorBaseBrush}"
+            IsHitTestVisible="False"
+            Opacity="0" />
+        <Border
+            x:Name="NonCalendarGradientLayer"
+            IsHitTestVisible="False"
+            Opacity="0.34"
+            Visibility="Collapsed">
+            <Border.Background>
+                <LinearGradientBrush StartPoint="0.5,0" EndPoint="0.5,1">
+                    <GradientStop Color="#00000000" Offset="0.34" />
+                    <GradientStop Color="#78000000" Offset="1" />
+                </LinearGradientBrush>
+            </Border.Background>
+        </Border>
 
     <Grid
         x:Name="ImageForegroundThemeScope"

--- a/src/DeskBox/Services/GlanceInstanceMigration.cs
+++ b/src/DeskBox/Services/GlanceInstanceMigration.cs
@@ -92,6 +92,11 @@ internal sealed class GlanceInstanceMigration : ILegacyInstanceMigration
                     "imageFit" => IsValidEnumValue<GlanceImageFitMode>(property.Value),
                     "timeFormat" => IsValidEnumValue<GlanceTimeFormatMode>(property.Value),
                     "layout" => IsValidEnumValue<GlanceLayoutMode>(property.Value),
+                    "transition" => IsValidEnumValue<GlanceTransitionMode>(property.Value),
+                    "transitionSpeed" => IsValidEnumValue<GlanceTransitionSpeed>(property.Value),
+                    "readability" => IsValidEnumValue<GlanceReadabilityMode>(property.Value),
+                    "backgroundImageTransparency" =>
+                        property.Value.ValueKind == JsonValueKind.Number && property.Value.TryGetDouble(out _),
                     _ => true,
                 };
                 if (!typeValid) return false;

--- a/tests/DeskBox.Tests/NativeGlanceDataGoldenTests.cs
+++ b/tests/DeskBox.Tests/NativeGlanceDataGoldenTests.cs
@@ -231,8 +231,9 @@ public class NativeGlanceDataGoldenTests
         string full = GlanceDataFile.BuildOwnedPatch(settings);
         using (JsonDocument document = JsonDocument.Parse(full))
         {
-            // 9 interaction fields + 6 display/time fields + layout.
-            Assert.Equal(16, document.RootElement.EnumerateObject().Count());
+            // 9 interaction + 6 display/time + layout + 4 playback-appearance
+            // fields.
+            Assert.Equal(20, document.RootElement.EnumerateObject().Count());
         }
     }
 


### PR DESCRIPTION
feat: transition modes, speeds, readability, and background transparency

Behavior parity batch 3: the four playback-appearance settings now drive
the native glance exactly as they drive the built-in widget.

- transition: verbatim port of the built-in RunTransition - CrossFade
  (opacity cross-fade), SlideFade (16px TranslateY slide + fade),
  ZoomFade (1.035 scale + fade), None (instant swap); speed table Fast
  170ms / Standard 300ms / Relaxed 520ms with CubicEase EaseOut; the
  outgoing image is released only after the storyboard completes, and
  transforms reset between runs
- readability: the built-in three-mode darkening (None 0 / Soft 0.28 /
  Strong 0.5) applied as ReadabilityOpacity, gated on the foreground
  being visible; native gains the two readability surfaces the probe
  xaml never had - a black layer for the non-calendar foreground (plus
  the bottom gradient) and a theme-fill layer for the calendar surface
- background transparency: the background layer container carries
  opacity = 1 - transparency (clamped 0-1), on top of which the
  transition animations run per-border
- the probe-era static readability layer (hardcoded 0.42) is replaced by
  the dynamic layers; the four new fields (transition, transitionSpeed,
  readability, backgroundImageTransparency) ride the typed lossless
  round-trip and the migration semantic validator

Tests: 3609/3609 green. No release artifacts produced.
