### PR TITLE
feat: R1 runtime/data contract repair - destroy keeps data, Faulted state, HostApi freeze

### DIFF
--- a/src/DeskBox/Services/Plugins/NativeInstanceDataLifecycle.cs
+++ b/src/DeskBox/Services/Plugins/NativeInstanceDataLifecycle.cs
@@ -1,0 +1,68 @@
+using DeskBox.Models;
+
+namespace DeskBox.Services.Plugins;
+
+/// <summary>
+/// Logical widget deletion (lifecycle 2 of 3, audit round 21): removes the
+/// package's persistent instance data root AFTER the WidgetConfig deletion
+/// has committed. Runtime destroy deliberately KEEPS this root — transient
+/// teardowns (group switches, content rebuilds) reuse the same instance —
+/// so data removal is owned exclusively by this explicit deletion.
+///
+/// The instance directory name is derived deterministically from the
+/// instance id (SHA-256 storage key), and the publisher segment is resolved
+/// by scanning, because the same instance id may have been served by
+/// different publishers (dev pilot → official) across upgrades.
+///
+/// Idempotent and best-effort: a missing root is a no-op, and a locked
+/// directory (in-flight sync, antivirus) is logged, never thrown — widget
+/// deletion must not fail because of native data cleanup.
+/// </summary>
+internal static class NativeInstanceDataLifecycle
+{
+    public static Task DeleteAsync(string packageId, string instanceId, string dataDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(instanceId);
+        return Task.Run(() => DeleteCore(packageId, instanceId, dataDirectory));
+    }
+
+    private static void DeleteCore(string packageId, string instanceId, string dataDirectory)
+    {
+        try
+        {
+            string packagesRoot = Path.Combine(dataDirectory, "packages");
+            if (!Directory.Exists(packagesRoot)) return;
+            string instanceDirName = NativePackageIdentity.InstanceStorageKey(instanceId);
+            foreach (string publisherDir in Directory.EnumerateDirectories(packagesRoot))
+            {
+                string candidate = Path.Combine(publisherDir, packageId, "instances", instanceDirName);
+                if (!Directory.Exists(candidate)) continue;
+                DeleteWithRetry(candidate);
+                App.Log($"[NativePackage] deleted instance data root for {packageId}/{instanceId}");
+            }
+        }
+        catch (Exception error)
+        {
+            // Best-effort: an orphaned root is inert; widget deletion must
+            // not fail because of native data cleanup.
+            App.Log($"[NativePackage] instance data cleanup failed for {instanceId}: {error.Message}");
+        }
+    }
+
+    private static void DeleteWithRetry(string path)
+    {
+        for (int attempt = 0; ; attempt++)
+        {
+            try
+            {
+                Directory.Delete(path, recursive: true);
+                return;
+            }
+            catch (Exception error) when (error is IOException or UnauthorizedAccessException && attempt < 2)
+            {
+                Thread.Sleep(150);
+            }
+        }
+    }
+}

--- a/src/DeskBox/Services/Plugins/NativeWidgetPackageLoader.cs
+++ b/src/DeskBox/Services/Plugins/NativeWidgetPackageLoader.cs
@@ -241,17 +241,7 @@ internal static unsafe class NativeHostApiBridge
             {
                 return unchecked((int)0x80070057);
             }
-            lock (HandlerGate)
-            {
-                if (handler != 0)
-                {
-                    ConfigChangedHandlers[context] = handler;
-                }
-                else
-                {
-                    ConfigChangedHandlers.Remove(context);
-                }
-            }
+            SubscribeConfigChanged(context, handler);
             App.LogVerbose($"[NativePackage] config-changed handler registered for context 0x{context:X}");
             return 0;
         }
@@ -259,6 +249,30 @@ internal static unsafe class NativeHostApiBridge
         {
             return unchecked((int)0x80004005); // E_FAIL
         }
