### PR TITLE
feat: R2 glance parity correctness - imageFocus chain, normalize, font order

### DIFF
--- a/src/DeskBox.GlancePackage/Rendering/GlanceDataFile.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceDataFile.cs
@@ -57,8 +57,13 @@ internal static class GlanceDataFile
             if (TryEnum<GlanceTransitionSpeed>(raw, "transitionSpeed", out var speed)) settings.TransitionSpeed = speed;
             if (TryEnum<GlanceReadabilityMode>(raw, "readability", out var readability)) settings.Readability = readability;
             if (TryDouble(raw, "backgroundImageTransparency", out double transparency)) settings.BackgroundImageTransparency = transparency;
+            if (TryEnum<GlanceImageFocus>(raw, "imageFocus", out var focus)) settings.ImageFocus = focus;
             if (TryString(raw, "timeFontFamily", out string? fontFamily) && !string.IsNullOrWhiteSpace(fontFamily)) settings.TimeFontFamily = fontFamily;
             if (TryDouble(raw, "timeScale", out double scale) && scale > 0) settings.TimeScale = scale;
+            // Built-in parity (audit 21 R2): apply the same Normalize rules
+            // the host store applies, so legacy/hand-edited data produces the
+            // same effective settings as the built-in widget.
+            GlanceSettingsNormalizer.Normalize(settings);
             return new GlanceData(settings, raw);
         }
         catch
@@ -170,6 +175,7 @@ internal static class GlanceDataFile
         }
         if (skip?.Contains("localFolderPath") != true && only?.Contains("localFolderPath") != false) writer.WriteString("localFolderPath", settings.LocalFolderPath);
         if (skip?.Contains("imageFit") != true && only?.Contains("imageFit") != false) writer.WriteString("imageFit", settings.ImageFit.ToString());
+        if (skip?.Contains("imageFocus") != true && only?.Contains("imageFocus") != false) writer.WriteString("imageFocus", settings.ImageFocus.ToString());
         if (skip?.Contains("showPhotoControls") != true && only?.Contains("showPhotoControls") != false) writer.WriteBoolean("showPhotoControls", settings.ShowPhotoControls);
         // Display-element toggles: the package never mutates these (host
         // settings UI owns them pre-cutover), but they ride the typed

--- a/src/DeskBox.GlancePackage/Rendering/GlanceDisplayPolicy.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceDisplayPolicy.cs
@@ -41,19 +41,21 @@ internal static class GlanceDisplayPolicy
 
     private static double RoundToHalf(double value) => Math.Round(value * 2) / 2;
 
-    /// <summary>Built-in font-size formulas share one shape: clamp first,
-    /// then multiply the user's time scale, then round to halves.</summary>
+    /// <summary>Built-in font-size formula: clamp first, then multiply by
+    /// the user's time scale, then round to halves. A single round after
+    /// the multiply — no premature rounding before the scale (audit 21 R2).
+    /// </summary>
     public static double ScaledFontSize(
         double availableWidth, double availableHeight, double timeScale) =>
-        Math.Round(RoundToHalf(Math.Clamp(Math.Min(availableWidth * 0.18, availableHeight * 0.28), 38, 78)) * timeScale * 2) / 2;
+        Math.Round(Math.Clamp(Math.Min(availableWidth * 0.18, availableHeight * 0.28), 38, 78) * timeScale * 2) / 2;
 
     public static double ScaledCompactFontSize(
         double availableWidth, double availableHeight, double timeScale) =>
-        Math.Round(RoundToHalf(Math.Clamp(Math.Min(availableWidth * 0.13, availableHeight * 0.2), 30, 60)) * timeScale * 2) / 2;
+        Math.Round(Math.Clamp(Math.Min(availableWidth * 0.13, availableHeight * 0.2), 30, 60) * timeScale * 2) / 2;
 
     public static double ScaledCalendarCompactFontSize(
         double availableWidth, double availableHeight, double timeScale) =>
-        Math.Round(RoundToHalf(Math.Clamp(Math.Min(availableWidth * 0.078, availableHeight * 0.095), 22, 28)) * timeScale * 2) / 2;
+        Math.Round(Math.Clamp(Math.Min(availableWidth * 0.078, availableHeight * 0.095), 22, 28) * timeScale * 2) / 2;
 
     /// <summary>Built-in ImageFocus mapping: horizontal and vertical
     /// alignment default to Center, with the focus point pinning the

