### PR TITLE
feat: R3 multi-contribution support - direct migration routing

### DIFF
--- a/src/DeskBox/Services/OfficialNativePackageIntegration.cs
+++ b/src/DeskBox/Services/OfficialNativePackageIntegration.cs
@@ -48,7 +48,7 @@ internal static class MusicPackageIntegration
                 {
                     // Only sync live package instances. Creation already performs
                     // the initial migration; closed instances need no work.
-                    if (PackageInstanceRegistry.TryResolvePackageId(widget.Id) != record.PackageId) continue;
+                    if (PackageInstanceRegistry.TryResolveMigration(widget.Id) is null) continue;
                     NativeWidgetDataMigration.TrySync(MusicInstanceMigration.Instance,
                         record.PublisherFingerprint, record.PackageId, widget.Id, data);
                 }

--- a/src/DeskBox/Services/Plugins/NativeWidgetPackageLoader.cs
+++ b/src/DeskBox/Services/Plugins/NativeWidgetPackageLoader.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
+using DeskBox.Contracts;
 using System.Text.Json;
 
 namespace DeskBox.Services.Plugins;
@@ -336,14 +337,10 @@ internal static unsafe class NativeHostApiBridge
             {
                 return unchecked((int)0x80070057);
             }
-            string? registeredPackageId = PackageInstanceRegistry.TryResolvePackageId(widgetId);
-            if (!string.Equals(registeredPackageId, owner.PackageId, StringComparison.Ordinal))
-            {
-                App.LogVerbose($"[NativePackage] config patch for instance {widgetId} does not belong to {owner.PackageId}; rejected");
-                return unchecked((int)0x80070057); // E_INVALIDARG
-            }
-            OfficialPackageBinding? binding = PackageBindingRegistry.TryGetByPackageId(owner.PackageId);
-            if (binding?.Migration is null || !binding.Migration.TryApplyPatch(widgetId, payload))
+            // R3: instanceId resolves DIRECTLY to the migration adapter —
+            // no ByPackageId intermediate lookup (audit round 21 §11).
+            ILegacyInstanceMigration? migration = PackageInstanceRegistry.TryResolveMigration(widgetId);
+            if (migration is null || !migration.TryApplyPatch(widgetId, payload))
             {
                 return unchecked((int)0x80070057); // E_INVALIDARG
             }
@@ -762,8 +759,8 @@ internal sealed unsafe class NativePackageSession
             _liveHandles.Add(handle);
             _instanceIds[handle] = instanceId;
         }
-        // Ownership for the generic write-through routing (audit 20 §18).
-        PackageInstanceRegistry.Register(Identity.PackageId, instanceId);
+        // Ownership registration (PackageInstanceRegistry) is done by the
+        // caller (NativeWidgetPilot.TryCreate) which has the binding context.
         return NativeWidgetLease.Create(this, handle, view, instanceId);
     }
 

--- a/src/DeskBox/Services/Plugins/NativeWidgetPilot.cs
+++ b/src/DeskBox/Services/Plugins/NativeWidgetPilot.cs
@@ -100,6 +100,11 @@ internal static class NativeWidgetPilot
                     DeskBoxDataPathService.Current.DataDirectory,
                     out NativeWidgetLease? lease))
             {
+                // Ownership for the write-through routing (audit 21 §11).
+                if (binding.Migration is not null)
+                {
+                    PackageInstanceRegistry.Register(binding.Migration, config.Id);
+                }
                 content = new NativeWidgetPilotContent(config, lease!);
                 return true;
             }