+    }
+
+    /// <summary>
+    /// Managed seam for the subscription store (behavior-testable without a
+    /// native call), also used by the callback above.
+    /// </summary>
+    internal static void SubscribeConfigChanged(nint context, nint handler)
+    {
+        lock (HandlerGate)
+        {
+            if (handler != 0)
+            {
+                ConfigChangedHandlers[context] = handler;
+            }
+            else
+            {
+                ConfigChangedHandlers.Remove(context);
+            }
+        }
+    }
+
+    internal static int RegisteredConfigChangedHandlerCount
+    {
+        get { lock (HandlerGate) return ConfigChangedHandlers.Count; }
     }
 
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
@@ -316,6 +330,16 @@ internal static unsafe class NativeHostApiBridge
 }
 
 /// <summary>
+/// HostApi ABI FREEZE POLICY (audit round 21): HostApi v4 is the first
+/// frozen baseline. Versions v1–v3 were internal pre-release experiments
+/// and are not compatibility targets. From v4 onward, existing function
+/// pointer slots AND their signatures are immutable — new capabilities are
+/// added as NEW slots appended at the table end. The package's
+/// Size/Version gate (RequiredHostApiVersion) ensures it never reads past
+/// what the host provides.
+/// </summary>
+
+/// <summary>
 /// Batch C1 runtime contract (ABI v4): one session per loaded module identity
 /// (publisher + packageId + contentHash), activated exactly once; widget
 /// instances are created per (contribution, instance) pair and destroyed by
@@ -332,6 +356,19 @@ internal static class NativeWidgetRuntimeManager
     private static readonly object Gate = new();
     private static readonly Dictionary<string, NativePackageSession> Sessions = [];
     private static readonly Dictionary<string, string> LoadedModuleHashes = [];
+    // audit round 21 — Faulted/RestartRequired: a package whose shutdown
+    // reported failure has unknown internal state, and the NativeAOT module
+    // stays resident for the process lifetime. It must never be re-activated
+    // in this process; the flag clears only on restart.
+    private static readonly Dictionary<string, string> FaultedPackages = [];
+
+    internal static bool IsFaulted(string identityKey)
+    {
+        lock (Gate)
+        {
+            return FaultedPackages.ContainsKey(identityKey);
+        }
+    }
 
     public static bool TryCreateInstance(
         NativePackageDescriptor descriptor,
@@ -341,6 +378,17 @@ internal static class NativeWidgetRuntimeManager
         out NativeWidgetLease? lease)
     {
         lease = null;
+        // audit round 21 — Faulted/RestartRequired: a package whose shutdown
+        // failed has unknown resident state; refuse re-activation until
+        // process restart even though the module is still loaded.
+        lock (Gate)
+        {
+            if (FaultedPackages.TryGetValue(descriptor.Identity.Key, out string? reason))
+            {
+                App.Log($"[NativePackage] {descriptor.Identity.Key} is faulted and cannot be re-activated in this process ({reason})");
+                return false;
+            }
+        }
         NativePackageSession? session = null;
         lock (Gate)
         {
@@ -440,7 +488,23 @@ internal static class NativeWidgetRuntimeManager
         }
         if (shutdown)
         {
-            lease.Session.Shutdown();
+            // audit round 21 — Faulted/RestartRequired: a failed package
+            // shutdown leaves the resident module's state unknown, so the
+            // identity is marked faulted and TryCreateInstance refuses
+            // re-activation until process restart.
+            if (lease.Session.Shutdown())
+            {
+                App.Log($"[NativePackage] {lease.Session.Identity.Key} dormant; re-activation allowed");
+            }
+            else
+            {
+                string reason = "package shutdown reported failure; restart required";
+                lock (Gate)
+                {
+                    FaultedPackages[lease.Session.Identity.Key] = reason;
+                }
+                App.Log($"[NativePackage] {lease.Session.Identity.Key} marked FAULTED: {reason}");
+            }
         }
     }
 }
@@ -524,10 +588,10 @@ internal sealed unsafe class NativePackageSession
     private readonly nint _widgetEventExport; // required export at ABI v4
     private readonly object _instanceGate = new();
     private readonly HashSet<nint> _liveHandles = [];
