### PR TITLE
feat: image focus, time font family, and time scale reach the native glance

### DIFF
--- a/src/DeskBox.GlancePackage/Rendering/GlanceDataFile.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceDataFile.cs
@@ -57,6 +57,8 @@ internal static class GlanceDataFile
             if (TryEnum<GlanceTransitionSpeed>(raw, "transitionSpeed", out var speed)) settings.TransitionSpeed = speed;
             if (TryEnum<GlanceReadabilityMode>(raw, "readability", out var readability)) settings.Readability = readability;
             if (TryDouble(raw, "backgroundImageTransparency", out double transparency)) settings.BackgroundImageTransparency = transparency;
+            if (TryString(raw, "timeFontFamily", out string? fontFamily) && !string.IsNullOrWhiteSpace(fontFamily)) settings.TimeFontFamily = fontFamily;
+            if (TryDouble(raw, "timeScale", out double scale) && scale > 0) settings.TimeScale = scale;
             return new GlanceData(settings, raw);
         }
         catch
@@ -183,6 +185,8 @@ internal static class GlanceDataFile
         if (skip?.Contains("transitionSpeed") != true && only?.Contains("transitionSpeed") != false) writer.WriteString("transitionSpeed", settings.TransitionSpeed.ToString());
         if (skip?.Contains("readability") != true && only?.Contains("readability") != false) writer.WriteString("readability", settings.Readability.ToString());
         if (skip?.Contains("backgroundImageTransparency") != true && only?.Contains("backgroundImageTransparency") != false) writer.WriteNumber("backgroundImageTransparency", settings.BackgroundImageTransparency);
+        if (skip?.Contains("timeFontFamily") != true && only?.Contains("timeFontFamily") != false) writer.WriteString("timeFontFamily", settings.TimeFontFamily);
+        if (skip?.Contains("timeScale") != true && only?.Contains("timeScale") != false) writer.WriteNumber("timeScale", settings.TimeScale);
     }
 
     private static bool TryBool(JsonElement root, string property, out bool value)

--- a/src/DeskBox.GlancePackage/Rendering/GlanceDisplayPolicy.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceDisplayPolicy.cs
@@ -41,6 +41,33 @@ internal static class GlanceDisplayPolicy
 
     private static double RoundToHalf(double value) => Math.Round(value * 2) / 2;
 
+    /// <summary>Built-in font-size formulas share one shape: clamp first,
+    /// then multiply the user's time scale, then round to halves.</summary>
+    public static double ScaledFontSize(
+        double availableWidth, double availableHeight, double timeScale) =>
+        Math.Round(RoundToHalf(Math.Clamp(Math.Min(availableWidth * 0.18, availableHeight * 0.28), 38, 78)) * timeScale * 2) / 2;
+
+    public static double ScaledCompactFontSize(
+        double availableWidth, double availableHeight, double timeScale) =>
+        Math.Round(RoundToHalf(Math.Clamp(Math.Min(availableWidth * 0.13, availableHeight * 0.2), 30, 60)) * timeScale * 2) / 2;
+
+    public static double ScaledCalendarCompactFontSize(
+        double availableWidth, double availableHeight, double timeScale) =>
+        Math.Round(RoundToHalf(Math.Clamp(Math.Min(availableWidth * 0.078, availableHeight * 0.095), 22, 28)) * timeScale * 2) / 2;
+
+    /// <summary>Built-in ImageFocus mapping: horizontal and vertical
+    /// alignment default to Center, with the focus point pinning the
+    /// corresponding edge/axis.</summary>
+    public static (Microsoft.UI.Xaml.Media.AlignmentX X, Microsoft.UI.Xaml.Media.AlignmentY Y) ResolveImageFocus(
+        GlanceImageFocus focus) => focus switch
+    {
+        GlanceImageFocus.Left => (Microsoft.UI.Xaml.Media.AlignmentX.Left, Microsoft.UI.Xaml.Media.AlignmentY.Center),
+        GlanceImageFocus.Right => (Microsoft.UI.Xaml.Media.AlignmentX.Right, Microsoft.UI.Xaml.Media.AlignmentY.Center),
+        GlanceImageFocus.Top => (Microsoft.UI.Xaml.Media.AlignmentX.Center, Microsoft.UI.Xaml.Media.AlignmentY.Top),
+        GlanceImageFocus.Bottom => (Microsoft.UI.Xaml.Media.AlignmentX.Center, Microsoft.UI.Xaml.Media.AlignmentY.Bottom),
+        _ => (Microsoft.UI.Xaml.Media.AlignmentX.Center, Microsoft.UI.Xaml.Media.AlignmentY.Center),
+    };
+
     /// <summary>
     /// Built-in UpdateClockTimer cadence: a time display needs per-minute
     /// ticks; date/weekday/calendar-only needs one tick per midnight;