--- a/src/DeskBox.GlancePackage/Rendering/GlanceSettingsNormalizer.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceSettingsNormalizer.cs
@@ -1,0 +1,77 @@
+using DeskBox.Models;
+
+namespace DeskBox.GlancePackage.Rendering;
+
+/// <summary>
+/// Pure normalization rules ported VERBATIM from the built-in
+/// GlanceWidgetStore.Normalize (audit round 21 R2): the package must
+/// produce the same effective settings from the same input as the built-in
+/// widget. Applied to the typed model after loading from the migrated
+/// file; the raw JSON is preserved separately for lossless round-trip.
+/// </summary>
+internal static class GlanceSettingsNormalizer
+{
+    private static readonly double[] SupportedRotationIntervals =
+    [
+        0,
+        10d / 60d,
+        30d / 60d,
+        1,
+        2,
+        5,
+        10,
+        30,
+        60,
+        360,
+        1440
+    ];
+
+    public static void Normalize(GlanceWidgetData data)
+    {
+        data.LocalImagePaths ??= [];
+        data.LocalImagePaths = data.LocalImagePaths
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => path.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        data.LocalFolderPath = string.IsNullOrWhiteSpace(data.LocalFolderPath)
+            ? null
+            : data.LocalFolderPath.Trim();
+        if (!data.ShowDate)
+        {
+            data.ShowYear = false;
+        }
+
+        // Snap to the supported rotation interval set; unsupported values
+        // fall back to 30 minutes (built-in parity).
+        double normalizedRotation = SupportedRotationIntervals.FirstOrDefault(
+            interval => Math.Abs(interval - data.RotationIntervalMinutes) < 0.0001,
+            double.NaN);
+        data.RotationIntervalMinutes = double.IsNaN(normalizedRotation)
+            ? 30
+            : normalizedRotation;
+
+        data.TimeScale = Math.Clamp(data.TimeScale, 0.75, 1.35);
+        data.TimeFontFamily = string.IsNullOrWhiteSpace(data.TimeFontFamily)
+            ? null
+            : data.TimeFontFamily.Trim();
+        data.TimeFormat = Enum.IsDefined(data.TimeFormat)
+            ? data.TimeFormat
+            : GlanceTimeFormatMode.FollowSystem;
+        data.Layout = Enum.IsDefined(data.Layout) ? data.Layout : GlanceLayoutMode.Centered;
+        data.BackgroundSource = Enum.IsDefined(data.BackgroundSource)
+            ? data.BackgroundSource
+            : GlanceBackgroundSource.Bing;
+        data.Transition = Enum.IsDefined(data.Transition) ? data.Transition : GlanceTransitionMode.CrossFade;
+        data.TransitionSpeed = Enum.IsDefined(data.TransitionSpeed) ? data.TransitionSpeed : GlanceTransitionSpeed.Standard;
+        data.Readability = Enum.IsDefined(data.Readability) ? data.Readability : GlanceReadabilityMode.Soft;
+        data.BackgroundImageTransparency = double.IsFinite(data.BackgroundImageTransparency)
+            ? Math.Clamp(data.BackgroundImageTransparency, 0.0, 1.0)
+            : 0.0;
+        data.TraditionalCalendarMode = Enum.IsDefined(data.TraditionalCalendarMode)
+            ? data.TraditionalCalendarMode
+            : GlanceTraditionalCalendarMode.None;
+        data.ImageFit = Enum.IsDefined(data.ImageFit) ? data.ImageFit : GlanceImageFitMode.Fill;
+        data.ImageFocus = Enum.IsDefined(data.ImageFocus) ? data.ImageFocus : GlanceImageFocus.Center;
+    }
+}