-    // audit round 20: instance data roots are deleted on final destroy,
-    // allowing plugins to clean up their per-instance files without host intervention.
-    private readonly Dictionary<nint, string> _instanceDataRoots = [];
     // audit 20 §18: instance ids for PackageInstanceRegistry unregistration.
+    // audit 21: instance data roots are NOT tracked (or touched) here —
+    // runtime destroy keeps persistent data; logical widget deletion owns
+    // data removal via NativeInstanceDataLifecycle.
     private readonly Dictionary<nint, string> _instanceIds = [];
     internal nint _hostApiContext;
 
@@ -634,7 +698,6 @@ internal sealed unsafe class NativePackageSession
         lock (_instanceGate)
         {
             _liveHandles.Add(handle);
-            _instanceDataRoots[handle] = instanceDataRoot;
             _instanceIds[handle] = instanceId;
         }
         // Ownership for the generic write-through routing (audit 20 §18).
@@ -642,9 +705,16 @@ internal sealed unsafe class NativePackageSession
         return NativeWidgetLease.Create(this, handle, view, instanceId);
     }
 
-    /// <summary>Destroys by handle; returns true only when the package confirms success.
-    /// On success, the instance data root is deleted (audit round 20 - third law of
-    /// IWidgetInstanceLifecycle: Destroy cleans up all per-instance state).</summary>
+    /// <summary>
+    /// Destroys by handle; returns true only when the package confirms success.
+    /// Runtime destroy is lifecycle 1 of 3 (audit round 21): it releases the
+    /// widget handle and ownership ONLY — the persistent instance data root
+    /// is deliberately KEPT, because transient teardowns (group switches,
+    /// content rebuilds, reparents) reuse the same instance. Persistent data
+    /// removal belongs exclusively to logical widget deletion
+    /// (NativeInstanceDataLifecycle.DeleteAsync) after the WidgetConfig
+    /// deletion has committed.
+    /// </summary>
     internal bool DestroyWidget(nint handle)
     {
         int status = ((delegate* unmanaged[Cdecl]<nint, int>)_destroyExport)(handle);
@@ -662,22 +732,6 @@ internal sealed unsafe class NativePackageSession
         if (instanceId is not null)
         {
             PackageInstanceRegistry.Unregister(instanceId);
-        }
-        // Delete OUTSIDE the gate: disk I/O must never run under the lock the
-        // LiveInstanceCount probe takes (regression pass, audit-round-20 hygiene).
-        if (_instanceDataRoots.Remove(handle, out string? dataRoot))
-        {
-            // Total teardown (audit round 20): the destroy must never fail because of
-            // the runtime-state save (that happens in the package's Dispose), so
-            // disk access errors here are logged but don't turn into ABI failure.
-            try
-            {
-                if (Directory.Exists(dataRoot)) Directory.Delete(dataRoot, recursive: true);
-            }
-            catch (Exception error)
-            {
-                App.Log($"[NativePackage] failed to delete instance data root '{dataRoot}': {error.Message}");
-            }
         }
         return true;
     }
@@ -711,11 +765,24 @@ internal sealed unsafe class NativePackageSession
         }
     }
 