--- a/src/DeskBox.GlancePackage/Rendering/GlanceMonthPipeline.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceMonthPipeline.cs
@@ -51,7 +51,8 @@ internal static class GlanceMonthPipeline
         GlanceWidgetData settings, CultureInfo culture, double availableWidth, double availableHeight)
     {
         DateTime now = DateTime.Now;
-        double compactFontSize = Math.Round(Math.Clamp(Math.Min(availableWidth * 0.078, availableHeight * 0.095), 22, 28) * 2) / 2;
+        double compactFontSize = GlanceDisplayPolicy.ScaledCompactFontSize(availableWidth, availableHeight, settings.TimeScale);
+        double calendarCompactFontSize = GlanceDisplayPolicy.ScaledCalendarCompactFontSize(availableWidth, availableHeight, settings.TimeScale);
         // Built-in layout resolution: Calendar degrades to Immersive when the
         // calendar is off or below the responsive floor.
         bool calendarEffective = GlanceDisplayPolicy.ShowCalendarEffective(
@@ -66,17 +67,18 @@ internal static class GlanceMonthPipeline
             WeekdayText = now.ToString("dddd", culture),
             CompactCalendarDateText = GlanceDisplayPolicy.FormatCompactCalendarDateText(now, culture),
             TraditionalCalendarTitle = month.TraditionalTitle,
-            TimeFontFamily = new FontFamily("XamlAutoFontFamily"),
-            TimeFontSize = GlanceDisplayPolicy.TimeFontSize(availableWidth, availableHeight),
+            TimeFontFamily = new FontFamily(string.IsNullOrWhiteSpace(settings.TimeFontFamily)
+                ? "XamlAutoFontFamily"
+                : settings.TimeFontFamily),
+            TimeFontSize = GlanceDisplayPolicy.ScaledFontSize(availableWidth, availableHeight, settings.TimeScale),
             CompactTimeFontSize = compactFontSize,
-            CalendarCompactTimeFontSize = compactFontSize,
+            CalendarCompactTimeFontSize = calendarCompactFontSize,
             CalendarPanelHeight = panelHeight,
             CalendarPanelWidth = panelWidth,
             CalendarPanelMaxWidth = 360,
             CalendarCornerRadius = new CornerRadius(12),
             PlayIconVisibility = Visibility.Collapsed,
-            PauseIconVisibility = Visibility.Visible,
-        // Built-in display toggles gate each element; the calendar
+            PauseIconVisibility = Visibility.Visible,        // Built-in display toggles gate each element; the calendar
         // surface follows the resolved layout.
         TimeVisibility = settings.ShowTime ? Visibility.Visible : Visibility.Collapsed,
         DateVisibility = settings.ShowDate ? Visibility.Visible : Visibility.Collapsed,

--- a/src/DeskBox.GlancePackage/Rendering/GlanceWidgetController.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceWidgetController.cs
@@ -431,6 +431,7 @@ internal sealed class GlanceWidgetController : IDisposable
             ImageSource = new Microsoft.UI.Xaml.Media.Imaging.BitmapImage(new Uri(_images[_runtimeState.ImageIndex])),
             Stretch = _imageStretch,
         };
+        (brush.AlignmentX, brush.AlignmentY) = GlanceDisplayPolicy.ResolveImageFocus(Settings.ImageFocus);
         Border incoming = _showingA ? _backgroundB : _backgroundA;
         Border outgoing = _showingA ? _backgroundA : _backgroundB;
         RunTransition(incoming, outgoing, brush);

--- a/src/DeskBox/Services/GlanceInstanceMigration.cs
+++ b/src/DeskBox/Services/GlanceInstanceMigration.cs
@@ -97,6 +97,10 @@ internal sealed class GlanceInstanceMigration : ILegacyInstanceMigration
                     "readability" => IsValidEnumValue<GlanceReadabilityMode>(property.Value),
                     "backgroundImageTransparency" =>
                         property.Value.ValueKind == JsonValueKind.Number && property.Value.TryGetDouble(out _),
+                    "timeFontFamily" =>
+                        property.Value.ValueKind is JsonValueKind.String or JsonValueKind.Null,
+                    "timeScale" =>
+                        property.Value.ValueKind == JsonValueKind.Number && property.Value.TryGetDouble(out _),
                     _ => true,
                 };
                 if (!typeValid) return false;