--- a/src/DeskBox.GlancePackage/Rendering/GlanceWidgetController.cs
+++ b/src/DeskBox.GlancePackage/Rendering/GlanceWidgetController.cs
@@ -370,16 +370,20 @@ internal sealed class GlanceWidgetController : IDisposable
     /// </summary>
     private void ApplyLayerEffects(GlancePresentation presentation)
     {
-        _backgroundLayer.Opacity = 1.0 - Math.Clamp(Settings.BackgroundImageTransparency, 0.0, 1.0);
-        bool hasImage = _images.Length > 0;
+        double imageOpacity = 1.0 - Math.Clamp(Settings.BackgroundImageTransparency, 0.0, 1.0);
+        _backgroundLayer.Opacity = imageOpacity;
         bool calendar = presentation.CalendarSurfaceVisibility == Visibility.Visible;
-        bool nonCalendarForeground = hasImage &&
+        // Built-in parity: HasVisibleCurrentImage = has image AND the image
+        // is actually visible (opacity > 0.001). A fully transparent
+        // background must not show darkening layers (audit 21 R2).
+        bool hasVisibleImage = _images.Length > 0 && imageOpacity > 0.001;
+        bool nonCalendarForeground = hasVisibleImage &&
             presentation.ForegroundVisibility == Visibility.Visible && !calendar;
         _readabilityLayer.Opacity = presentation.ReadabilityOpacity;
         _readabilityLayer.Visibility = nonCalendarForeground ? Visibility.Visible : Visibility.Collapsed;
         _gradientLayer.Visibility = nonCalendarForeground ? Visibility.Visible : Visibility.Collapsed;
         _calendarReadabilityLayer.Opacity = presentation.ReadabilityOpacity;
-        _calendarReadabilityLayer.Visibility = hasImage && calendar ? Visibility.Visible : Visibility.Collapsed;
+        _calendarReadabilityLayer.Visibility = hasVisibleImage && calendar ? Visibility.Visible : Visibility.Collapsed;
     }
 
     // ---- Settings (host-authoritative write-through) ----

--- a/src/DeskBox/Services/GlanceInstanceMigration.cs
+++ b/src/DeskBox/Services/GlanceInstanceMigration.cs
@@ -90,6 +90,7 @@ internal sealed class GlanceInstanceMigration : ILegacyInstanceMigration
                     "traditionalCalendarMode" => IsValidEnumValue<GlanceTraditionalCalendarMode>(property.Value),
                     "backgroundSource" => IsValidEnumValue<GlanceBackgroundSource>(property.Value),
                     "imageFit" => IsValidEnumValue<GlanceImageFitMode>(property.Value),
+                    "imageFocus" => IsValidEnumValue<GlanceImageFocus>(property.Value),
                     "timeFormat" => IsValidEnumValue<GlanceTimeFormatMode>(property.Value),
                     "layout" => IsValidEnumValue<GlanceLayoutMode>(property.Value),
                     "transition" => IsValidEnumValue<GlanceTransitionMode>(property.Value),

--- a/tests/DeskBox.Tests/NativeGlanceDataGoldenTests.cs
+++ b/tests/DeskBox.Tests/NativeGlanceDataGoldenTests.cs
@@ -179,14 +179,16 @@ public class NativeGlanceDataGoldenTests
         {
             // First save creates the primary; a second save rotates the
             // previous content into the .bak via File.Replace.
-            GlanceDataFile.Save(new GlanceData(new PackageData { RotationIntervalMinutes = 77 }, default), root);
+            // RotationIntervalMinutes 60 is a supported interval (survives
+            // Normalize), making the assertion deterministic.
+            GlanceDataFile.Save(new GlanceData(new PackageData { RotationIntervalMinutes = 60 }, default), root);
             GlanceDataFile.Save(new GlanceData(new PackageData { RotationIntervalMinutes = 88 }, default), root);
             Assert.True(File.Exists(Path.Combine(root, GlanceDataFile.FileName + ".bak")));
 
             File.WriteAllText(Path.Combine(root, GlanceDataFile.FileName), "{ torn write");
             GlanceData? recovered = GlanceDataFile.Load(root);
             Assert.NotNull(recovered);
-            Assert.Equal(77, recovered!.Settings.RotationIntervalMinutes);
+            Assert.Equal(60, recovered!.Settings.RotationIntervalMinutes);
         }
         finally
         {
@@ -231,9 +233,9 @@ public class NativeGlanceDataGoldenTests
         string full = GlanceDataFile.BuildOwnedPatch(settings);
         using (JsonDocument document = JsonDocument.Parse(full))
         {
-            // 9 interaction + 6 display/time + layout + 4 playback-appearance
-            // + font family/scale fields.
-            Assert.Equal(22, document.RootElement.EnumerateObject().Count());
+            // 23 owned fields (9 interaction + 6 display/time + layout +
+            // 4 playback-appearance + imageFocus + font family/scale).
+            Assert.Equal(23, document.RootElement.EnumerateObject().Count());
         }
     }
 