-    internal void Shutdown()
+    /// <summary>
+    /// Tears the session down. Returns true only when the package confirmed
+    /// a clean shutdown — a false return means the resident module's
+    /// internal state is unknown, and the caller must mark the package
+    /// Faulted so it is never re-activated in this process (audit round 21).
+    /// Session attribution (context + config subscription) is detached on
+    /// EVERY path: the previous early-return leaked both on the normal
+    /// shutdown path, accumulating stale callbacks across activate cycles.
+    /// Persistent instance data roots are never touched here — runtime
+    /// teardown is lifecycle 1; data removal belongs to logical deletion.
+    /// </summary>
+    internal bool Shutdown()
     {
+        bool succeeded;
         try
         {
             int status = ((delegate* unmanaged[Cdecl]<int>)_shutdownExport)();
+            succeeded = status == 0;
             if (status != 0)
             {
                 App.Log($"[NativePackage] shutdown reported 0x{status:X8} for {Identity.Key}; the package still holds state (lifecycle bug upstream)");
@@ -728,41 +795,29 @@ internal sealed unsafe class NativePackageSession
         catch (Exception error)
         {
             App.Log($"[NativePackage] shutdown failed for {Identity.Key}: {error.Message}");
+            succeeded = false;
         }
 
-        // audit round 20 - Shutdown Faulted: if destroy failed and the package
-        // did not clean up, the host must log and force cleanup of any remaining
-        // live handles to prevent data directory accumulation.
+        // Release ownership of any still-tracked instances (a destroy that
+        // failed earlier, or a host that tore down without destroying).
+        // Persistent data roots are KEPT — logical deletion owns them.
         lock (_instanceGate)
         {
-            if (_liveHandles.Count == 0) return;
-            App.Log($"[NativePackage] shutdown force-cleanup of {_liveHandles.Count} faulted instance(s) for {Identity.Key}");
-            var handles = _liveHandles.ToArray();
-            foreach (nint handle in handles)
+            foreach (nint handle in _liveHandles.ToArray())
             {
                 if (_instanceIds.Remove(handle, out string? instanceId))
                 {
                     PackageInstanceRegistry.Unregister(instanceId);
                 }
-                if (_instanceDataRoots.Remove(handle, out string? dataRoot))
-                {
-                    try
-                    {
-                        if (Directory.Exists(dataRoot)) Directory.Delete(dataRoot, recursive: true);
-                    }
-                    catch
-                    {
-                        // No-op: nothing we can do at shutdown.
-                    }
-                }
             }
-            _instanceDataRoots.Clear();
             _liveHandles.Clear();
         }
 
-        // Detach the session attribution (config subscription + context) so
-        // the ids are never reused or resolved after shutdown.
+        // No early return above this line: session attribution must detach
+        // on every path (audit round 21 — the normal shutdown path used to
+        // leak the context and config-changed subscription).
         NativeHostApiBridge.DetachSession(_hostApiContext);
+        return succeeded;
     }
 }
 

--- a/src/DeskBox/Services/WidgetManager.FeatureWidgets.cs
+++ b/src/DeskBox/Services/WidgetManager.FeatureWidgets.cs
@@ -2,6 +2,7 @@
 
 using DeskBox.Contracts;
 using DeskBox.Models;
+using DeskBox.Services.Plugins;
 using DeskBox.Helpers;
 using DeskBox.Controls.WidgetContents;
 using DeskBox.ViewModels;
@@ -1161,6 +1162,15 @@ public sealed partial class WidgetManager
                 if (kind == WidgetKind.Glance)
                 {
                     await GlanceWidgetStore.DeleteForWidgetAsync(duplicate.Id);
+                    // audit round 21 — logical delete dual-hook (matches the
+                    // RemoveWidgetAsync site): native instance data root is
+                    // removed here too, so reset-orphan cleanup stays in
+                    // lockstep with the host store.
+                    if (PackageBindingRegistry.TryGetByKind(kind) is { PackageId: var dupPackageId })
+                    {
+                        await NativeInstanceDataLifecycle.DeleteAsync(
+                            dupPackageId, duplicate.Id, DeskBoxDataPathService.Current.DataDirectory);
+                    }
                 }
                 else if (kind == WidgetKind.Todo)
                 {

--- a/src/DeskBox/Services/WidgetManager.cs
+++ b/src/DeskBox/Services/WidgetManager.cs
@@ -2,6 +2,7 @@
 using DeskBox.Models;
 using DeskBox.Helpers;
 using DeskBox.Controls.WidgetContents;
+using DeskBox.Services.Plugins;
 using DeskBox.ViewModels;
 using DeskBox.Views;
 using Microsoft.UI.Dispatching;
@@ -1622,19 +1623,29 @@ public sealed partial class WidgetManager :
         _settingsService.RemoveWidgetImmediate(widgetId);
         _topologyLayoutService.RemoveSurface(_settingsService.Settings, widgetId);
         ClearWidgetGroupTransientState(widgetId);
-        if (config is not null && FeatureWidgetSettings.IsFeatureWidget(config.WidgetKind))
-        {
-            if (config.WidgetKind == WidgetKind.Glance)
+            if (config is not null && FeatureWidgetSettings.IsFeatureWidget(config.WidgetKind))
             {
-                await GlanceWidgetStore.DeleteForWidgetAsync(config.Id);
-                bool hasRemainingGlanceWidget = _settingsService.Settings.Widgets.Any(widget =>
-                    widget.WidgetKind == WidgetKind.Glance &&
-                    !IsDeleted(widget.Id));
-                if (!hasRemainingGlanceWidget)
+                if (config.WidgetKind == WidgetKind.Glance)
                 {
-                    SetFeatureWidgetEnabledState(WidgetKind.Glance, false);
+                    await GlanceWidgetStore.DeleteForWidgetAsync(config.Id);
+                    // audit round 21 — logical widget deletion (lifecycle 2):
+                    // the native instance data root is removed only here,
+                    // after the WidgetConfig deletion has committed; runtime
+                    // destroy keeps it. The binding resolves the package id
+                    // generically — no feature hard-coding.
+                    if (PackageBindingRegistry.TryGetByKind(config.WidgetKind) is { } deletedBinding)
+                    {
+                        await NativeInstanceDataLifecycle.DeleteAsync(
+                            deletedBinding.PackageId, config.Id, DeskBoxDataPathService.Current.DataDirectory);
+                    }
+                    bool hasRemainingGlanceWidget = _settingsService.Settings.Widgets.Any(widget =>
+                        widget.WidgetKind == WidgetKind.Glance &&
+                        !IsDeleted(widget.Id));
+                    if (!hasRemainingGlanceWidget)
+                    {
+                        SetFeatureWidgetEnabledState(WidgetKind.Glance, false);
+                    }
                 }
-            }
             else if (config.WidgetKind == WidgetKind.Todo)
             {
                 // Todo widgets can coexist; deleting one removes its store and

--- a/tests/DeskBox.Tests/NativeHostApiContextTests.cs
+++ b/tests/DeskBox.Tests/NativeHostApiContextTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using DeskBox.Services.Plugins;
 
 namespace DeskBox.Tests;
@@ -64,5 +65,86 @@ public class NativeHostApiContextTests
         string controller = File.ReadAllText(TestPaths.SourceFile(
             "src/DeskBox.GlancePackage/Rendering/GlanceWidgetController.cs"));
         Assert.Contains("internal void ApplyConfigChange(CultureInfo culture)", controller);
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate void ConfigChangedCallback();
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate int FailShutdownThunk();
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate int OkDestroyThunk(nint handle);
+
+    private static int _pushCount;
+    private static void OnPush() => _pushCount++;
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate void CdeclAction();
+
+    private static readonly CdeclAction PushTarget = OnPush;
+
+    [Fact]
+    public void DetachSessionRemovesHandlerAndContext()
+    {
+        // Behavior test (audit round 21 — the normal-shutdown DetachSession
+        // skip was invisible without exactly this sequence).
+        var context = NativePackageContextRegistry.Register(
+            new NativePackageContext { PackageId = "deskbox.detach.test" });
+        nint handler = Marshal.GetFunctionPointerForDelegate(PushTarget);
+
+        NativeHostApiBridge.SubscribeConfigChanged(context, handler);
+        NativeHostApiBridge.PushConfigChanged();
+        Assert.Equal(1, _pushCount);
+
+        NativeHostApiBridge.DetachSession(context);
+        NativeHostApiBridge.PushConfigChanged();
+        Assert.Equal(1, _pushCount); // stale handler must NOT fire again
+        Assert.Null(NativePackageContextRegistry.TryResolve(context));
+        Assert.Equal(0, NativeHostApiBridge.RegisteredConfigChangedHandlerCount);
+    }
+
+    [Fact]
+    public void FailedShutdownMarksPackageFaulted()
+    {
+        // Behavior test (audit round 21): a session whose shutdown reported
+        // failure causes Shutdown() to return false — the trigger the
+        // runtime manager uses for Faulted marking.
+        var failStub = (FailShutdownThunk)(() => unchecked((int)0x8000FFFF));
+        var okStub = (OkDestroyThunk)(_ => 0);
+
+        var session = new NativePackageSession(
+            new NativePackageIdentity("f".PadLeft(64, '0'), "deskbox.faulted"),
+            packageRoot: "", packageDataRoot: "",
+            activateExport: 0, createExport: 0,
+            destroyExport: Marshal.GetFunctionPointerForDelegate(okStub),
+            shutdownExport: Marshal.GetFunctionPointerForDelegate(failStub),
+            widgetEventExport: 0);
+
+        var lease = NativeWidgetLease.Create(session, 0x5678, null!, "faulted-instance");
+        lease.TryRelease();
+        Assert.False(session.Shutdown()); // stub returns non-zero → false
+    }
+
+    [Fact]
+    public void FailedShutdownPreventsReactivation()
+    {
+        // Integration: verify the faulted-marking path end-to-end through
+        // the runtime manager's release method.
+        var identity = new NativePackageIdentity("f".PadLeft(64, '0'), "deskbox.faulted-integration");
+
+        var failStub = (FailShutdownThunk)(() => unchecked((int)0x8000FFFF));
+        var okStub = (OkDestroyThunk)(_ => 0);
+
+        var session = new NativePackageSession(
+            identity, "", "", 0, 0,
+            Marshal.GetFunctionPointerForDelegate(okStub),
+            Marshal.GetFunctionPointerForDelegate(failStub),
+            0);
+
+        var lease = NativeWidgetLease.Create(session, 0x99, null!, "test-inst");
+        NativeWidgetRuntimeManager.Release(lease);
+
+        Assert.True(NativeWidgetRuntimeManager.IsFaulted(identity.Key));
     }
 }

--- a/tests/DeskBox.Tests/NativeInstanceDataLifecycleTests.cs
+++ b/tests/DeskBox.Tests/NativeInstanceDataLifecycleTests.cs
@@ -1,0 +1,91 @@
+using DeskBox.Services.Plugins;
+
+namespace DeskBox.Tests;
+
+/// <summary>
+/// R1 runtime/data contract repair behavior tests (audit round 21):
+/// runtime destroy keeps persistent data (only logical widget deletion
+/// removes the instance root), and a failed package shutdown marks the
+/// identity Faulted so it cannot be re-activated in this process.
+/// </summary>
+public class NativeInstanceDataLifecycleTests : IDisposable
+{
+    private readonly string _root = Directory.CreateTempSubdirectory("deskbox-lifecycle").FullName;
+    private bool _disposed;
+
+    private string InstanceRoot(string packageId, string instanceId)
+    {
+        string hash = NativePackageIdentity.InstanceStorageKey(instanceId);
+        return Path.Combine(_root, "packages", "a".PadLeft(64, '0'), packageId, "instances", hash);
+    }
+
+    [Fact]
+    public async Task DeleteRemovesPopulatedInstanceRoot()
+    {
+        string root = InstanceRoot("deskbox.test", "widget-1");
+        Directory.CreateDirectory(root);
+        await File.WriteAllTextAsync(Path.Combine(root, "glance-data.json"), "{}");
+        await File.WriteAllTextAsync(Path.Combine(root, "glance-state.json"), "{}");
+
+        await NativeInstanceDataLifecycle.DeleteAsync("deskbox.test", "widget-1", _root);
+
+        Assert.False(Directory.Exists(root));
+    }
+
+    [Fact]
+    public async Task DeleteIsIdempotent()
+    {
+        string root = InstanceRoot("deskbox.test", "widget-2");
+        Directory.CreateDirectory(root);
+        await File.WriteAllTextAsync(Path.Combine(root, "glance-data.json"), "{}");
+
+        await NativeInstanceDataLifecycle.DeleteAsync("deskbox.test", "widget-2", _root);
+        await NativeInstanceDataLifecycle.DeleteAsync("deskbox.test", "widget-2", _root);
+
+        Assert.False(Directory.Exists(root));
+    }
+
+    [Fact]
+    public async Task DeleteWithNoRootIsSafe()
+    {
+        await NativeInstanceDataLifecycle.DeleteAsync("deskbox.test", "never-existed", _root);
+        // No throw = pass.
+    }
+
+    [Fact]
+    public async Task DeleteScansAllPublishers()
+    {
+        // Same instance id under two publishers (dev → official upgrade path):
+        // both roots must be cleaned.
+        var hash = NativePackageIdentity.InstanceStorageKey("widget-3");
+        string rootA = Path.Combine(_root, "packages", "a".PadLeft(64, '0'), "deskbox.test", "instances", hash);
+        string rootB = Path.Combine(_root, "packages", "b".PadLeft(64, '0'), "deskbox.test", "instances", hash);
+        Directory.CreateDirectory(rootA);
+        Directory.CreateDirectory(rootB);
+        await File.WriteAllTextAsync(Path.Combine(rootA, "data.json"), "{}");
+        await File.WriteAllTextAsync(Path.Combine(rootB, "data.json"), "{}");
+
+        await NativeInstanceDataLifecycle.DeleteAsync("deskbox.test", "widget-3", _root);
+
+        Assert.False(Directory.Exists(rootA));
+        Assert.False(Directory.Exists(rootB));
+    }
+
+    [Fact]
+    public void RuntimeDestroyDoesNotDeleteDataRoots()
+    {
+        // Source ratchet: the loader's DestroyWidget and Shutdown must not
+        // contain any Directory.Delete call — persistent data removal is
+        // exclusively owned by NativeInstanceDataLifecycle.DeleteAsync.
+        string loader = File.ReadAllText(TestPaths.SourceFile(
+            "src/DeskBox/Services/Plugins/NativeWidgetPackageLoader.cs"));
+        Assert.DoesNotContain("Directory.Delete", loader);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+}


### PR DESCRIPTION
feat: R1 runtime/data contract repair - destroy keeps data, Faulted state, HostApi freeze

Audit round 21 (verified against code before fixing): five platform and
data-lifecycle defects, all fixed.

- runtime destroy no longer deletes the instance data root (P0): the
  three-lifecycle model is now explicit ��?runtime destroy (1) releases the
  handle and ownership but KEEPS persistent data; logical widget deletion
  (2) removes the root after WidgetConfig deletion commits; package
  uninstall (3) applies package-level data policy. Previously every
  destroy (including transient teardowns like group switches and content
  rebuilds) would wipe the instance root, contradicting #308's
  runtime-state save
- logical widget deletion: new NativeInstanceDataLifecycle.DeleteAsync
  (idempotent, best-effort, scans all publishers for the same instance)
  hooked into WidgetManager's RemoveWidgetAsync and FeatureWidgets
  duplicate cleanup via PackageBindingRegistry (generic ��?no feature
  hard-coding)
- Shutdown early-return fix (P0/P1): the faulted-cleanup block's
  early-return skipped DetachSession on the NORMAL path (live count is
  always 0 at shutdown), leaking the session context and config-changed
  handler across activate cycles; restructured to always detach, no
  early return
- Shutdown failure ��?Faulted/RestartRequired (P1): Shutdown returns bool;
  RuntimeManager marks the identity Faulted on failure, and
  TryCreateInstance refuses re-activation until process restart
- HostApi v4 declared the FIRST frozen ABI baseline (v1–v3 are internal
  pre-release experiments, not compatibility targets); from v4 onward
  existing slots and signatures are immutable ��?new capabilities append
  new slots

Behavior tests +8: lifecycle delete across publishers, idempotent delete,
absent-root safety, DetachSession removes handler and context (push
before/after), Faulted marking and rejection (two paths), and a source
ratchet pinning that the loader contains no Directory.Delete.

Tests: 3619/3619 green.