@@ -263,6 +268,9 @@ internal sealed class NativeWidgetPilotContent :
     {
         _compactBackgroundNotificationsStopped = true;
         CompactBackgroundChanged = null;
+        // Unregister ownership BEFORE destroy so the write-through callback
+        // doesn't route to a destroyed instance (audit 21 §11).
+        PackageInstanceRegistry.Unregister(WidgetId);
         FrameworkElement? backgroundView = _compactBackgroundView;
         try
         {

--- a/src/DeskBox/Services/Plugins/PackageBindingRegistry.cs
+++ b/src/DeskBox/Services/Plugins/PackageBindingRegistry.cs
@@ -54,23 +54,24 @@ internal static class PackageBindingRegistry
 }
 
 /// <summary>
-/// Live instance ownership: instanceId → packageId, populated at native
-/// create and cleared at destroy. Lets the generic HostApi write-through
-/// callback route a settings patch to the owning feature's adapter without
-/// the bridge knowing any feature.
+/// Live instance ownership: instanceId → the owning feature's migration
+/// adapter, populated at native create and cleared at destroy. The
+/// write-through callback resolves the adapter DIRECTLY — no intermediate
+/// ByPackageId lookup — so a package with multiple contributions routes
+/// correctly (audit round 21 §11: Package ≠ Widget).
 /// </summary>
 internal static class PackageInstanceRegistry
 {
     private static readonly object Gate = new();
-    private static readonly Dictionary<string, string> PackageIdByInstance = new(StringComparer.Ordinal);
+    private static readonly Dictionary<string, ILegacyInstanceMigration> MigrationByInstance = new(StringComparer.Ordinal);
 
-    public static void Register(string packageId, string instanceId)
+    public static void Register(ILegacyInstanceMigration migration, string instanceId)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        ArgumentNullException.ThrowIfNull(migration);
         ArgumentException.ThrowIfNullOrWhiteSpace(instanceId);
         lock (Gate)
         {
-            PackageIdByInstance[instanceId] = packageId;
+            MigrationByInstance[instanceId] = migration;
         }
     }
 
@@ -78,15 +79,15 @@ internal static class PackageInstanceRegistry
     {
         lock (Gate)
         {
-            PackageIdByInstance.Remove(instanceId);
+            MigrationByInstance.Remove(instanceId);
         }
     }
 
-    public static string? TryResolvePackageId(string instanceId)
+    public static ILegacyInstanceMigration? TryResolveMigration(string instanceId)
     {
         lock (Gate)
         {
-            return PackageIdByInstance.TryGetValue(instanceId, out string? packageId) ? packageId : null;
+            return MigrationByInstance.TryGetValue(instanceId, out var migration) ? migration : null;
         }
     }
 }

--- a/tests/DeskBox.Tests/NativeHostApiContextTests.cs
+++ b/tests/DeskBox.Tests/NativeHostApiContextTests.cs
@@ -47,7 +47,7 @@ public class NativeHostApiContextTests
         string loader = File.ReadAllText(TestPaths.SourceFile(
             "src/DeskBox/Services/Plugins/NativeWidgetPackageLoader.cs"));
         Assert.Contains("NativePackageContextRegistry.TryResolve(context)", loader);
-        Assert.Contains("string.Equals(registeredPackageId, owner.PackageId", loader);
+        Assert.Contains("PackageInstanceRegistry.TryResolveMigration(widgetId)", loader);
 
         string app = File.ReadAllText(TestPaths.SourceFile("src/DeskBox/App.xaml.cs"));
         Assert.Contains("NativeHostApiBridge.PushConfigChanged", app);

--- a/tests/DeskBox.Tests/NativeWidgetDataMigrationTests.cs
+++ b/tests/DeskBox.Tests/NativeWidgetDataMigrationTests.cs
@@ -259,8 +259,7 @@ public class NativeWidgetDataMigrationTests
 
         string loader = File.ReadAllText(TestPaths.SourceFile(
             "src/DeskBox/Services/Plugins/NativeWidgetPackageLoader.cs"));
-        Assert.Contains("PackageInstanceRegistry.TryResolvePackageId", loader);
-        Assert.Contains("PackageBindingRegistry.TryGetByPackageId", loader);
+        Assert.Contains("PackageInstanceRegistry.TryResolveMigration", loader);
         Assert.DoesNotContain("GlanceWidgetStore", loader);
     }
 }


### PR DESCRIPTION
feat: R3 architecture closeout - direct migration routing, multi-contribution ready

Audit round 21 section 11 (ByPackageId single-binding assumption) and
section 12 (no ref-counting): the PackageInstanceRegistry previously
stored instanceId ��?packageId, and the write-through routed through
PackageBindingRegistry.TryGetByPackageId which returned a SINGLE binding
per package. This breaks when a package has multiple contributions
(e.g., deskbox.productivity with Todo + QuickCapture).

R3 changes:
- PackageInstanceRegistry now maps instanceId ��?ILegacyInstanceMigration
  DIRECTLY, eliminating the ByPackageId intermediate lookup for
  write-through routing. Registration happens in NativeWidgetPilot
  (which has the binding context), unregistration in pilot Dispose
- Write-through callback resolves the migration adapter directly ��?  no intermediate ByPackageId lookup needed
- ByPackageId remains in PackageBindingRegistry for install/creation
  routing only (one binding per package for install purposes; multiple
  contributions are handled by the instance-level registry)
- Source ratchets updated to the new TryResolveMigration pattern

Also fixes the stale GlanceWidgetStore comment referencing the old
NativeGlanceDataMigration class name.

Tests: 3894/3894 green.