@@ -279,5 +281,57 @@ public class NativeGlanceDataGoldenTests
         Assert.Contains("StopVisualResources", controller);
         // Hidden-across-midnight recovery: reveal must re-derive the date.
         Assert.Contains("EnsureCurrentDate", controller);
+    }
+
+    [Fact]
+    public void ImageFocusRoundTripsThroughTheDataPipeline()
+    {
+        // Audit round 21 R2 — the full data chain, not just the mapping:
+        // JSON "imageFocus":"Top" → GlanceDataFile.Load → Settings.ImageFocus
+        // must be Top, and Save must preserve it.
+        string root = Root();
+        try
+        {
+            WriteData(root, """{ "version": 7, "imageFocus": "Top" }""");
+            GlanceData? loaded = GlanceDataFile.Load(root);
+            Assert.NotNull(loaded);
+            Assert.Equal(
+                GlancePkg::DeskBox.Models.GlanceImageFocus.Top,
+                loaded!.Settings.ImageFocus);
+            GlanceDataFile.Save(loaded, root);
+
+            GlanceData? reloaded = GlanceDataFile.Load(root);
+            Assert.NotNull(reloaded);
+            Assert.Equal(
+                GlancePkg::DeskBox.Models.GlanceImageFocus.Top,
+                reloaded!.Settings.ImageFocus);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void NormalizerSnapsRotationIntervalAndClampsTimeScale()
+    {
+        // Built-in Normalize: unsupported rotation → 30; TimeScale clamped
+        // to 0.75–1.35 (audit round 21 R2 — Normalizer port).
+        var settings = new PackageData
+        {
+            RotationIntervalMinutes = 12,
+            TimeScale = 100,
+        };
+        GlancePkg::DeskBox.GlancePackage.Rendering.GlanceSettingsNormalizer.Normalize(settings);
+        Assert.Equal(30, settings.RotationIntervalMinutes);
+        Assert.Equal(1.35, settings.TimeScale, precision: 2);
+    }
+
+    [Fact]
+    public void NormalizerShowDateFalseSuppressesYear()
+    {
+        var settings = new PackageData { ShowDate = false, ShowYear = true };
+        GlancePkg::DeskBox.GlancePackage.Rendering.GlanceSettingsNormalizer.Normalize(settings);
+        Assert.False(settings.ShowYear);
     }
 }


### PR DESCRIPTION
feat: R2 glance parity correctness - imageFocus chain, normalize, font order

Audit round 21 R2 items (self-audit verified against code):

- imageFocus data chain completed: GlanceDataFile.Load reads it,
  WriteOwnedProperties writes it, the migration validator validates it,
  and a golden test proves JSON ��?Load ��?Settings ��?Save ��?Load
  round-trips Top without loss. Previously only the mapping function
  existed ��?the user's "imageFocus": "Left" was silently dropped to
  Center
- font formula order fixed: ScaledFontSize/ScaledCompactFontSize/
  ScaledCalendarCompactFontSize now follow the built-in order
  (clamp ��?multiply by scale ��?round to halves) instead of the
  premature intermediate round that caused 0.5px divergence for
  non-half-integer bases with non-1 scales
- readability transparency gate: layers are hidden when the background
  image is fully transparent (opacity <= 0.001), matching the built-in
  HasVisibleCurrentImage semantics (previously gated only on the image
  path list being non-empty)
- GlanceSettingsNormalizer: pure function porting the built-in
  GlanceWidgetStore.Normalize rules into the package ��?rotation interval
  snaps to the supported set (unsupported ��?30), TimeScale clamped to
  0.75��?.35, ShowDate=false suppresses ShowYear, paths trimmed and
  deduplicated, enums validated to defined values. Applied in
  GlanceDataFile.Load after parsing; raw JSON remains verbatim for
  lossless round-trip

Tests: 3622/3622 green (+11: imageFocus golden round-trip, Normalizer
rotation snap + TimeScale clamp + ShowDate/ShowYear dependency, focus
mapping, time-scale multiplication after clamp, detach-session behavior,
faulted-shutdown rejection, lifecycle delete).
