### PR TITLE
fix: harden SMTC transport, fix CreateWidget rollback, memory script

### DIFF
--- a/src/DeskBox.GlancePackage/Abi/Exports.cs
+++ b/src/DeskBox.GlancePackage/Abi/Exports.cs
@@ -167,8 +167,20 @@ public static unsafe class Exports
                 _handles[handle] = lifecycleHandle;
                 Instances[handle] = controller.View;
             }
-            *widgetHandle = handle;
-            *view = WinRT.MarshalInspectable<FrameworkElement>.FromManaged(controller.View);
+            try
+            {
+                *widgetHandle = handle;
+                *view = WinRT.MarshalInspectable<FrameworkElement>.FromManaged(controller.View);
+            }
+            catch
+            {
+                lock (InstanceGate)
+                {
+                    _handles.Remove(handle);
+                    Instances.Remove(handle);
+                }
+                throw;
+            }
             HostLog($"widget created: {contribution}/{instance}");
             return S_OK;
         }

--- a/src/DeskBox.MusicPackage/Services/MusicSessionService.cs
+++ b/src/DeskBox.MusicPackage/Services/MusicSessionService.cs
@@ -224,46 +224,70 @@ public sealed class MusicSessionService : IDisposable
 
     public async Task<bool> TryTogglePlayPauseAsync(string? sessionId)
     {
-        var session = await GetSessionAsync(sessionId);
-        if (session is null)
+        try
         {
-            return false;
-        }
+            var session = await GetSessionAsync(sessionId);
+            if (session is null)
+            {
+                return false;
+            }
 
-        var playbackInfo = session.GetPlaybackInfo();
-        return playbackInfo.PlaybackStatus == GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing
-            ? await session.TryPauseAsync()
-            : await session.TryPlayAsync();
+            var playbackInfo = session.GetPlaybackInfo();
+            return playbackInfo.PlaybackStatus == GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing
+                ? await session.TryPauseAsync()
+                : await session.TryPlayAsync();
+        }
+        catch { return false; } // stale session mid-call (audit 21: SMTC transport)
     }
 
     public async Task<bool> TryPlayAsync(string? sessionId)
     {
-        var session = await GetSessionAsync(sessionId);
-        return session is not null && await session.TryPlayAsync();
+        try
+        {
+            var session = await GetSessionAsync(sessionId);
+            return session is not null && await session.TryPlayAsync();
+        }
+        catch { return false; }
     }
 
     public async Task<bool> TryPauseAsync(string? sessionId)
     {
-        var session = await GetSessionAsync(sessionId);
-        return session is not null && await session.TryPauseAsync();
+        try
+        {
+            var session = await GetSessionAsync(sessionId);
+            return session is not null && await session.TryPauseAsync();
+        }
+        catch { return false; }
     }
 
     public async Task<bool> TryPreviousAsync(string? sessionId)
     {
-        var session = await GetSessionAsync(sessionId);
-        return session is not null && await session.TrySkipPreviousAsync();
+        try
+        {
+            var session = await GetSessionAsync(sessionId);
+            return session is not null && await session.TrySkipPreviousAsync();
+        }
+        catch { return false; }
     }
 
     public async Task<bool> TryNextAsync(string? sessionId)
     {
-        var session = await GetSessionAsync(sessionId);
-        return session is not null && await session.TrySkipNextAsync();
+        try
+        {
+            var session = await GetSessionAsync(sessionId);
+            return session is not null && await session.TrySkipNextAsync();
+        }
+        catch { return false; }
     }
 
     public async Task<bool> TrySeekAsync(string? sessionId, TimeSpan position)
     {
-        var session = await GetSessionAsync(sessionId);
-        return session is not null && await session.TryChangePlaybackPositionAsync((long)position.TotalMilliseconds * 10_000);
+        try
+        {
+            var session = await GetSessionAsync(sessionId);
+            return session is not null && await session.TryChangePlaybackPositionAsync((long)position.TotalMilliseconds * 10_000);
+        }
+        catch { return false; }
     }
 
     public async Task<bool> TryChangePlaybackModeAsync(string? sessionId, MusicPlaybackMode playbackMode)


### PR DESCRIPTION
feat: harden SMTC transport, fix CreateWidget rollback, memory measurement script

Self-audit fixes from sub-agent code reviews of the three Codex packages:

- Music: all SMTC transport Try* methods (TogglePlayPause, Play, Pause,
  Previous, Next, Seek) now catch stale-session WinRT exceptions and
  return false, matching the codebase's own guarded paths. Previously
  unguarded calls reached async void UI handlers and could crash the
  host process if a session vanished mid-call
- Glance: CreateWidget now rolls back handle/Instances registration if
  the ABI view marshal throws (previously a stale Instances entry made
  Shutdown return E_UNEXPECTED for the process lifetime)
- Added measure-memory.ps1 script for Simon to capture per-process
  Private Working Set / Commit / threads / handles at each stage of
  the three-package memory measurement (P0 action from architecture
  review)

Tests: 3893/3893 green.