--- a/tests/DeskBox.Tests/NativeGlanceDataGoldenTests.cs
+++ b/tests/DeskBox.Tests/NativeGlanceDataGoldenTests.cs
@@ -232,8 +232,8 @@ public class NativeGlanceDataGoldenTests
         using (JsonDocument document = JsonDocument.Parse(full))
         {
             // 9 interaction + 6 display/time + layout + 4 playback-appearance
-            // fields.
-            Assert.Equal(20, document.RootElement.EnumerateObject().Count());
+            // + font family/scale fields.
+            Assert.Equal(22, document.RootElement.EnumerateObject().Count());
         }
     }
 

--- a/tests/DeskBox.Tests/NativeGlanceDisplayPolicyTests.cs
+++ b/tests/DeskBox.Tests/NativeGlanceDisplayPolicyTests.cs
@@ -91,6 +91,34 @@ public class NativeGlanceDisplayPolicyTests
     }
 
     [Fact]
+    public void TimeScaleMultipliesAfterTheClamp()
+    {
+        // Built-in order: clamp first, then multiply by the user's scale,
+        // then round to halves - scale can exceed the clamp range.
+        Assert.Equal(117, Display.ScaledFontSize(440, 560, 1.5));
+        Assert.Equal(78, Display.ScaledFontSize(440, 560, 1.0));
+        // Compact variants use their own clamps.
+        Assert.Equal(57, Display.ScaledCompactFontSize(440, 560, 1.0));
+        Assert.Equal(28, Display.ScaledCalendarCompactFontSize(440, 560, 1.0));
+    }
+
+    [Fact]
+    public void ImageFocusPinsTheNamedEdges()
+    {
+        var (topX, topY) = Display.ResolveImageFocus(GlancePkg::DeskBox.Models.GlanceImageFocus.Top);
+        Assert.Equal(Microsoft.UI.Xaml.Media.AlignmentX.Center, topX);
+        Assert.Equal(Microsoft.UI.Xaml.Media.AlignmentY.Top, topY);
+
+        var (leftX, leftY) = Display.ResolveImageFocus(GlancePkg::DeskBox.Models.GlanceImageFocus.Left);
+        Assert.Equal(Microsoft.UI.Xaml.Media.AlignmentX.Left, leftX);
+        Assert.Equal(Microsoft.UI.Xaml.Media.AlignmentY.Center, leftY);
+
+        var (centerX, centerY) = Display.ResolveImageFocus(GlancePkg::DeskBox.Models.GlanceImageFocus.Center);
+        Assert.Equal(Microsoft.UI.Xaml.Media.AlignmentX.Center, centerX);
+        Assert.Equal(Microsoft.UI.Xaml.Media.AlignmentY.Center, centerY);
+    }
+
+    [Fact]
     public void TwelveHourSurvivesQuotedLiterals()
     {
         // A pattern with a quoted literal containing "t" must not lose the


### PR DESCRIPTION
feat: image focus, time font family, and time scale reach the native glance

Behavior parity batch 4 (small self-contained items):

- image focus: the brush alignment maps Left/Right to AlignmentX and
  Top/Bottom to AlignmentY with Center defaults (built-in mapping);
  ResolveImageFocus returns the alignment pair so the mapping stays
  unit-testable without a WinUI runtime
- time font family: the presentation font falls back to
  XamlAutoFontFamily when the setting is empty
- time scale: all three font formulas (time / compact / calendar-compact)
  follow the built-in order - clamp, multiply by the user's scale, round
  to halves - so a 1.5x scale can exceed the base clamp range
- timeFontFamily (string-or-null) and timeScale (number) ride the typed
  lossless round-trip and the migration semantic validator

Deliberately deferred: CalendarMaterialMode/Transparency parity needs the
theme-token channel (FollowSystem reads the host widget material and
accent; FollowImage needs image-palette extraction) and lands with that
batch.

Tests +2: time-scale multiplication after the clamp (three font
formulas), image-focus edge pinning.

Tests: 3611/3611 green.
